### PR TITLE
ci(T-0.11): prebuilt vercel deploy flow

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -39,9 +39,15 @@ jobs:
       - name: Install Vercel CLI
         if: steps.gate.outputs.skipped == 'false'
         run: npm i -g vercel@latest
-      - name: Deploy to Vercel
+      - name: Pull Vercel environment
         if: steps.gate.outputs.skipped == 'false'
-        run: vercel deploy --prod --yes --token="$VERCEL_TOKEN"
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+      - name: Build project artifacts
+        if: steps.gate.outputs.skipped == 'false'
+        run: vercel build --prod --token="$VERCEL_TOKEN"
+      - name: Deploy prebuilt artifacts
+        if: steps.gate.outputs.skipped == 'false'
+        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
       - name: Health check
         if: steps.gate.outputs.skipped == 'false' && env.WEB_HEALTH_URL != ''
         run: |


### PR DESCRIPTION
## Summary
- Switch `deploy-web.yml` to canonical Vercel prebuilt sequence: `vercel pull` → `vercel build --prod` → `vercel deploy --prebuilt --prod`.
- Workflow already pins `vercel@latest` (currently 51.x), 10 majors past the 41.4.1 `fsPath` crash that originally blocked this path.

## Test plan
- [ ] CI `branch-name` + `commitlint` green
- [ ] `deploy-web` job runs end-to-end on merge
- [ ] Health check returns 200/307/308 for `WEB_HEALTH_URL`

Closes #95