### PR TITLE
feat(T-0.11): railway predeploy runs db migrations

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "migration:run": "pnpm build && typeorm migration:run -d dist/cli-data-source.js",
+    "migration:run:prod": "typeorm migration:run -d dist/cli-data-source.js",
     "migration:revert": "pnpm build && typeorm migration:revert -d dist/cli-data-source.js",
     "migration:show": "pnpm build && typeorm migration:show -d dist/cli-data-source.js",
     "migration:generate": "pnpm build && typeorm migration:generate -d dist/cli-data-source.js"

--- a/railway.json
+++ b/railway.json
@@ -6,6 +6,7 @@
   },
   "deploy": {
     "startCommand": "node --enable-source-maps apps/api/dist/bootstrap.js",
+    "preDeployCommand": "pnpm --filter @commit-analyzer/database migration:run:prod",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 100,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
## Summary
- Railway's `deploy.preDeployCommand` now runs TypeORM migrations before the new container takes traffic. If it fails the deploy aborts and the old container keeps serving.
- New `migration:run:prod` script in the database package skips the `pnpm build` step since `packages/database/dist` is already baked into the runner image by the Dockerfile.
- Idempotent: re-runs on every deploy are cheap (`No migrations are pending` on a no-op).

## Why preDeployCommand, not a GH Actions step
Running migrations from GH Actions *before* `railway up` risks schema-ahead-of-code if Railway deploy then fails. preDeployCommand is tied to the deploy lifecycle: schema advances only if the new container is about to ship.

## Test plan
- [x] `docker build -f apps/api/Dockerfile -t ca-api:migrate-smoke .` succeeds
- [x] Inside the built image, `pnpm --filter @commit-analyzer/database migration:run:prod` connects to local postgres, reads `typeorm_migrations`, exits 0 with "No migrations are pending"
- [x] CI Lint/Typecheck/Unit tests green

## Prod DB status (pre-merge)
Prod `public` schema is empty — migrations never ran. First deploy after this lands will apply both `1713000000000-initial` and `1713000001000-api-key-revoked-at`.