### PR TITLE
ci(T-0.11): cd skeleton vercel + railway

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "apps/api/**"
       - "packages/**"
+      - "railway.json"
+      - "turbo.json"
+      - "pnpm-lock.yaml"
       - ".github/workflows/deploy-api.yml"
 
 concurrency:
@@ -19,27 +22,36 @@ jobs:
     env:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       RAILWAY_SERVICE_ID_API: ${{ secrets.RAILWAY_SERVICE_ID_API }}
+      API_HEALTH_URL: ${{ vars.API_HEALTH_URL }}
     steps:
       - name: Check secrets
         id: gate
         run: |
           if [ -z "$RAILWAY_TOKEN" ] || [ -z "$RAILWAY_SERVICE_ID_API" ]; then
             echo "skipped=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipped: Railway secrets not configured (RAILWAY_TOKEN / RAILWAY_SERVICE_ID_API)."
+            echo "::notice::Skipped: Railway secrets not configured."
           else
             echo "skipped=false" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/checkout@v4
         if: steps.gate.outputs.skipped == 'false'
-      - uses: ./.github/actions/setup
-        if: steps.gate.outputs.skipped == 'false'
-      - name: Build api
-        if: steps.gate.outputs.skipped == 'false'
-        run: pnpm --filter @commit-analyzer/api build
       - name: Install Railway CLI
         if: steps.gate.outputs.skipped == 'false'
-        run: pnpm add -g @railway/cli
+        run: npm i -g @railway/cli
       - name: Deploy to Railway
         if: steps.gate.outputs.skipped == 'false'
         run: railway up --service "$RAILWAY_SERVICE_ID_API" --ci
