### PR TITLE
feat(T-1.6): ts-rest contracts for auth + repos

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "prebuild": "pnpm --filter @commit-analyzer/shared-types build",
+    "prebuild": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/contracts build",
     "build": "tsc",
     "start": "node --enable-source-maps dist/bootstrap.js",
-    "predev": "pnpm --filter @commit-analyzer/shared-types build",
+    "predev": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/contracts build",
     "dev": "tsx watch src/bootstrap.ts",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@commit-analyzer/contracts": "workspace:*",
     "@commit-analyzer/shared-types": "workspace:*",
     "@nestjs/common": "^11",
     "@nestjs/core": "^11",

--- a/apps/api/src/shared/contracts.ts
+++ b/apps/api/src/shared/contracts.ts
@@ -1,0 +1,2 @@
+export { authContract, contracts, reposContract } from "@commit-analyzer/contracts";
+export type { Contracts } from "@commit-analyzer/contracts";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "prebuild": "pnpm --filter @commit-analyzer/shared-types build",
+    "prebuild": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/contracts build",
     "build": "next build",
-    "predev": "pnpm --filter @commit-analyzer/shared-types build",
+    "predev": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/contracts build",
     "dev": "next dev",
     "start": "next start",
     "test": "node scripts/check-messages.mjs",
@@ -25,6 +25,7 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
+    "@commit-analyzer/contracts": "workspace:*",
     "@commit-analyzer/shared-types": "workspace:^",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.0",

--- a/apps/web/src/lib/contracts.ts
+++ b/apps/web/src/lib/contracts.ts
@@ -1,0 +1,2 @@
+export { authContract, contracts, reposContract } from "@commit-analyzer/contracts";
+export type { Contracts } from "@commit-analyzer/contracts";

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -3,17 +3,32 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "echo \"no tests yet\" && exit 0",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "clean": "rm -rf dist .turbo *.tsbuildinfo",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ts-rest/core": "^3.51.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@commit-analyzer/eslint-config": "workspace:*",
     "@commit-analyzer/typescript-config": "workspace:*",
     "eslint": "^9.14.0",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.5"
   }
 }

--- a/packages/contracts/src/auth.contract.test.ts
+++ b/packages/contracts/src/auth.contract.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  apiKeySchema,
+  authContract,
+  createApiKeyRequestSchema,
+  createApiKeyResponseSchema,
+  userSchema,
+} from "./auth.contract.js";
+
+const validUser = {
+  id: "9b2d3f5a-1c4e-4b7a-9f0d-3a2b1c4d5e6f",
+  email: "dev@example.com",
+  name: "Dev User",
+  avatarUrl: "https://example.com/a.png",
+  createdAt: "2026-04-14T10:00:00.000Z",
+};
+
+const validApiKey = {
+  id: "8b1c2d3e-4f5a-4b6c-8d7e-9f0a1b2c3d4e",
+  name: "ci-bot",
+  prefix: "ca_live_abcd",
+  lastUsedAt: null,
+  createdAt: "2026-04-14T10:00:00.000Z",
+};
+
+describe("userSchema", () => {
+  it("parses a valid user", () => {
+    expect(userSchema.parse(validUser)).toEqual(validUser);
+  });
+
+  it("rejects a bad email", () => {
+    expect(() => userSchema.parse({ ...validUser, email: "not-an-email" })).toThrow();
+  });
+});
+
+describe("apiKeySchema", () => {
+  it("parses a valid api key", () => {
+    expect(apiKeySchema.parse(validApiKey)).toEqual(validApiKey);
+  });
+
+  it("rejects when id is not a uuid", () => {
+    expect(() => apiKeySchema.parse({ ...validApiKey, id: "nope" })).toThrow();
+  });
+});
+
+describe("createApiKeyRequestSchema", () => {
+  it("accepts a reasonable name", () => {
+    expect(createApiKeyRequestSchema.parse({ name: "ci-bot" })).toEqual({ name: "ci-bot" });
+  });
+
+  it("rejects an empty name", () => {
+    expect(() => createApiKeyRequestSchema.parse({ name: "" })).toThrow();
+  });
+});
+
+describe("createApiKeyResponseSchema", () => {
+  it("parses a key create response including plaintext key", () => {
+    const parsed = createApiKeyResponseSchema.parse({
+      ...validApiKey,
+      key: "ca_live_abcd1234567890",
+    });
+    expect(parsed.key).toBe("ca_live_abcd1234567890");
+  });
+});
+
+describe("authContract", () => {
+  it("declares the four endpoints in scope", () => {
+    expect(authContract.me.method).toBe("GET");
+    expect(authContract.me.path).toBe("/me");
+    expect(authContract.apiKeys.list.method).toBe("GET");
+    expect(authContract.apiKeys.list.path).toBe("/api-keys");
+    expect(authContract.apiKeys.create.method).toBe("POST");
+    expect(authContract.apiKeys.create.path).toBe("/api-keys");
+    expect(authContract.apiKeys.revoke.method).toBe("DELETE");
+    expect(authContract.apiKeys.revoke.path).toBe("/api-keys/:id");
+  });
+
+  it("tags every auth endpoint with jwt", () => {
+    expect(authContract.me.metadata).toEqual({ auth: "jwt" });
+    expect(authContract.apiKeys.list.metadata).toEqual({ auth: "jwt" });
+    expect(authContract.apiKeys.create.metadata).toEqual({ auth: "jwt" });
+    expect(authContract.apiKeys.revoke.metadata).toEqual({ auth: "jwt" });
+  });
+});

