### PR TITLE
feat(T-0.4): docker-compose for postgres + redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: commit-analyzer-postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dev}
+      POSTGRES_DB: ${POSTGRES_DB:-app}
+    ports:
+      - "${POSTGRES_PORT:-55432}:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-app}"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+      start_period: 2s
+
+  redis:
+    image: redis:7-alpine
+    container_name: commit-analyzer-redis
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+      start_period: 1s
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- Add root `docker-compose.yml` with `postgres:16` (default host port **55432**, container 5432) and `redis:7-alpine` (6379).
- Healthchecks on both services (`pg_isready`, `redis-cli ping`).
- Named `pgdata` volume for postgres persistence.
- Credentials + ports overridable via env (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_PORT`, `REDIS_PORT`); defaults match `docs/11-deployment.md` (`POSTGRES_DB=app`, `POSTGRES_PASSWORD=dev`).

Note: host port for postgres defaults to **55432** instead of 5432 to avoid collision with a locally-installed postgres; override via `POSTGRES_PORT` if desired. `.env.example` wiring is deferred to T-0.5.

## Test plan
- [x] `docker compose up -d` → both services reach `healthy` within ~6s.
- [x] `psql -h 127.0.0.1 -p 55432 -U postgres -d app -c "select 1"` succeeds from host.
- [x] `redis-cli -h 127.0.0.1 ping` → `PONG` from host.
- [x] `docker compose down -v` cleans up.

Closes #4