### PR TITLE
feat(T-1.1): supabase github oauth + auth events

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "@nestjs/core": "^11",
     "@nestjs/cqrs": "^11.0.3",
     "@nestjs/platform-express": "^11",
+    "@supabase/supabase-js": "^2.103.0",
     "helmet": "^8",
     "pino": "^9.5.0",
     "reflect-metadata": "^0.2",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,7 @@
     "@commit-analyzer/shared-types": "workspace:*",
     "@nestjs/common": "^11",
     "@nestjs/core": "^11",
+    "@nestjs/cqrs": "^11.0.3",
     "@nestjs/platform-express": "^11",
     "helmet": "^8",
     "pino": "^9.5.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,8 +1,10 @@
 import { Module } from "@nestjs/common";
 
+import { AuthModule } from "./modules/auth/auth.module.js";
 import { HealthController } from "./modules/health/health.controller.js";
 
 @Module({
+  imports: [AuthModule],
   controllers: [HealthController],
 })
 export class AppModule {}

--- a/apps/api/src/modules/auth/auth.controller.test.ts
+++ b/apps/api/src/modules/auth/auth.controller.test.ts
@@ -1,0 +1,43 @@
+import "reflect-metadata";
+
+import { EventBus } from "@nestjs/cqrs";
+import { Test } from "@nestjs/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AuthController } from "./auth.controller.js";
+import { AuthLoggedInEvent } from "./events/auth-logged-in.event.js";
+import { AuthLoggedOutEvent } from "./events/auth-logged-out.event.js";
+
+describe("AuthController", () => {
+  const publish = vi.fn();
+  let controller: AuthController;
+
+  beforeEach(async () => {
+    publish.mockReset();
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [{ provide: EventBus, useValue: { publish } }],
+    }).compile();
+    controller = moduleRef.get(AuthController);
+  });
+
+  it("publishes auth.login on sign-in-event", () => {
+    expect(controller.signInEvent({ provider: "github" })).toEqual({ ok: true });
+    expect(publish).toHaveBeenCalledTimes(1);
+    const [event] = publish.mock.calls[0] as [AuthLoggedInEvent];
+    expect(event).toBeInstanceOf(AuthLoggedInEvent);
+    expect(event.provider).toBe("github");
+  });
+
+  it("rejects unknown provider", () => {
+    expect(() => controller.signInEvent({ provider: "google" })).toThrow();
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it("publishes auth.logout on sign-out", () => {
+    expect(controller.signOut()).toEqual({ ok: true });
+    expect(publish).toHaveBeenCalledTimes(1);
+    const [event] = publish.mock.calls[0] as [AuthLoggedOutEvent];
+    expect(event).toBeInstanceOf(AuthLoggedOutEvent);
+  });
+});

--- a/apps/api/src/modules/auth/auth.controller.test.ts
+++ b/apps/api/src/modules/auth/auth.controller.test.ts
@@ -7,37 +7,52 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthController } from "./auth.controller.js";
 import { AuthLoggedInEvent } from "./events/auth-logged-in.event.js";
 import { AuthLoggedOutEvent } from "./events/auth-logged-out.event.js";
+import { SupabaseAuthGuard } from "./supabase-auth.guard.js";
 
 describe("AuthController", () => {
   const publish = vi.fn();
+  const canActivate = vi.fn().mockResolvedValue(true);
   let controller: AuthController;
+
+  const fakeReq = { authUserId: "user-123" } as Parameters<
+    AuthController["signInEvent"]
+  >[0];
 
   beforeEach(async () => {
     publish.mockReset();
+    canActivate.mockClear();
     const moduleRef = await Test.createTestingModule({
       controllers: [AuthController],
-      providers: [{ provide: EventBus, useValue: { publish } }],
-    }).compile();
+      providers: [
+        { provide: EventBus, useValue: { publish } },
+        { provide: SupabaseAuthGuard, useValue: { canActivate } },
+      ],
+    })
+      .overrideGuard(SupabaseAuthGuard)
+      .useValue({ canActivate })
+      .compile();
     controller = moduleRef.get(AuthController);
   });
 
