### PR TITLE
feat(T-0.3): root scripts + Turbo pipelines

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch --preserveWatchOutput",
+    "test": "echo \"no tests yet\" && exit 0",
+    "clean": "rm -rf dist .turbo *.tsbuildinfo",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "//": "TODO: `dev` only runs tsc --watch today; wire up a server runtime (e.g. tsx watch src/index.ts) when the api runtime lands.",
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch --preserveWatchOutput",

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "extends": "@commit-analyzer/typescript-config/node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
   "include": ["src/**/*"]
 }

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build": "tsc",
+    "test": "echo \"no tests yet\" && exit 0",
+    "clean": "rm -rf dist .turbo *.tsbuildinfo",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "extends": "@commit-analyzer/typescript-config/node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
   "include": ["src/**/*"]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch --preserveWatchOutput",
+    "test": "echo \"no tests yet\" && exit 0",
+    "clean": "rm -rf .next .turbo *.tsbuildinfo",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "//": "TODO(T-0.8): replace tsc-based build/dev with `next build`/`next dev` when Next.js lands.",
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch --preserveWatchOutput",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "packageManager": "pnpm@9.12.0",
   "scripts": {
     "build": "turbo run build",
-    "lint": "pnpm -r exec eslint .",
-    "typecheck": "pnpm -r exec tsc --noEmit",
+    "dev": "turbo run dev",
+    "test": "turbo run test",
+    "lint": "turbo run lint",
+    "typecheck": "turbo run typecheck",
+    "clean": "turbo run clean && rm -rf node_modules/.cache .turbo",
     "format": "prettier --write \"**/*.{ts,tsx,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,json,md}\""
   },

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build": "tsc",
+    "test": "echo \"no tests yet\" && exit 0",
+    "clean": "rm -rf dist .turbo *.tsbuildinfo",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "extends": "@commit-analyzer/typescript-config/node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
   "include": ["src/**/*"]
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build": "tsc",
+    "test": "echo \"no tests yet\" && exit 0",
+    "clean": "rm -rf dist .turbo *.tsbuildinfo",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/database/tsconfig.json
+++ b/packages/database/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "extends": "@commit-analyzer/typescript-config/node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
   "include": ["src/**/*"]
 }

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build": "tsc",
+    "test": "echo \"no tests yet\" && exit 0",
+    "clean": "rm -rf dist .turbo *.tsbuildinfo",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "extends": "@commit-analyzer/typescript-config/node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
   "include": ["src/**/*"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,8 +1,24 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "ui": "tui",
   "tasks": {
     "build": {
-      "outputs": ["dist/**"]
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"]
+    },
+    "lint": {
+      "dependsOn": ["^build"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "ui": "tui",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -14,11 +13,7 @@
       "dependsOn": ["^build"],
       "outputs": ["coverage/**"]
     },
-    "lint": {
-      "dependsOn": ["^build"]
-    },
-    "typecheck": {
-      "dependsOn": ["^build"]
-    }
+    "lint": {},
+    "typecheck": {}
   }
 }


### PR DESCRIPTION
## Summary
- Expand `turbo.json` with `build` (`dependsOn: ^build`, outputs `dist/**` + `.next/**`), persistent `dev`, plus `test`, `lint`, `typecheck` pipelines.
- Map root `package.json` scripts to `turbo run <task>` for `dev|build|test|lint|typecheck` (+ `clean`).
- Add `build`/`dev`/`test`/`clean` scripts and `outDir`/`rootDir` to each workspace so Turbo has real work to orchestrate.

## Acceptance
- [x] `pnpm dev` starts api + web concurrently in TS watch mode.
- [x] `pnpm build` builds all buildable workspaces (6 tasks, all green).
- [x] `pnpm test` runs zero-or-more suites and exits 0.
- [x] `pnpm lint` and `pnpm typecheck` pass.

Closes #3