### PR TITLE
feat(T-1.3): aes-256-gcm crypto service

### DIFF
--- a/apps/api/src/shared/crypto.service.spec.ts
+++ b/apps/api/src/shared/crypto.service.spec.ts
@@ -1,0 +1,85 @@
+import { randomBytes } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { CryptoService, DecryptionError } from "./crypto.service.js";
+
+const makeKey = (): Buffer => randomBytes(32);
+
+describe("CryptoService", () => {
+  it("round-trips an empty string", () => {
+    const svc = new CryptoService(makeKey());
+    expect(svc.decrypt(svc.encrypt(""))).toBe("");
+  });
+
+  it("round-trips unicode", () => {
+    const svc = new CryptoService(makeKey());
+    const plain = "héllo 🌍 — Привіт, 世界";
+    expect(svc.decrypt(svc.encrypt(plain))).toBe(plain);
+  });
+
+  it("emits versioned v1 format with four parts", () => {
+    const svc = new CryptoService(makeKey());
+    const out = svc.encrypt("hello");
+    const parts = out.split(":");
+    expect(parts).toHaveLength(4);
+    expect(parts[0]).toBe("v1");
+  });
+
+  it("produces distinct ciphertexts for same plaintext (fresh IV)", () => {
+    const svc = new CryptoService(makeKey());
+    expect(svc.encrypt("same")).not.toBe(svc.encrypt("same"));
+  });
+
+  it("round-trips 1000 random inputs", () => {
+    const svc = new CryptoService(makeKey());
+    for (let i = 0; i < 1000; i++) {
+      const len = Math.floor(Math.random() * 256);
+      const plain = randomBytes(len).toString("base64");
+      expect(svc.decrypt(svc.encrypt(plain))).toBe(plain);
+    }
+  });
+
+  it("throws DecryptionError on tampered ciphertext", () => {
+    const svc = new CryptoService(makeKey());
+    const encrypted = svc.encrypt("secret");
+    const parts = encrypted.split(":");
+    const data = Buffer.from(parts[2]!, "base64");
+    data[0] = (data[0] ?? 0) ^ 0x01;
+    parts[2] = data.toString("base64");
+    expect(() => svc.decrypt(parts.join(":"))).toThrow(DecryptionError);
+  });
+
+  it("throws DecryptionError on tampered auth tag", () => {
+    const svc = new CryptoService(makeKey());
+    const encrypted = svc.encrypt("secret");
+    const parts = encrypted.split(":");
+    const tag = Buffer.from(parts[3]!, "base64");
+    tag[0] = (tag[0] ?? 0) ^ 0x01;
+    parts[3] = tag.toString("base64");
+    expect(() => svc.decrypt(parts.join(":"))).toThrow(DecryptionError);
+  });
+
+  it("throws DecryptionError when decrypted with wrong key", () => {
+    const a = new CryptoService(makeKey());
+    const b = new CryptoService(makeKey());
+    const encrypted = a.encrypt("secret");
+    expect(() => b.decrypt(encrypted)).toThrow(DecryptionError);
+  });
+
+  it("throws DecryptionError on unsupported version prefix", () => {
+    const svc = new CryptoService(makeKey());
+    const encrypted = svc.encrypt("x");
+    const bad = "v2" + encrypted.slice(2);
+    expect(() => svc.decrypt(bad)).toThrow(DecryptionError);
+  });
+
+  it("throws DecryptionError on malformed segment count", () => {
+    const svc = new CryptoService(makeKey());
+    expect(() => svc.decrypt("v1:only:two")).toThrow(DecryptionError);
+  });
+
+  it("rejects key of wrong length", () => {
+    expect(() => new CryptoService(Buffer.alloc(16))).toThrow(/32 bytes/);
+  });
+});

