### PR TITLE
fix(T-0.11): prebuild shared-types for web+api

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prebuild": "pnpm --filter @commit-analyzer/shared-types build",
     "build": "tsc",
     "start": "node --enable-source-maps dist/bootstrap.js",
+    "predev": "pnpm --filter @commit-analyzer/shared-types build",
     "dev": "tsx watch src/bootstrap.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prebuild": "pnpm --filter @commit-analyzer/shared-types build",
     "build": "next build",
+    "predev": "pnpm --filter @commit-analyzer/shared-types build",
     "dev": "next dev",
     "start": "next start",
     "test": "node scripts/check-messages.mjs",


### PR DESCRIPTION
## Summary
- Vercel runs `pnpm run build` (= `next build`) directly, bypassing turbo, so `@commit-analyzer/shared-types/dist/` was never built and Next failed with `Module not found: '@commit-analyzer/shared-types/env'`.
- Added `prebuild` (and `predev`) hooks in `apps/web` and `apps/api` that run `pnpm --filter @commit-analyzer/shared-types build` before the framework build.
- Same risk would hit api on Railway — preempting it.

## Test plan
- [x] `rm -rf packages/shared-types/{dist,tsconfig.tsbuildinfo}` then `pnpm --filter @commit-analyzer/web run build` → past module resolution (only fails locally on missing env, which Vercel pulls)
- [ ] `Deploy Web` workflow green on main