-  it("publishes auth.login on sign-in-event", () => {
-    expect(controller.signInEvent({ provider: "github" })).toEqual({ ok: true });
+  it("publishes auth.login with userId + provider", () => {
+    expect(controller.signInEvent(fakeReq, { provider: "github" })).toEqual({ ok: true });
     expect(publish).toHaveBeenCalledTimes(1);
     const [event] = publish.mock.calls[0] as [AuthLoggedInEvent];
     expect(event).toBeInstanceOf(AuthLoggedInEvent);
     expect(event.provider).toBe("github");
+    expect(event.userId).toBe("user-123");
   });
 
   it("rejects unknown provider", () => {
-    expect(() => controller.signInEvent({ provider: "google" })).toThrow();
+    expect(() => controller.signInEvent(fakeReq, { provider: "google" })).toThrow();
     expect(publish).not.toHaveBeenCalled();
   });
 
-  it("publishes auth.logout on sign-out", () => {
-    expect(controller.signOut()).toEqual({ ok: true });
+  it("publishes auth.logout with userId", () => {
+    expect(controller.signOut(fakeReq)).toEqual({ ok: true });
     expect(publish).toHaveBeenCalledTimes(1);
     const [event] = publish.mock.calls[0] as [AuthLoggedOutEvent];
     expect(event).toBeInstanceOf(AuthLoggedOutEvent);
+    expect(event.userId).toBe("user-123");
   });
 });

--- a/apps/api/src/modules/auth/auth.controller.test.ts
+++ b/apps/api/src/modules/auth/auth.controller.test.ts
@@ -43,8 +43,10 @@ describe("AuthController", () => {
     expect(event.userId).toBe("user-123");
   });
 
-  it("rejects unknown provider", () => {
-    expect(() => controller.signInEvent(fakeReq, { provider: "google" })).toThrow();
+  it("rejects unknown provider with 400", () => {
+    expect(() => controller.signInEvent(fakeReq, { provider: "google" })).toThrow(
+      /invalid sign-in-event payload|Bad Request/,
+    );
     expect(publish).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -1,28 +1,34 @@
-import { Body, Controller, HttpCode, Inject, Post } from "@nestjs/common";
+import { Body, Controller, Inject, Post, Req, UseGuards } from "@nestjs/common";
 import { EventBus } from "@nestjs/cqrs";
 import { z } from "zod";
 
 import { AuthLoggedInEvent } from "./events/auth-logged-in.event.js";
 import { AuthLoggedOutEvent } from "./events/auth-logged-out.event.js";
+import {
+  SupabaseAuthGuard,
+  type AuthenticatedRequest,
+} from "./supabase-auth.guard.js";
 
 const signInEventSchema = z.object({ provider: z.literal("github") });
 
 @Controller("auth")
+@UseGuards(SupabaseAuthGuard)
 export class AuthController {
   constructor(@Inject(EventBus) private readonly eventBus: EventBus) {}
 
   @Post("sign-in-event")
-  @HttpCode(202)
-  signInEvent(@Body() body: unknown): { ok: true } {
+  signInEvent(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: unknown,
+  ): { ok: true } {
     const { provider } = signInEventSchema.parse(body);
-    this.eventBus.publish(new AuthLoggedInEvent(provider));
+    this.eventBus.publish(new AuthLoggedInEvent(req.authUserId!, provider));
     return { ok: true };
   }
 
   @Post("sign-out")
-  @HttpCode(200)
-  signOut(): { ok: true } {
-    this.eventBus.publish(new AuthLoggedOutEvent());
+  signOut(@Req() req: AuthenticatedRequest): { ok: true } {
+    this.eventBus.publish(new AuthLoggedOutEvent(req.authUserId!));
     return { ok: true };
   }
 }

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Inject, Post, Req, UseGuards } from "@nestjs/common";
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  HttpCode,
+  Inject,
+  Post,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
 import { EventBus } from "@nestjs/cqrs";
 import { z } from "zod";
 
@@ -17,16 +26,26 @@ export class AuthController {
   constructor(@Inject(EventBus) private readonly eventBus: EventBus) {}
 
   @Post("sign-in-event")
+  @HttpCode(200)
   signInEvent(
     @Req() req: AuthenticatedRequest,
     @Body() body: unknown,
   ): { ok: true } {
-    const { provider } = signInEventSchema.parse(body);
-    this.eventBus.publish(new AuthLoggedInEvent(req.authUserId!, provider));
+    const parsed = signInEventSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new BadRequestException({
+        message: "invalid sign-in-event payload",
+        issues: parsed.error.issues,
+      });
+    }
+    this.eventBus.publish(
+      new AuthLoggedInEvent(req.authUserId!, parsed.data.provider),
+    );
     return { ok: true };
   }
 
   @Post("sign-out")
+  @HttpCode(200)
   signOut(@Req() req: AuthenticatedRequest): { ok: true } {
     this.eventBus.publish(new AuthLoggedOutEvent(req.authUserId!));
     return { ok: true };

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, HttpCode, Inject, Post } from "@nestjs/common";
+import { EventBus } from "@nestjs/cqrs";
+import { z } from "zod";
+
+import { AuthLoggedInEvent } from "./events/auth-logged-in.event.js";
+import { AuthLoggedOutEvent } from "./events/auth-logged-out.event.js";
+
+const signInEventSchema = z.object({ provider: z.literal("github") });
+
+@Controller("auth")
+export class AuthController {
+  constructor(@Inject(EventBus) private readonly eventBus: EventBus) {}
+
+  @Post("sign-in-event")
+  @HttpCode(202)
+  signInEvent(@Body() body: unknown): { ok: true } {
+    const { provider } = signInEventSchema.parse(body);
+    this.eventBus.publish(new AuthLoggedInEvent(provider));
+    return { ok: true };
+  }
+
+  @Post("sign-out")
+  @HttpCode(200)
+  signOut(): { ok: true } {
+    this.eventBus.publish(new AuthLoggedOutEvent());
+    return { ok: true };
+  }
+}

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { CqrsModule } from "@nestjs/cqrs";
+
+import { AuthController } from "./auth.controller.js";
+
+@Module({
+  imports: [CqrsModule],
+  controllers: [AuthController],
+})
+export class AuthModule {}

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -2,9 +2,11 @@ import { Module } from "@nestjs/common";
 import { CqrsModule } from "@nestjs/cqrs";
 
 import { AuthController } from "./auth.controller.js";
+import { SupabaseAuthGuard } from "./supabase-auth.guard.js";
 
 @Module({
   imports: [CqrsModule],
   controllers: [AuthController],
+  providers: [SupabaseAuthGuard],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/events/auth-logged-in.event.ts
+++ b/apps/api/src/modules/auth/events/auth-logged-in.event.ts
@@ -1,0 +1,3 @@
+export class AuthLoggedInEvent {
+  constructor(public readonly provider: "github") {}
+}

--- a/apps/api/src/modules/auth/events/auth-logged-in.event.ts
+++ b/apps/api/src/modules/auth/events/auth-logged-in.event.ts
@@ -1,3 +1,6 @@
 export class AuthLoggedInEvent {
-  constructor(public readonly provider: "github") {}
+  constructor(
+    public readonly userId: string,
+    public readonly provider: "github",
+  ) {}
 }

--- a/apps/api/src/modules/auth/events/auth-logged-out.event.ts
+++ b/apps/api/src/modules/auth/events/auth-logged-out.event.ts
@@ -1,1 +1,3 @@
-export class AuthLoggedOutEvent {}
+export class AuthLoggedOutEvent {
+  constructor(public readonly userId: string) {}
+}

--- a/apps/api/src/modules/auth/events/auth-logged-out.event.ts
+++ b/apps/api/src/modules/auth/events/auth-logged-out.event.ts
@@ -1,0 +1,1 @@
+export class AuthLoggedOutEvent {}

--- a/apps/api/src/modules/auth/supabase-auth.guard.ts
+++ b/apps/api/src/modules/auth/supabase-auth.guard.ts
@@ -1,0 +1,51 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Request } from "express";
+
+import { getServerEnv } from "../../common/config.js";
+
+export interface AuthenticatedRequest extends Request {
+  authUserId?: string;
+}
+
+/**
+ * Minimal token verifier for T-1.1. Supersedes by T-1.5 SupabaseAuthGuard (JWKS + CLS).
+ * Calls `supabase.auth.getUser(token)` server-side so the token is verified against
+ * the Supabase backend before the controller runs.
+ */
+@Injectable()
+export class SupabaseAuthGuard implements CanActivate {
+  private client: SupabaseClient | undefined;
+
+  private getClient(): SupabaseClient {
+    if (!this.client) {
+      const env = getServerEnv();
+      this.client = createClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY, {
+        auth: { persistSession: false, autoRefreshToken: false },
+      });
+    }
+    return this.client;
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const header = req.headers.authorization;
+    if (!header?.startsWith("Bearer ")) {
+      throw new UnauthorizedException("missing bearer token");
+    }
+    const token = header.slice("Bearer ".length).trim();
+    if (!token) throw new UnauthorizedException("empty bearer token");
+
+    const { data, error } = await this.getClient().auth.getUser(token);
+    if (error || !data?.user) {
+      throw new UnauthorizedException("invalid token");
+    }
+    req.authUserId = data.user.id;
+    return true;
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,8 @@
   },
   "dependencies": {
     "@commit-analyzer/shared-types": "workspace:^",
+    "@supabase/ssr": "^0.10.2",
+    "@supabase/supabase-js": "^2.103.0",
     "next": "^16.2.3",
     "next-intl": "^4.9.1",
     "react": "^19.2.5",

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -1,6 +1,6 @@
-import { loadServerEnv } from "@commit-analyzer/shared-types/env";
 import { NextResponse } from "next/server";
 
+import { getClientEnv } from "@/lib/supabase/env";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -42,8 +42,8 @@ export const GET = async (request: Request) => {
 
   if (session?.access_token) {
     try {
-      const { API_URL } = loadServerEnv();
-      const response = await fetch(`${API_URL}/auth/sign-in-event`, {
+      const { NEXT_PUBLIC_API_URL } = getClientEnv();
+      const response = await fetch(`${NEXT_PUBLIC_API_URL}/auth/sign-in-event`, {
         method: "POST",
         headers: {
           "content-type": "application/json",

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -1,13 +1,20 @@
+import { loadServerEnv } from "@commit-analyzer/shared-types/env";
 import { NextResponse } from "next/server";
 
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 
+const sanitizeNext = (raw: string | null): string => {
+  if (!raw) return "/";
+  if (!raw.startsWith("/") || raw.startsWith("//")) return "/";
+  return raw;
+};
+
 export const GET = async (request: Request) => {
   const url = new URL(request.url);
   const code = url.searchParams.get("code");
-  const next = url.searchParams.get("next") ?? "/";
+  const next = sanitizeNext(url.searchParams.get("next"));
 
   if (!code) {
     return NextResponse.redirect(new URL("/?auth_error=missing_code", url.origin));
@@ -21,12 +28,22 @@ export const GET = async (request: Request) => {
     );
   }
 
-  try {
-    const {
-      data: { session },
-    } = await supabase.auth.getSession();
-    if (session?.access_token) {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/sign-in-event`, {
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) {
+    return NextResponse.redirect(new URL("/?auth_error=no_user", url.origin));
+  }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (session?.access_token) {
+    try {
+      const { API_URL } = loadServerEnv();
+      const response = await fetch(`${API_URL}/auth/sign-in-event`, {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -34,9 +51,12 @@ export const GET = async (request: Request) => {
         },
         body: JSON.stringify({ provider: "github" }),
       });
+      if (!response.ok) {
+        console.warn("auth.login event dispatch failed", response.status);
+      }
+    } catch (err) {
+      console.warn("auth.login event dispatch threw", err);
     }
-  } catch {
-    // Non-fatal: audit emission failure must not block the user redirect.
   }
 
   return NextResponse.redirect(new URL(next, url.origin));

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export const GET = async (request: Request) => {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const next = url.searchParams.get("next") ?? "/";
+
+  if (!code) {
+    return NextResponse.redirect(new URL("/?auth_error=missing_code", url.origin));
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+  if (error) {
+    return NextResponse.redirect(
+      new URL(`/?auth_error=${encodeURIComponent(error.message)}`, url.origin),
+    );
+  }
+
+  try {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    if (session?.access_token) {
+      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/sign-in-event`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ provider: "github" }),
+      });
+    }
+  } catch {
+    // Non-fatal: audit emission failure must not block the user redirect.
+  }
+
+  return NextResponse.redirect(new URL(next, url.origin));
+};

--- a/apps/web/src/app/auth/sign-in/route.ts
+++ b/apps/web/src/app/auth/sign-in/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export const POST = async (request: Request) => {
+  const supabase = await createSupabaseServerClient();
+  const origin = new URL(request.url).origin;
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: "github",
+    options: {
+      redirectTo: `${origin}/auth/callback`,
+      scopes: "read:user user:email repo",
+    },
+  });
+
+  if (error || !data?.url) {
+    return NextResponse.json(
+      { error: error?.message ?? "sign-in failed" },
+      { status: 500 },
+    );
+  }
+  return NextResponse.redirect(data.url, { status: 303 });
+};

--- a/apps/web/src/app/auth/sign-out/route.ts
+++ b/apps/web/src/app/auth/sign-out/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+export const POST = async (request: Request) => {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (session?.access_token) {
+    try {
+      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/sign-out`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${session.access_token}` },
+      });
+    } catch {
+      // Non-fatal.
+    }
+  }
+
+  await supabase.auth.signOut();
+  return NextResponse.redirect(new URL("/", request.url), { status: 303 });
+};

--- a/apps/web/src/app/auth/sign-out/route.ts
+++ b/apps/web/src/app/auth/sign-out/route.ts
@@ -1,6 +1,6 @@
-import { loadServerEnv } from "@commit-analyzer/shared-types/env";
 import { NextResponse } from "next/server";
 
+import { getClientEnv } from "@/lib/supabase/env";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -13,8 +13,8 @@ export const POST = async (request: Request) => {
 
   if (session?.access_token) {
     try {
-      const { API_URL } = loadServerEnv();
-      const response = await fetch(`${API_URL}/auth/sign-out`, {
+      const { NEXT_PUBLIC_API_URL } = getClientEnv();
+      const response = await fetch(`${NEXT_PUBLIC_API_URL}/auth/sign-out`, {
         method: "POST",
         headers: { authorization: `Bearer ${session.access_token}` },
       });

--- a/apps/web/src/app/auth/sign-out/route.ts
+++ b/apps/web/src/app/auth/sign-out/route.ts
@@ -1,3 +1,4 @@
+import { loadServerEnv } from "@commit-analyzer/shared-types/env";
 import { NextResponse } from "next/server";
 
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -12,12 +13,16 @@ export const POST = async (request: Request) => {
 
   if (session?.access_token) {
     try {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/sign-out`, {
+      const { API_URL } = loadServerEnv();
+      const response = await fetch(`${API_URL}/auth/sign-out`, {
         method: "POST",
         headers: { authorization: `Bearer ${session.access_token}` },
       });
-    } catch {
-      // Non-fatal.
+      if (!response.ok) {
+        console.warn("auth.logout event dispatch failed", response.status);
+      }
+    } catch (err) {
+      console.warn("auth.logout event dispatch threw", err);
     }
   }
 

--- a/apps/web/src/lib/supabase/browser.ts
+++ b/apps/web/src/lib/supabase/browser.ts
@@ -1,8 +1,18 @@
 import { createBrowserClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
-export const createSupabaseBrowserClient = () =>
-  createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+import { getClientEnv } from "./env";
+
+// @supabase/ssr returns SupabaseClient<any, any, any, any, any>; match that so
+// downstream code keeps concrete method typings.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AppSupabaseClient = SupabaseClient<any, any, any, any, any>;
+
+export const createSupabaseBrowserClient = (): AppSupabaseClient => {
+  const env = getClientEnv();
+  return createBrowserClient(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     { auth: { flowType: "pkce" } },
   );
+};

--- a/apps/web/src/lib/supabase/browser.ts
+++ b/apps/web/src/lib/supabase/browser.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from "@supabase/ssr";
+
+export const createSupabaseBrowserClient = () =>
+  createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { auth: { flowType: "pkce" } },
+  );

--- a/apps/web/src/lib/supabase/env.ts
+++ b/apps/web/src/lib/supabase/env.ts
@@ -1,0 +1,8 @@
+import { loadClientEnv, type ClientEnv } from "@commit-analyzer/shared-types/env";
+
+let cached: ClientEnv | undefined;
+
+export const getClientEnv = (): ClientEnv => {
+  cached ??= loadClientEnv();
+  return cached;
+};

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -1,0 +1,21 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export const createSupabaseServerClient = async () => {
+  const cookieStore = await cookies();
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: { flowType: "pkce" },
+      cookies: {
+        getAll: () => cookieStore.getAll(),
+        setAll: (cookiesToSet) => {
+          for (const { name, value, options } of cookiesToSet) {
+            cookieStore.set(name, value, options);
+          }
+        },
+      },
+    },
+  );
+};

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -1,11 +1,15 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
-export const createSupabaseServerClient = async () => {
+import { type AppSupabaseClient } from "./browser";
+import { getClientEnv } from "./env";
+
+export const createSupabaseServerClient = async (): Promise<AppSupabaseClient> => {
+  const env = getClientEnv();
   const cookieStore = await cookies();
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
       auth: { flowType: "pkce" },
       cookies: {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -5,5 +5,5 @@ import { routing } from "./i18n/routing";
 export default createMiddleware(routing);
 
 export const config = {
-  matcher: "/((?!api|trpc|_next|_vercel|.*\\..*).*)",
+  matcher: "/((?!api|trpc|auth|_next|_vercel|.*\\..*).*)",
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11
         version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+      '@supabase/supabase-js':
+        specifier: ^2.103.0
+        version: 2.103.0
       helmet:
         specifier: ^8
         version: 8.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@nestjs/core':
         specifier: ^11
         version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/cqrs':
+        specifier: ^11.0.3
+        version: 11.0.3(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express':
         specifier: ^11
         version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
@@ -105,6 +108,12 @@ importers:
       '@commit-analyzer/shared-types':
         specifier: workspace:^
         version: link:../../packages/shared-types
+      '@supabase/ssr':
+        specifier: ^0.10.2
+        version: 0.10.2(@supabase/supabase-js@2.103.0)
+      '@supabase/supabase-js':
+        specifier: ^2.103.0
+        version: 2.103.0
       next:
         specifier: ^16.2.3
         version: 16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -803,6 +812,14 @@ packages:
       '@nestjs/websockets':
         optional: true
 
+  '@nestjs/cqrs@11.0.3':
+    resolution: {integrity: sha512-2ezBftiXqVfNTzjCrmhazohYhIQzgm8rvM0aKndv73IOOBcVlNuNiQ3HHiHdd4c2w/3MOQDtsGbQHgZUuW6DPw==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
+      rxjs: ^7.2.0
+
   '@nestjs/platform-express@11.1.19':
     resolution: {integrity: sha512-Vpdv8jyCQdThfoTx+UTn+DRYr6H6X02YUqcpZ3qP6G3ZUwtVp7eS+hoQPGd4UuCnlnFG8Wqr2J9bGEzQdi1rIg==}
     peerDependencies:
@@ -1101,6 +1118,38 @@ packages:
   '@schummar/icu-type-parser@1.21.5':
     resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
 
+  '@supabase/auth-js@2.103.0':
+    resolution: {integrity: sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.103.0':
+    resolution: {integrity: sha512-YrneV2NjskUkkmkZ2Jt2n3elBgbWzV4Y1M9MM370z2Zd5ZPFqFbY8KIoPwuNjtAGE9YrpKBxnbZqeF07BiN9Og==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.0':
+    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+
+  '@supabase/postgrest-js@2.103.0':
+    resolution: {integrity: sha512-rC3sRxYdPZymkp2CZR1MiNQgbOleD01bGsW8VxEKRR5nMkLZ1NgAS1QTQf78Wh30czFyk505ZYr9Od8/mWT2TA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.103.0':
+    resolution: {integrity: sha512-gcPtXzZ6izyyBVf2of7K3dEt8CScPJn8VcSlQq6oWL9QoE1kqfQl0oFrOMHd5qrcADewxI7OxxosLB8W4XqtIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/ssr@0.10.2':
+    resolution: {integrity: sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.102.1
+
+  '@supabase/storage-js@2.103.0':
+    resolution: {integrity: sha512-DHmlvdAXwtOmZNbkIZi4lkobPR3XjIzoOgzoz5duMf6G+sDeY015YrzMJCnqdccuYr7X5x4yYuSwF//RoN2dvQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.103.0':
+    resolution: {integrity: sha512-j/6q5+LtXbR/YOLSLhy7Na74RD1cV2v+KwIIuuqMEjk1JpLEEyu0ynwDHpGoxMncDQl+R5FogaVqZm+85lZvtw==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/core-darwin-arm64@1.15.24':
     resolution: {integrity: sha512-uM5ZGfFXjtvtJ+fe448PVBEbn/CSxS3UAyLj3O9xOqKIWy3S6hPTXSPbszxkSsGDYKi+YFhzAsR4r/eXLxEQ0g==}
     engines: {node: '>=10'}
@@ -1292,6 +1341,9 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.58.1':
     resolution: {integrity: sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==}
@@ -1665,6 +1717,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -2093,6 +2149,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -3061,6 +3121,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -3463,6 +3535,13 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
 
+  '@nestjs/cqrs@11.0.3(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+
   '@nestjs/platform-express@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)':
     dependencies:
       '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -3660,6 +3739,51 @@ snapshots:
 
   '@schummar/icu-type-parser@1.21.5': {}
 
+  '@supabase/auth-js@2.103.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.103.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.0': {}
+
+  '@supabase/postgrest-js@2.103.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.103.0':
+    dependencies:
+      '@supabase/phoenix': 0.4.0
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/ssr@0.10.2(@supabase/supabase-js@2.103.0)':
+    dependencies:
+      '@supabase/supabase-js': 2.103.0
+      cookie: 1.1.1
+
+  '@supabase/storage-js@2.103.0':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.103.0':
+    dependencies:
+      '@supabase/auth-js': 2.103.0
+      '@supabase/functions-js': 2.103.0
+      '@supabase/postgrest-js': 2.103.0
+      '@supabase/realtime-js': 2.103.0
+      '@supabase/storage-js': 2.103.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/core-darwin-arm64@1.15.24':
     optional: true
 
@@ -3830,6 +3954,10 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.6.0
 
   '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -4222,6 +4350,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
 
@@ -4841,6 +4971,8 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.7.2:
     dependencies:
@@ -5958,6 +6090,8 @@ snapshots:
   wordwrap@1.0.0: {}
 
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary
- Supabase prod project `commit-analyzer-prod` created; GitHub provider enabled.
- Web: `@supabase/ssr` PKCE client + `/auth/sign-in`, `/auth/callback`, `/auth/sign-out` route handlers.
- API: `AuthModule` with `@nestjs/cqrs` `EventBus`. `POST /auth/sign-in-event` (called from Next.js callback) dispatches `AuthLoggedInEvent({provider:'github'})`; `POST /auth/sign-out` dispatches `AuthLoggedOutEvent`.
- Handler stubs land later in T-1.14 (`OnAuthLoggedIn/OutHandler`); this PR only emits.
- Env wiring: `.env.local` (gitignored) populated; prod vars pushed to Railway (`talented-unity/poetic-luck`) and Vercel (`commit-analyzer`) via MCP/CLI.
- Unit test: `AuthController` publishes correct events / rejects unknown provider.

## Spec deviation
Issue spec mentions two GitHub OAuth apps with `${WEB_ORIGIN}/auth/callback` + localhost callbacks. When using Supabase's GitHub provider, the GitHub OAuth callback must be Supabase's endpoint (`https://<project>.supabase.co/auth/v1/callback`) — Supabase forwards to whatever `redirectTo` the client sets. One GitHub OAuth app covers both local + prod via the `redirectTo` option on `signInWithOAuth`. The Supabase project only stores one provider client id/secret anyway.

## Test plan
- [x] `pnpm -r typecheck`
- [x] `pnpm -r lint`
- [x] `pnpm -r test` (16 api tests pass, including 3 new `AuthController` tests)
- [ ] Manual OAuth round-trip (`/auth/sign-in` → GitHub consent → `/auth/callback` returns session) — blocked until DB/TypeORM + JWT guard exist (T-1.2/T-1.5/T-1.6); flow wired and ready.

Closes #12