### PR TITLE
fix(T-0.11): drop buildkit cache mounts (kaniko)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1.7
 FROM node:20-alpine AS base
 RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
 WORKDIR /app
@@ -13,8 +12,7 @@ COPY packages/database/package.json packages/database/package.json
 COPY packages/eslint-config/package.json packages/eslint-config/package.json
 COPY packages/shared-types/package.json packages/shared-types/package.json
 COPY packages/typescript-config/package.json packages/typescript-config/package.json
-RUN --mount=type=cache,id=pnpm,sharing=locked,target=/root/.local/share/pnpm/store \
-    pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile
 
 FROM deps AS build
 COPY packages/typescript-config packages/typescript-config
@@ -35,8 +33,8 @@ COPY --chown=app:app packages/database/package.json packages/database/package.js
 COPY --chown=app:app packages/eslint-config/package.json packages/eslint-config/package.json
 COPY --chown=app:app packages/shared-types/package.json packages/shared-types/package.json
 COPY --chown=app:app packages/typescript-config/package.json packages/typescript-config/package.json
-RUN --mount=type=cache,id=pnpm,sharing=locked,target=/root/.local/share/pnpm/store \
-    pnpm install --frozen-lockfile --prod --filter "@commit-analyzer/api..."
+RUN pnpm install --frozen-lockfile --prod --filter "@commit-analyzer/api..." \
+ && pnpm store prune
 COPY --from=build --chown=app:app /app/packages/shared-types/dist packages/shared-types/dist
 COPY --from=build --chown=app:app /app/apps/api/dist apps/api/dist
 USER app


### PR DESCRIPTION
## Summary
- Remove \`RUN --mount=type=cache\` from \`apps/api/Dockerfile\` and the \`# syntax=\` directive.
- Railway's Dockerfile builder is Kaniko-based and rejects BuildKit cache mount IDs without its cache-key prefix, causing the post-merge deploy to fail with \`Cache mount ID is not prefixed with cache key\`.
- Replaces the cache with a post-install \`pnpm store prune\` to keep the runner layer small.

## Verification
- \`docker build -f apps/api/Dockerfile .\` succeeds locally.
- Container still runs as non-root; \`GET /health\` → \`200\` with full env set.

Follow-up to #101 / #94.