### PR TITLE
fix(T-0.11): setup pnpm before vercel build

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -36,6 +36,8 @@ jobs:
           fi
       - uses: actions/checkout@v4
         if: steps.gate.outputs.skipped == 'false'
+      - uses: ./.github/actions/setup
+        if: steps.gate.outputs.skipped == 'false'
       - name: Install Vercel CLI
         if: steps.gate.outputs.skipped == 'false'
         run: npm i -g vercel@latest


### PR DESCRIPTION
## Summary
- `Deploy Web` failed with `sh: 1: pnpm: not found` during `vercel build`. Vercel's project install command is `cd ../.. && pnpm install --frozen-lockfile`, but the runner had no pnpm/Node installed.
- Reuse the existing `./.github/actions/setup` composite (pnpm 9.12.0 + Node 20) before `vercel build`.

## Test plan
- [ ] Workflow run on main succeeds end-to-end
- [ ] Health check passes