### PR TITLE
fix(T-0.3): dev task depends on ^build

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,7 @@
       ]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
## Summary
- `pnpm dev` on a fresh clone failed because `apps/web` and `apps/api` import `@commit-analyzer/shared-types/env`, whose `exports` map points at `dist/`, but the `dev` turbo task had no `^build` dependency.
- Added `dependsOn: ["^build"]` so workspace deps build before persistent dev servers start.

## Test plan
- [x] `rm -rf packages/shared-types/{dist,tsconfig.tsbuildinfo,.turbo}` then `pnpm exec turbo run typecheck --force` → 9/9 green, `dist/env/` regenerated
- [ ] CI green