### PR TITLE
fix(T-0.11): dockerfile builder for api service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+**/node_modules
+**/dist
+**/.turbo
+**/.next
+**/*.tsbuildinfo
+**/coverage
+**/.env
+**/.env.*
+!**/.env.example
+.git
+.github
+.claude
+.vscode
+.idea
+apps/web/.next
+apps/cli/dist

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.7
+FROM node:20-alpine AS base
+RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
+WORKDIR /app
+
+FROM base AS deps
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json ./
+COPY apps/api/package.json apps/api/package.json
+COPY apps/cli/package.json apps/cli/package.json
+COPY apps/web/package.json apps/web/package.json
+COPY packages/contracts/package.json packages/contracts/package.json
+COPY packages/database/package.json packages/database/package.json
+COPY packages/eslint-config/package.json packages/eslint-config/package.json
+COPY packages/shared-types/package.json packages/shared-types/package.json
+COPY packages/typescript-config/package.json packages/typescript-config/package.json
+RUN --mount=type=cache,id=pnpm,sharing=locked,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
+
+FROM deps AS build
+COPY packages/typescript-config packages/typescript-config
+COPY packages/shared-types packages/shared-types
+COPY apps/api apps/api
+RUN pnpm --filter @commit-analyzer/shared-types build \
+ && pnpm --filter @commit-analyzer/api build
+
+FROM base AS runner
+ENV NODE_ENV=production
+RUN addgroup -S app && adduser -S app -G app
+COPY --chown=app:app pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY --chown=app:app apps/api/package.json apps/api/package.json
+COPY --chown=app:app apps/cli/package.json apps/cli/package.json
+COPY --chown=app:app apps/web/package.json apps/web/package.json
+COPY --chown=app:app packages/contracts/package.json packages/contracts/package.json
+COPY --chown=app:app packages/database/package.json packages/database/package.json
+COPY --chown=app:app packages/eslint-config/package.json packages/eslint-config/package.json
+COPY --chown=app:app packages/shared-types/package.json packages/shared-types/package.json
+COPY --chown=app:app packages/typescript-config/package.json packages/typescript-config/package.json
+RUN --mount=type=cache,id=pnpm,sharing=locked,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --prod --filter "@commit-analyzer/api..."
+COPY --from=build --chown=app:app /app/packages/shared-types/dist packages/shared-types/dist
+COPY --from=build --chown=app:app /app/apps/api/dist apps/api/dist
+USER app
+EXPOSE 3000
+CMD ["node", "--enable-source-maps", "apps/api/dist/bootstrap.js"]

--- a/railway.json
+++ b/railway.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "builder": "NIXPACKS",
-    "buildCommand": "corepack enable && corepack prepare pnpm@9.12.0 --activate && pnpm install --frozen-lockfile && pnpm --filter @commit-analyzer/shared-types build && pnpm --filter @commit-analyzer/api build"
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "apps/api/Dockerfile"
   },
   "deploy": {
     "startCommand": "node --enable-source-maps apps/api/dist/bootstrap.js",


### PR DESCRIPTION
## Summary
- Add multi-stage `apps/api/Dockerfile` (deps → build → runner) using pnpm 9.12, Node 20 Alpine, non-root `app` user.
- Flip `railway.json` from Nixpacks to `DOCKERFILE` builder; drop obsolete `buildCommand`. Start command and health check unchanged.
- Add root `.dockerignore` to keep the build context lean.

## Verification
- `docker build -f apps/api/Dockerfile .` → succeeds.
- Container runs as non-root; `GET /health` → `200 {"status":"ok"}` with a full env set.
- `pnpm -r typecheck`, `pnpm -r lint`, `pnpm -r test` all green.

Closes #94