--- a/apps/api/src/shared/crypto.service.ts
+++ b/apps/api/src/shared/crypto.service.ts
@@ -1,0 +1,70 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+import { Injectable } from "@nestjs/common";
+
+import { getServerEnv } from "../common/config.js";
+
+const VERSION = "v1";
+const ALGO = "aes-256-gcm";
+const IV_LENGTH = 12;
+const TAG_LENGTH = 16;
+const KEY_LENGTH = 32;
+
+export class DecryptionError extends Error {
+  constructor(message = "decryption failed") {
+    super(message);
+    this.name = "DecryptionError";
+  }
+}
+
+@Injectable()
+export class CryptoService {
+  private readonly key: Buffer;
+
+  constructor(key?: Buffer) {
+    const resolved = key ?? Buffer.from(getServerEnv().ENCRYPTION_KEY_BASE64, "base64");
+    if (resolved.length !== KEY_LENGTH) {
+      throw new Error(`encryption key must be ${KEY_LENGTH} bytes`);
+    }
+    this.key = resolved;
+  }
+
+  encrypt(plaintext: string): string {
+    const iv = randomBytes(IV_LENGTH);
+    const cipher = createCipheriv(ALGO, this.key, iv);
+    const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    return [VERSION, iv.toString("base64"), ciphertext.toString("base64"), tag.toString("base64")].join(":");
+  }
+
+  decrypt(cipher: string): string {
+    const parts = cipher.split(":");
+    if (parts.length !== 4 || parts[0] !== VERSION) {
+      throw new DecryptionError("unsupported ciphertext format");
+    }
+    const ivB64 = parts[1]!;
+    const dataB64 = parts[2]!;
+    const tagB64 = parts[3]!;
+    let iv: Buffer;
+    let data: Buffer;
+    let tag: Buffer;
+    try {
+      iv = Buffer.from(ivB64, "base64");
+      data = Buffer.from(dataB64, "base64");
+      tag = Buffer.from(tagB64, "base64");
+    } catch {
+      throw new DecryptionError("invalid base64 segment");
+    }
+    if (iv.length !== IV_LENGTH || tag.length !== TAG_LENGTH) {
+      throw new DecryptionError("invalid iv or tag length");
+    }
+    try {
+      const decipher = createDecipheriv(ALGO, this.key, iv);
+      decipher.setAuthTag(tag);
+      const plaintext = Buffer.concat([decipher.update(data), decipher.final()]);
+      return plaintext.toString("utf8");
+    } catch {
+      throw new DecryptionError();
+    }
+  }
+}

--- a/packages/eslint-config/api.js
+++ b/packages/eslint-config/api.js
@@ -17,6 +17,7 @@ const elements = [
     pattern: "{index,main,bootstrap,app.module}.ts",
   },
   { type: "common", pattern: "src/common" },
+  { type: "shared", pattern: "src/shared" },
   {
     type: "module",
     pattern: "src/modules/*",
@@ -44,10 +45,14 @@ export default [
           rules: [
             {
               from: { type: "app" },
-              allow: { to: { type: ["app", "common", "module"] } },
+              allow: { to: { type: ["app", "common", "shared", "module"] } },
             },
             {
               from: { type: "module" },
+              allow: { to: { type: ["common", "shared"] } },
+            },
+            {
+              from: { type: "shared" },
               allow: { to: { type: "common" } },
             },
           ],


### PR DESCRIPTION
## Summary
- Add `CryptoService` in `apps/api/src/shared/crypto.service.ts` providing AES-256-GCM `encrypt`/`decrypt` with versioned `v1:<iv>:<ciphertext>:<tag>` base64 format.
- Key sourced from `ENCRYPTION_KEY_BASE64` (already validated in shared-types env schema); constructor also accepts an explicit key for tests.
- Custom `DecryptionError` thrown on tamper, wrong key, malformed input, or bad version prefix.
- Vitest suite: 1k random round-trip, empty string, unicode, distinct IVs, tampered ciphertext/tag, wrong key, bad version, malformed segments, key-length guard.
- Extend `eslint-plugin-boundaries` config with a `shared` element so `src/shared/*` is a recognized layer (app/module may depend on it; shared → common only).

Closes #14