### PR TITLE
ci(T-0.10): pr hygiene workflows + commitlint

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -1,0 +1,27 @@
+name: branch-name
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  branch-name:
+    name: branch-name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch name
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          pattern='^(feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert)/T-[0-9]+\.[0-9]+-[a-z0-9-]+$'
+          echo "Branch: $BRANCH"
+          if [[ ! "$BRANCH" =~ $pattern ]]; then
+            echo "::error::Branch '$BRANCH' does not match required pattern: $pattern"
+            echo "Expected e.g. feat/T-1.3-crypto-service"
+            exit 1
+          fi
+          echo "OK"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,21 @@
+name: commitlint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    name: commitlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: commitlint.config.cjs

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,34 @@
+name: pr-lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-lint:
+    name: pr-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            refactor
+            test
+            perf
+            build
+            ci
+            style
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" must start lowercase (Conventional Commits).

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -19,8 +19,9 @@ module.exports = {
         'revert',
       ],
     ],
-    'subject-case': [0],
+    'subject-case': [2, 'always', ['lower-case']],
     'subject-full-stop': [2, 'never', '.'],
+    'subject-max-length': [2, 'always', 50],
     'header-max-length': [2, 'always', 72],
   },
 };

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,26 @@
+/** @type {import('@commitlint/types').UserConfig} */
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'chore',
+        'docs',
+        'refactor',
+        'test',
+        'perf',
+        'build',
+        'ci',
+        'style',
+        'revert',
+      ],
+    ],
+    'subject-case': [0],
+    'subject-full-stop': [2, 'never', '.'],
+    'header-max-length': [2, 'always', 72],
+  },
+};


### PR DESCRIPTION
## Summary
- Add `pr-lint` (amannn/action-semantic-pull-request) validating PR titles as Conventional Commits.
- Add `commitlint` (wagoid/commitlint-github-action) validating every commit against `@commitlint/config-conventional`.
- Add `branch-name` regex check: `^(feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert)/T-\d+\.\d+-[a-z0-9-]+$`.
- Add `commitlint.config.cjs` with project type-enum + header-max-length 72.

## Bootstrap note
Branch protection on `main` (require PR, linear history, squash-only, no force-push/delete, required checks: `pr-lint`, `commitlint`, `branch-name`) to be enabled **after** merge — checks don't exist until this PR lands.

## Verification
- CONTRIBUTING.md conventions already match enforced rules — no doc changes needed.

Closes #10