--- a/packages/contracts/src/auth.contract.ts
+++ b/packages/contracts/src/auth.contract.ts
@@ -1,0 +1,92 @@
+import { initContract } from "@ts-rest/core";
+import { z } from "zod";
+
+import { errorEnvelopeSchema } from "./shared/error.js";
+
+const c = initContract();
+
+export const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  name: z.string().nullable(),
+  avatarUrl: z.string().url().nullable(),
+  createdAt: z.string().datetime(),
+});
+export type User = z.infer<typeof userSchema>;
+
+export const apiKeySchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  prefix: z.string(),
+  lastUsedAt: z.string().datetime().nullable(),
+  createdAt: z.string().datetime(),
+});
+export type ApiKey = z.infer<typeof apiKeySchema>;
+
+export const createApiKeyRequestSchema = z.object({
+  name: z.string().min(1).max(100),
+});
+export type CreateApiKeyRequest = z.infer<typeof createApiKeyRequestSchema>;
+
+export const createApiKeyResponseSchema = apiKeySchema.extend({
+  key: z.string(),
+});
+export type CreateApiKeyResponse = z.infer<typeof createApiKeyResponseSchema>;
+
+export const authContract = c.router(
+  {
+    me: {
+      method: "GET",
+      path: "/me",
+      responses: {
+        200: userSchema,
+        401: errorEnvelopeSchema,
+      },
+      summary: "Get the currently authenticated user",
+      metadata: { auth: "jwt" } as const,
+    },
+    apiKeys: c.router(
+      {
+        list: {
+          method: "GET",
+          path: "/api-keys",
+          responses: {
+            200: z.object({ items: z.array(apiKeySchema) }),
+            401: errorEnvelopeSchema,
+          },
+          summary: "List API keys for the current user",
+          metadata: { auth: "jwt" } as const,
+        },
+        create: {
+          method: "POST",
+          path: "/api-keys",
+          body: createApiKeyRequestSchema,
+          responses: {
+            201: createApiKeyResponseSchema,
+            400: errorEnvelopeSchema,
+            401: errorEnvelopeSchema,
+          },
+          summary: "Create a new API key (plaintext returned once)",
+          metadata: { auth: "jwt" } as const,
+        },
+        revoke: {
+          method: "DELETE",
+          path: "/api-keys/:id",
+          pathParams: z.object({ id: z.string().uuid() }),
+          body: c.noBody(),
+          responses: {
+            204: c.noBody(),
+            401: errorEnvelopeSchema,
+            404: errorEnvelopeSchema,
+          },
+          summary: "Revoke an API key",
+          metadata: { auth: "jwt" } as const,
+        },
+      },
+      { pathPrefix: "" },
+    ),
+  },
+  {
+    strictStatusCodes: true,
+  },
+);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,1 +1,34 @@
-export const name = "@commit-analyzer/contracts";
+import { initContract } from "@ts-rest/core";
+
+import { authContract } from "./auth.contract.js";
+import { reposContract } from "./repos.contract.js";
+
+const c = initContract();
+
+export const contracts = c.router({
+  auth: authContract,
+  repos: reposContract,
+});
+
+export type Contracts = typeof contracts;
+
+export { authContract } from "./auth.contract.js";
+export type {
+  ApiKey,
+  CreateApiKeyRequest,
+  CreateApiKeyResponse,
+  User,
+} from "./auth.contract.js";
+export {
+  apiKeySchema,
+  createApiKeyRequestSchema,
+  createApiKeyResponseSchema,
+  userSchema,
+} from "./auth.contract.js";
+
+export { reposContract } from "./repos.contract.js";
+export type { ConnectedRepo, GithubRepo } from "./repos.contract.js";
+export { connectedRepoSchema, githubRepoSchema } from "./repos.contract.js";
+
+export { errorEnvelopeSchema } from "./shared/error.js";
+export type { ErrorEnvelope } from "./shared/error.js";

