### PR TITLE
fix(T-1.4): dockerfile copy contracts+database build

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -17,8 +17,12 @@ RUN pnpm install --frozen-lockfile
 FROM deps AS build
 COPY packages/typescript-config packages/typescript-config
 COPY packages/shared-types packages/shared-types
+COPY packages/contracts packages/contracts
+COPY packages/database packages/database
 COPY apps/api apps/api
 RUN pnpm --filter @commit-analyzer/shared-types build \
+ && pnpm --filter @commit-analyzer/contracts build \
+ && pnpm --filter @commit-analyzer/database build \
  && pnpm --filter @commit-analyzer/api build
 
 FROM base AS runner
@@ -36,6 +40,8 @@ COPY --chown=app:app packages/typescript-config/package.json packages/typescript
 RUN pnpm install --frozen-lockfile --prod --filter "@commit-analyzer/api..." \
  && pnpm store prune
 COPY --from=build --chown=app:app /app/packages/shared-types/dist packages/shared-types/dist
+COPY --from=build --chown=app:app /app/packages/contracts/dist packages/contracts/dist
+COPY --from=build --chown=app:app /app/packages/database/dist packages/database/dist
 COPY --from=build --chown=app:app /app/apps/api/dist apps/api/dist
 USER app
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- Deploy API workflow was failing since #110 (T-1.6 added `@commit-analyzer/contracts`) and kept failing on #111 (T-1.4 added `@commit-analyzer/database`). The Dockerfile's `build` stage only copied `shared-types`, so tsc couldn't resolve the new workspace deps; the `runner` stage also didn't copy their `dist/` folders.
- `build` stage now copies + builds `packages/contracts` and `packages/database` alongside `shared-types`.
- `runner` stage now copies `packages/{contracts,database}/dist` into the final image.

## Test plan
- [x] `docker build -f apps/api/Dockerfile -t commit-analyzer-api:smoke .` succeeds locally
- [x] Container boots against real postgres — `/health` → 200
- [x] CI Lint/Typecheck/Unit tests green