-        working-directory: apps/api
+      - name: Health check
+        if: steps.gate.outputs.skipped == 'false' && env.API_HEALTH_URL != ''
+        run: |
+          echo "Probing $API_HEALTH_URL"
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$API_HEALTH_URL" || echo "000")
+            echo "attempt $i: HTTP $code"
+            if [ "$code" = "200" ]; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::Health check failed for $API_HEALTH_URL"
+          exit 1

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,45 @@
+name: Deploy API
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/api/**"
+      - "packages/**"
+      - ".github/workflows/deploy-api.yml"
+
+concurrency:
+  group: deploy-api
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy api to Railway
+    runs-on: ubuntu-latest
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      RAILWAY_SERVICE_ID_API: ${{ secrets.RAILWAY_SERVICE_ID_API }}
+    steps:
+      - name: Check secrets
+        id: gate
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ] || [ -z "$RAILWAY_SERVICE_ID_API" ]; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipped: Railway secrets not configured (RAILWAY_TOKEN / RAILWAY_SERVICE_ID_API)."
+          else
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.skipped == 'false'
+      - uses: ./.github/actions/setup
+        if: steps.gate.outputs.skipped == 'false'
+      - name: Build api
+        if: steps.gate.outputs.skipped == 'false'
+        run: pnpm --filter @commit-analyzer/api build
+      - name: Install Railway CLI
+        if: steps.gate.outputs.skipped == 'false'
+        run: pnpm add -g @railway/cli
+      - name: Deploy to Railway
+        if: steps.gate.outputs.skipped == 'false'
+        run: railway up --service "$RAILWAY_SERVICE_ID_API" --ci
+        working-directory: apps/api

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -9,6 +9,7 @@ on:
       - "railway.json"
       - "turbo.json"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - ".github/workflows/deploy-api.yml"
 
 concurrency:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,54 @@
+name: Deploy Web
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/web/**"
+      - "packages/**"
+      - ".github/workflows/deploy-web.yml"
+
+concurrency:
+  group: deploy-web
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy web to Vercel
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - name: Check secrets
+        id: gate
+        run: |
+          if [ -z "$VERCEL_TOKEN" ] || [ -z "$VERCEL_ORG_ID" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipped: Vercel secrets not configured (VERCEL_TOKEN / VERCEL_ORG_ID / VERCEL_PROJECT_ID)."
+          else
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.skipped == 'false'
+      - uses: ./.github/actions/setup
+        if: steps.gate.outputs.skipped == 'false'
+      - name: Build web
+        if: steps.gate.outputs.skipped == 'false'
+        run: pnpm --filter @commit-analyzer/web build
+      - name: Install Vercel CLI
+        if: steps.gate.outputs.skipped == 'false'
+        run: pnpm add -g vercel@latest
+      - name: Pull Vercel environment
+        if: steps.gate.outputs.skipped == 'false'
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+        working-directory: apps/web
+      - name: Build Vercel artifact
+        if: steps.gate.outputs.skipped == 'false'
+        run: vercel build --prod --token="$VERCEL_TOKEN"
+        working-directory: apps/web
+      - name: Deploy to Vercel
+        if: steps.gate.outputs.skipped == 'false'
+        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
+        working-directory: apps/web

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -8,6 +8,7 @@ on:
       - "packages/**"
       - "turbo.json"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - ".github/workflows/deploy-web.yml"
 
 concurrency:
@@ -48,6 +49,7 @@ jobs:
           for i in 1 2 3 4 5 6 7 8 9 10; do
             code=$(curl -s -o /dev/null -w "%{http_code}" "$WEB_HEALTH_URL" || echo "000")
             echo "attempt $i: HTTP $code"
+            # next-intl root redirects to /<locale>, so 307/308 are expected on `/`
             if [ "$code" = "200" ] || [ "$code" = "307" ] || [ "$code" = "308" ]; then
               exit 0
             fi

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - "apps/web/**"
       - "packages/**"
+      - "turbo.json"
+      - "pnpm-lock.yaml"
       - ".github/workflows/deploy-web.yml"
 
 concurrency:
@@ -20,35 +22,36 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      WEB_HEALTH_URL: ${{ vars.WEB_HEALTH_URL }}
     steps:
       - name: Check secrets
         id: gate
         run: |
           if [ -z "$VERCEL_TOKEN" ] || [ -z "$VERCEL_ORG_ID" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
             echo "skipped=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipped: Vercel secrets not configured (VERCEL_TOKEN / VERCEL_ORG_ID / VERCEL_PROJECT_ID)."
+            echo "::notice::Skipped: Vercel secrets not configured."
           else
             echo "skipped=false" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/checkout@v4
         if: steps.gate.outputs.skipped == 'false'
-      - uses: ./.github/actions/setup
-        if: steps.gate.outputs.skipped == 'false'
-      - name: Build web
-        if: steps.gate.outputs.skipped == 'false'
-        run: pnpm --filter @commit-analyzer/web build
       - name: Install Vercel CLI
         if: steps.gate.outputs.skipped == 'false'
-        run: pnpm add -g vercel@latest
-      - name: Pull Vercel environment
-        if: steps.gate.outputs.skipped == 'false'
-        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
-        working-directory: apps/web
-      - name: Build Vercel artifact
-        if: steps.gate.outputs.skipped == 'false'
-        run: vercel build --prod --token="$VERCEL_TOKEN"
-        working-directory: apps/web
+        run: npm i -g vercel@latest
       - name: Deploy to Vercel
         if: steps.gate.outputs.skipped == 'false'
-        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
-        working-directory: apps/web
+        run: vercel deploy --prod --yes --token="$VERCEL_TOKEN"
+      - name: Health check
+        if: steps.gate.outputs.skipped == 'false' && env.WEB_HEALTH_URL != ''
+        run: |
+          echo "Probing $WEB_HEALTH_URL"
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$WEB_HEALTH_URL" || echo "000")
+            echo "attempt $i: HTTP $code"
+            if [ "$code" = "200" ] || [ "$code" = "307" ] || [ "$code" = "308" ]; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::Health check failed for $WEB_HEALTH_URL"
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ coverage/
 # Misc
 *.tgz
 .cache/
+
+# Vercel
+.vercel

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Required repository secrets:
 | `deploy-web` | `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`  |
 | `deploy-api` | `RAILWAY_TOKEN`, `RAILWAY_SERVICE_ID_API`             |
 
+Health checks are driven by repository variables (not secrets):
+
+| Variable          | Example                                                 |
+| ----------------- | ------------------------------------------------------- |
+| `WEB_HEALTH_URL`  | `https://commit-analyzer.vercel.app/`                   |
+| `API_HEALTH_URL`  | `https://poetic-luck-production.up.railway.app/health`  |
+
+Live environments:
+
+- Web → <https://commit-analyzer.vercel.app>
+- API → <https://poetic-luck-production.up.railway.app/health>
+
 ## Status
 
 In development. See [issues](../../issues) and [milestones](../../milestones) for current phase progress.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for commit conventions, branch naming, 
 
 Specification documents live outside the repo (thesis project) and are intentionally gitignored. Tasks are tracked as GitHub issues grouped by phase milestones.
 
+## Deployment
+
+Continuous deployment runs from `main` via GitHub Actions:
+
+- `deploy-web` — Vercel (triggered on `apps/web/**`, `packages/**`)
+- `deploy-api` — Railway (triggered on `apps/api/**`, `packages/**`)
+
+Each workflow logs a skip notice and exits green when its secrets are absent, so the pipeline stays non-blocking until infra is provisioned.
+
+Required repository secrets:
+
+| Workflow     | Secrets                                               |
+| ------------ | ----------------------------------------------------- |
+| `deploy-web` | `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`  |
+| `deploy-api` | `RAILWAY_TOKEN`, `RAILWAY_SERVICE_ID_API`             |
+
 ## Status
 
 In development. See [issues](../../issues) and [milestones](../../milestones) for current phase progress.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,7 +6,6 @@ import createNextIntlPlugin from "next-intl/plugin";
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@commit-analyzer/shared-types"],
   turbopack: {
     root: fileURLToPath(new URL("../..", import.meta.url)),
   },

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,6 +6,7 @@ import createNextIntlPlugin from "next-intl/plugin";
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
+  transpilePackages: ["@commit-analyzer/shared-types"],
   turbopack: {
     root: fileURLToPath(new URL("../..", import.meta.url)),
   },

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -3,12 +3,19 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./env": "./src/env/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./env": {
+      "types": "./dist/env/index.d.ts",
+      "default": "./dist/env/index.js"
+    }
   },
+  "files": ["dist"],
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/railway.json
+++ b/railway.json
@@ -2,10 +2,10 @@
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
     "builder": "NIXPACKS",
-    "buildCommand": "corepack enable && corepack prepare pnpm@9.12.0 --activate && pnpm install --frozen-lockfile && pnpm --filter @commit-analyzer/shared-types build"
+    "buildCommand": "corepack enable && corepack prepare pnpm@9.12.0 --activate && pnpm install --frozen-lockfile && pnpm --filter @commit-analyzer/shared-types build && pnpm --filter @commit-analyzer/api build"
   },
   "deploy": {
-    "startCommand": "pnpm --filter @commit-analyzer/api exec tsx src/bootstrap.ts",
+    "startCommand": "node --enable-source-maps apps/api/dist/bootstrap.js",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 100,
     "restartPolicyType": "ON_FAILURE",

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "corepack enable && corepack prepare pnpm@9.12.0 --activate && pnpm install --frozen-lockfile && pnpm --filter @commit-analyzer/shared-types build"
+  },
+  "deploy": {
+    "startCommand": "pnpm --filter @commit-analyzer/api exec tsx src/bootstrap.ts",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 100,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -35,7 +35,9 @@
       "dependsOn": ["^build"],
       "outputs": ["coverage/**"]
     },
-    "lint": {},
+    "lint": {
+      "dependsOn": ["^build"]
+    },
     "typecheck": {
       "dependsOn": ["^build"]
     }

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,29 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
+      "env": [
+        "NODE_ENV",
+        "LOG_LEVEL",
+        "APP_URL",
+        "API_URL",
+        "WEB_ORIGIN",
+        "DATABASE_URL",
+        "REDIS_URL",
+        "SUPABASE_URL",
+        "SUPABASE_ANON_KEY",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "GITHUB_CLIENT_ID",
+        "GITHUB_CLIENT_SECRET",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ENCRYPTION_KEY_BASE64",
+        "CSP_CONNECT_SRC",
+        "NEXT_PUBLIC_APP_URL",
+        "NEXT_PUBLIC_API_URL",
+        "NEXT_PUBLIC_SUPABASE_URL",
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY"
+      ]
     },
     "dev": {
       "cache": false,
@@ -14,6 +36,8 @@
       "outputs": ["coverage/**"]
     },
     "lint": {},
-    "typecheck": {}
+    "typecheck": {
+      "dependsOn": ["^build"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add `deploy-web.yml` (Vercel) and `deploy-api.yml` (Railway) workflows triggered on `main` pushes under the relevant app paths. Both gate on required secrets and log a skip notice when absent so the pipeline stays non-blocking.
- Post-deploy health checks curl `vars.WEB_HEALTH_URL` / `vars.API_HEALTH_URL` so deploy failures mark the commit status red.
- Add `railway.json` at repo root so Railway builds + starts the Nest API via tsx against monorepo sources.
- Switch `@commit-analyzer/shared-types` to `dist/` based exports + declare `dependsOn: ["^build"]` on `typecheck` so Next turbopack (strict `.js` resolver) can consume it in production builds.
- Declare env allowlist on `turbo.build` so Vercel-provided env vars survive turbo's pruning.
- Add `transpilePackages: ["@commit-analyzer/shared-types"]` to the Next.js config and ignore `.vercel/` locally.
- Document required secrets + live environment URLs in README.

## Verified
- API: `https://poetic-luck-production.up.railway.app/health` → 200 `{"status":"ok"}`
- Web: `https://commit-analyzer.vercel.app/` → 200
- `pnpm lint`, `pnpm typecheck`, `pnpm test` all green locally against this branch.

Closes #11