--- a/packages/contracts/src/repos.contract.test.ts
+++ b/packages/contracts/src/repos.contract.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  connectedRepoSchema,
+  githubRepoSchema,
+  reposContract,
+} from "./repos.contract.js";
+
+const validGithubRepo = {
+  githubRepoId: 123456,
+  owner: "octocat",
+  name: "hello-world",
+  fullName: "octocat/hello-world",
+  private: false,
+  defaultBranch: "main",
+  description: "demo",
+  htmlUrl: "https://github.com/octocat/hello-world",
+  connected: false,
+};
+
+const validConnectedRepo = {
+  id: "2f5c1e3a-9d4b-4a7e-8f2c-1b3d4e5f6a7b",
+  githubRepoId: 123456,
+  owner: "octocat",
+  name: "hello-world",
+  fullName: "octocat/hello-world",
+  defaultBranch: "main",
+  lastSyncedAt: null,
+  createdAt: "2026-04-14T10:00:00.000Z",
+};
+
+describe("githubRepoSchema", () => {
+  it("parses a valid github repo", () => {
+    expect(githubRepoSchema.parse(validGithubRepo)).toEqual(validGithubRepo);
+  });
+
+  it("rejects a non-url html url", () => {
+    expect(() =>
+      githubRepoSchema.parse({ ...validGithubRepo, htmlUrl: "not a url" }),
+    ).toThrow();
+  });
+
+  it("rejects a non-positive github id", () => {
+    expect(() =>
+      githubRepoSchema.parse({ ...validGithubRepo, githubRepoId: 0 }),
+    ).toThrow();
+  });
+});
+
+describe("connectedRepoSchema", () => {
+  it("parses a valid connected repo", () => {
+    expect(connectedRepoSchema.parse(validConnectedRepo)).toEqual(validConnectedRepo);
+  });
+
+  it("rejects when createdAt is not ISO datetime", () => {
+    expect(() =>
+      connectedRepoSchema.parse({ ...validConnectedRepo, createdAt: "yesterday" }),
+    ).toThrow();
+  });
+});
+
+describe("reposContract", () => {
+  it("declares every endpoint in scope", () => {
+    expect(reposContract.listGithub.method).toBe("GET");
+    expect(reposContract.listGithub.path).toBe("/repos/github");
+    expect(reposContract.listConnected.method).toBe("GET");
+    expect(reposContract.listConnected.path).toBe("/repos");
+    expect(reposContract.connect.method).toBe("POST");
+    expect(reposContract.connect.path).toBe("/repos/:githubRepoId/connect");
+    expect(reposContract.disconnect.method).toBe("DELETE");
+    expect(reposContract.disconnect.path).toBe("/repos/:repoId");
+  });
+
+  it("tags every repo endpoint with jwt", () => {
+    expect(reposContract.listGithub.metadata).toEqual({ auth: "jwt" });
+    expect(reposContract.listConnected.metadata).toEqual({ auth: "jwt" });
+    expect(reposContract.connect.metadata).toEqual({ auth: "jwt" });
+    expect(reposContract.disconnect.metadata).toEqual({ auth: "jwt" });
+  });
+});

