### PR TITLE
feat(T-0.1): Turborepo + pnpm workspace scaffold

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@commit-analyzer/api",
+  "version": "0.0.0",
+  "private": true
+}

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@commit-analyzer/cli",
+  "version": "0.0.0",
+  "private": true
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@commit-analyzer/web",
+  "version": "0.0.0",
+  "private": true
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "commit-analyzer",
+  "private": true,
+  "packageManager": "pnpm@9.12.0",
+  "scripts": {
+    "build": "turbo run build"
+  },
+  "devDependencies": {
+    "turbo": "^2.0.0"
+  }
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@commit-analyzer/contracts",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@commit-analyzer/database",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@commit-analyzer/eslint-config",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@commit-analyzer/shared-types",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@commit-analyzer/typescript-config",
+  "version": "0.0.0",
+  "private": true
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,94 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      turbo:
+        specifier: ^2.0.0
+        version: 2.9.6
+
+  apps/api: {}
+
+  apps/cli: {}
+
+  apps/web: {}
+
+  packages/contracts: {}
+
+  packages/database: {}
+
+  packages/eslint-config: {}
+
+  packages/shared-types: {}
+
+  packages/typescript-config: {}
+
+packages:
+
+  '@turbo/darwin-64@2.9.6':
+    resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.6':
+    resolution: {integrity: sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.6':
+    resolution: {integrity: sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.6':
+    resolution: {integrity: sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.6':
+    resolution: {integrity: sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.6':
+    resolution: {integrity: sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@2.9.6:
+    resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
+    hasBin: true
+
+snapshots:
+
+  '@turbo/darwin-64@2.9.6':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.6':
+    optional: true
+
+  '@turbo/linux-64@2.9.6':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.6':
+    optional: true
+
+  '@turbo/windows-64@2.9.6':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.6':
+    optional: true
+
+  turbo@2.9.6:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.6
+      '@turbo/darwin-arm64': 2.9.6
+      '@turbo/linux-64': 2.9.6
+      '@turbo/linux-arm64': 2.9.6
+      '@turbo/windows-64': 2.9.6
+      '@turbo/windows-arm64': 2.9.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**"]
+    }
+  }
+}


### PR DESCRIPTION
Closes #1

## Summary
- Root `package.json` (pnpm@9.12.0, turbo@^2 devDep), `pnpm-workspace.yaml`, `turbo.json`
- 8 empty workspaces: `apps/{web,api,cli}`, `packages/{contracts,database,shared-types,eslint-config,typescript-config}`

## Notes
- `turbo.json` includes a minimal `build` task (`outputs: ["dist/**"]`) — turbo ^2 rejects empty `tasks: {}` on dry-run. Pipelines will be fleshed out in T-0.3.

## Test plan
- [x] `pnpm install` — clean
- [x] `pnpm -r ls` — lists all 8 workspaces
- [x] `pnpm turbo run build --dry` — valid plan