### PR TITLE
fix(T-0.11): railway uses account token env

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -21,14 +21,14 @@ jobs:
     name: Deploy api to Railway
     runs-on: ubuntu-latest
     env:
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
       RAILWAY_SERVICE_ID_API: ${{ secrets.RAILWAY_SERVICE_ID_API }}
       API_HEALTH_URL: ${{ vars.API_HEALTH_URL }}
     steps:
       - name: Check secrets
         id: gate
         run: |
-          if [ -z "$RAILWAY_TOKEN" ] || [ -z "$RAILWAY_SERVICE_ID_API" ]; then
+          if [ -z "$RAILWAY_API_TOKEN" ] || [ -z "$RAILWAY_SERVICE_ID_API" ]; then
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Skipped: Railway secrets not configured."
           else

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Required repository secrets:
 | Workflow     | Secrets                                               |
 | ------------ | ----------------------------------------------------- |
 | `deploy-web` | `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`  |
-| `deploy-api` | `RAILWAY_TOKEN`, `RAILWAY_SERVICE_ID_API`             |
+| `deploy-api` | `RAILWAY_API_TOKEN`, `RAILWAY_SERVICE_ID_API`         |
 
 Health checks are driven by repository variables (not secrets):
 


### PR DESCRIPTION
## Summary
- Workflow referenced secret `RAILWAY_TOKEN`, but the provisioned token is an **account** token, which the Railway CLI reads from `RAILWAY_API_TOKEN`. Deploy failed on first post-merge run with `Invalid RAILWAY_TOKEN`.
- Switch `.github/workflows/deploy-api.yml` and the README secrets table to `RAILWAY_API_TOKEN`.

Verified locally: `RAILWAY_API_TOKEN=… railway whoami` → authenticated; `RAILWAY_TOKEN=…` → unauthorized.