--- a/packages/contracts/src/repos.contract.ts
+++ b/packages/contracts/src/repos.contract.ts
@@ -1,0 +1,87 @@
+import { initContract } from "@ts-rest/core";
+import { z } from "zod";
+
+import { errorEnvelopeSchema } from "./shared/error.js";
+
+const c = initContract();
+
+export const githubRepoSchema = z.object({
+  githubRepoId: z.number().int().positive(),
+  owner: z.string(),
+  name: z.string(),
+  fullName: z.string(),
+  private: z.boolean(),
+  defaultBranch: z.string(),
+  description: z.string().nullable(),
+  htmlUrl: z.string().url(),
+  connected: z.boolean(),
+});
+export type GithubRepo = z.infer<typeof githubRepoSchema>;
+
+export const connectedRepoSchema = z.object({
+  id: z.string().uuid(),
+  githubRepoId: z.number().int().positive(),
+  owner: z.string(),
+  name: z.string(),
+  fullName: z.string(),
+  defaultBranch: z.string(),
+  lastSyncedAt: z.string().datetime().nullable(),
+  createdAt: z.string().datetime(),
+});
+export type ConnectedRepo = z.infer<typeof connectedRepoSchema>;
+
+export const reposContract = c.router(
+  {
+    listGithub: {
+      method: "GET",
+      path: "/repos/github",
+      responses: {
+        200: z.object({ items: z.array(githubRepoSchema) }),
+        401: errorEnvelopeSchema,
+        502: errorEnvelopeSchema,
+      },
+      summary: "List the authenticated user's GitHub repositories",
+      metadata: { auth: "jwt" } as const,
+    },
+    listConnected: {
+      method: "GET",
+      path: "/repos",
+      responses: {
+        200: z.object({ items: z.array(connectedRepoSchema) }),
+        401: errorEnvelopeSchema,
+      },
+      summary: "List repositories connected to the current user",
+      metadata: { auth: "jwt" } as const,
+    },
+    connect: {
+      method: "POST",
+      path: "/repos/:githubRepoId/connect",
+      pathParams: z.object({
+        githubRepoId: z.coerce.number().int().positive(),
+      }),
+      body: c.noBody(),
+      responses: {
+        201: connectedRepoSchema,
+        401: errorEnvelopeSchema,
+        404: errorEnvelopeSchema,
+        409: errorEnvelopeSchema,
+      },
+      summary: "Connect a GitHub repository to the current user",
+      metadata: { auth: "jwt" } as const,
+    },
+    disconnect: {
+      method: "DELETE",
+      path: "/repos/:repoId",
+      pathParams: z.object({ repoId: z.string().uuid() }),
+      body: c.noBody(),
+      responses: {
+        204: c.noBody(),
+        401: errorEnvelopeSchema,
+        404: errorEnvelopeSchema,
+      },
+      summary: "Disconnect a repository",
+      metadata: { auth: "jwt" } as const,
+    },
+  },
+  { strictStatusCodes: true },
+);

