### PR TITLE
fix(T-0.11): pass railway project + env to CI

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -23,6 +23,8 @@ jobs:
     env:
       RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
       RAILWAY_SERVICE_ID_API: ${{ secrets.RAILWAY_SERVICE_ID_API }}
+      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
       API_HEALTH_URL: ${{ vars.API_HEALTH_URL }}
     steps:
       - name: Check secrets


### PR DESCRIPTION
Account-token Railway CLI runs in CI need project + environment IDs in env vars (no interactive `railway link`). Adding `RAILWAY_PROJECT_ID` / `RAILWAY_ENVIRONMENT_ID` repo variables and wiring them into `deploy-api.yml`.