--- a/packages/contracts/src/shared/error.ts
+++ b/packages/contracts/src/shared/error.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const errorEnvelopeSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+    details: z.unknown().optional(),
+  }),
+});
+
+export type ErrorEnvelope = z.infer<typeof errorEnvelopeSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@commit-analyzer/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       '@commit-analyzer/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
@@ -108,6 +111,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@commit-analyzer/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       '@commit-analyzer/shared-types':
         specifier: workspace:^
         version: link:../../packages/shared-types
@@ -159,6 +165,13 @@ importers:
         version: 5.9.3
 
   packages/contracts:
+    dependencies:
+      '@ts-rest/core':
+        specifier: ^3.51.0
+        version: 3.52.1(@types/node@25.6.0)(zod@3.25.76)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@commit-analyzer/eslint-config':
         specifier: workspace:*
@@ -172,6 +185,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.5
+        version: 2.1.9(@types/node@25.6.0)
 
   packages/database:
     dependencies:
@@ -1279,6 +1295,17 @@ packages:
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@ts-rest/core@3.52.1':
+    resolution: {integrity: sha512-tAjz7Kxq/grJodcTA1Anop4AVRDlD40fkksEV5Mmal88VoZeRKAG8oMHsDwdwPZz+B/zgnz0q2sF+cm5M7Bc7g==}
+    peerDependencies:
+      '@types/node': ^18.18.7 || >=20.8.4
+      zod: ^3.22.3
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      zod:
+        optional: true
 
   '@turbo/darwin-64@2.9.6':
     resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
@@ -4181,6 +4208,11 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@ts-rest/core@3.52.1(@types/node@25.6.0)(zod@3.25.76)':
+    optionalDependencies:
+      '@types/node': 25.6.0
+      zod: 3.25.76
+
   '@turbo/darwin-64@2.9.6':
     optional: true
 
@@ -4453,6 +4485,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 5.4.21(@types/node@22.19.17)
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.6.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@25.6.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -6513,6 +6553,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.9(@types/node@25.6.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@25.6.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.21(@types/node@22.19.17):
     dependencies:
       esbuild: 0.21.5
@@ -6520,6 +6578,15 @@ snapshots:
       rollup: 4.60.1
     optionalDependencies:
       '@types/node': 22.19.17
+      fsevents: 2.3.3
+
+  vite@5.4.21(@types/node@25.6.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.9
+      rollup: 4.60.1
+    optionalDependencies:
+      '@types/node': 25.6.0
       fsevents: 2.3.3
 
   vitest@2.1.9(@types/node@22.19.17):
@@ -6546,6 +6613,41 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.9(@types/node@25.6.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.6.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@25.6.0)
+      vite-node: 2.1.9(@types/node@25.6.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
## Summary
- New `@commit-analyzer/contracts` package built on `@ts-rest/core` + Zod, with `auth.contract.ts` (`GET /me`, `GET/POST /api-keys`, `DELETE /api-keys/:id`) and `repos.contract.ts` (`GET /repos/github`, `GET /repos`, `POST /repos/:githubRepoId/connect`, `DELETE /repos/:repoId`).
- Shared `errorEnvelopeSchema` for non-2xx responses; every endpoint tagged `metadata.auth: "jwt"` per `docs/05-api-contracts.md` §2.
- Barrel `index.ts` exports a top-level `contracts` router (`auth`, `repos`) plus per-contract schemas and inferred DTO types.
- Unit tests (vitest, 16 cases) parse valid fixtures and reject bad ones for every DTO, and assert each endpoint's method/path/auth metadata.
- `apps/api` and `apps/web` gain the workspace dependency, a prebuild of `@commit-analyzer/contracts`, and a tiny re-export module proving the package type-checks from both sides.

## Test plan
- [x] `pnpm --filter @commit-analyzer/contracts build`
- [x] `pnpm --filter @commit-analyzer/contracts test` (16/16 passing)
- [x] `pnpm -r typecheck` (api + web consume `@commit-analyzer/contracts` cleanly)
- [x] `pnpm -r lint`
- [x] `pnpm -r test`

Closes #17