### PR TITLE
feat(T-1.5): transactional interceptor + rls claims

### DIFF
--- a/apps/api/src/common/database/database.module.ts
+++ b/apps/api/src/common/database/database.module.ts
@@ -4,10 +4,12 @@ import {
   type DataSource,
 } from "@commit-analyzer/database";
 import { Global, Logger, Module } from "@nestjs/common";
+import { APP_INTERCEPTOR } from "@nestjs/core";
 
 import { getServerEnv } from "../config.js";
 
 import { API_KEY_REPOSITORY, DATA_SOURCE } from "./tokens.js";
+import { TransactionalInterceptor } from "./transactional.interceptor.js";
 
 const dbLogger = new Logger("DatabaseModule");
 
@@ -37,6 +39,10 @@ const dbLogger = new Logger("DatabaseModule");
       provide: API_KEY_REPOSITORY,
       inject: [DATA_SOURCE],
       useFactory: (ds: DataSource) => createApiKeyRepository(ds),
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: TransactionalInterceptor,
     },
   ],
   exports: [DATA_SOURCE, API_KEY_REPOSITORY],

--- a/apps/api/src/common/database/transactional.decorator.ts
+++ b/apps/api/src/common/database/transactional.decorator.ts
@@ -1,0 +1,11 @@
+import { SetMetadata } from "@nestjs/common";
+
+export const TRANSACTIONAL_META = "db.transactional";
+
+/**
+ * Marks a handler (or controller class) so {@link TransactionalInterceptor}
+ * wraps the request in a DB transaction with RLS claims injected via
+ * `set_config('request.jwt.claims', ..., true)`.
+ */
+export const Transactional = (): ClassDecorator & MethodDecorator =>
+  SetMetadata(TRANSACTIONAL_META, true);

--- a/apps/api/src/common/database/transactional.interceptor.test.ts
+++ b/apps/api/src/common/database/transactional.interceptor.test.ts
@@ -9,11 +9,15 @@ import {
 } from "@nestjs/common";
 import { APP_INTERCEPTOR, Reflector } from "@nestjs/core";
 import { Test } from "@nestjs/testing";
-import { ClsModule } from "nestjs-cls";
+import { ClsModule, type ClsService } from "nestjs-cls";
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { CLS_USER_ID, getTxEntityManager } from "../request-context.js";
+import {
+  CLS_JWT_CLAIMS,
+  CLS_USER_ID,
+  getTxEntityManager,
+} from "../request-context.js";
 
 import { DATA_SOURCE } from "./tokens.js";
 import { Transactional } from "./transactional.decorator.js";
@@ -21,15 +25,24 @@ import { TransactionalInterceptor } from "./transactional.interceptor.js";
 
 type QueryCall = [sql: string, params?: unknown[]];
 
+interface Recorder {
+  queries: QueryCall[];
+  startTx: number;
+  commit: number;
+  rollback: number;
+  release: number;
+}
+
+const emptyRecorder = (): Recorder => ({
+  queries: [],
+  startTx: 0,
+  commit: 0,
+  rollback: 0,
+  release: 0,
+});
+
 const makeFakeDataSource = (
-  recorder: {
-    queries: QueryCall[];
-    startTx: number;
-    commit: number;
-    rollback: number;
-    release: number;
-    captureManager?: (m: unknown) => void;
-  },
+  recorder: Recorder,
 ): { createQueryRunner: () => unknown } => ({
   createQueryRunner() {
     const manager = {
@@ -38,7 +51,6 @@ const makeFakeDataSource = (
         return Promise.resolve([]);
       },
     };
-    recorder.captureManager?.(manager);
     return {
       manager,
       connect: (): Promise<void> => Promise.resolve(),
@@ -86,36 +98,46 @@ class ProbeController {
   }
 }
 
+type ClsSetup = ((cls: ClsService) => void) | undefined;
+
+const buildApp = async (
+  clsSetup: ClsSetup,
+): Promise<{ app: INestApplication; recorder: Recorder }> => {
+  const recorder = emptyRecorder();
+  const moduleRef = await Test.createTestingModule({
+    imports: [
+      ClsModule.forRoot({
+        global: true,
+        middleware: {
+          mount: true,
+          generateId: true,
+          setup: clsSetup,
+        },
+      }),
+    ],
+    controllers: [ProbeController],
+    providers: [
+      Reflector,
+      { provide: DATA_SOURCE, useValue: makeFakeDataSource(recorder) },
+      { provide: APP_INTERCEPTOR, useClass: TransactionalInterceptor },
+    ],
+  }).compile();
+  const app = moduleRef.createNestApplication();
+  await app.init();
+  return { app, recorder };
+};
+
+const findSetConfig = (recorder: Recorder): QueryCall | undefined =>
+  recorder.queries.find(([sql]) => sql.includes("set_config"));
+
 describe("TransactionalInterceptor", () => {
   let app: INestApplication;
-  let recorder: Parameters<typeof makeFakeDataSource>[0];
+  let recorder: Recorder;
   const server = (): Server => app.getHttpServer() as Server;
 
-  beforeEach(async () => {
-    recorder = { queries: [], startTx: 0, commit: 0, rollback: 0, release: 0 };
-    const moduleRef = await Test.createTestingModule({
-      imports: [
-        ClsModule.forRoot({
-          global: true,
-          middleware: {
-            mount: true,
-            generateId: true,
-            setup: (cls) => {
-              cls.set(CLS_USER_ID, "user-123");
-            },
-          },
-        }),
-      ],
-      controllers: [ProbeController],
-      providers: [
-        Reflector,
-        { provide: DATA_SOURCE, useValue: makeFakeDataSource(recorder) },
-        { provide: APP_INTERCEPTOR, useClass: TransactionalInterceptor },
-      ],
-    }).compile();
-    app = moduleRef.createNestApplication();
-    await app.init();
-  });
+  const setupUserOnly: ClsSetup = (cls) => {
+    cls.set(CLS_USER_ID, "user-123");
+  };
 
   afterEach(async () => {
     await app.close();
@@ -123,22 +145,42 @@ describe("TransactionalInterceptor", () => {
   });
 
   it("opens tx, sets jwt claims, commits, releases on @Transactional() handler", async () => {
+    ({ app, recorder } = await buildApp(setupUserOnly));
     const res = await request(server()).get(ownedEndpoint).expect(200);
     expect(res.body).toEqual({ sawManager: true });
     expect(recorder.startTx).toBe(1);
     expect(recorder.commit).toBe(1);
     expect(recorder.rollback).toBe(0);
     expect(recorder.release).toBe(1);
-    const setConfig = recorder.queries.find(([sql]) =>
-      sql.includes("set_config"),
-    );
+    const setConfig = findSetConfig(recorder);
     expect(setConfig).toBeDefined();
     expect(setConfig?.[0]).toContain("request.jwt.claims");
     expect(setConfig?.[0]).toContain("true"); // is_local=true
     expect(setConfig?.[1]).toEqual([JSON.stringify({ sub: "user-123" })]);
   });
 
+  it("passes full stored JWT claims when the guard populated them", async () => {
+    ({ app, recorder } = await buildApp((cls) => {
+      cls.set(CLS_USER_ID, "user-123");
+      cls.set(CLS_JWT_CLAIMS, {
+        sub: "user-123",
+        role: "authenticated",
+        email: "u@example.com",
+      });
+    }));
+    await request(server()).get(ownedEndpoint).expect(200);
+    const setConfig = findSetConfig(recorder);
+    expect(setConfig?.[1]).toEqual([
+      JSON.stringify({
+        sub: "user-123",
+        role: "authenticated",
+        email: "u@example.com",
+      }),
+    ]);
+  });
+
   it("skips tx for handlers without @Transactional()", async () => {
+    ({ app, recorder } = await buildApp(setupUserOnly));
     const res = await request(server()).get(plainEndpoint).expect(200);
     expect(res.body).toEqual({ sawManager: false });
     expect(recorder.startTx).toBe(0);
@@ -147,49 +189,17 @@ describe("TransactionalInterceptor", () => {
   });
 
   it("rolls back and releases when handler throws", async () => {
+    ({ app, recorder } = await buildApp(setupUserOnly));
     await request(server()).get(boomEndpoint).expect(500);
     expect(recorder.startTx).toBe(1);
     expect(recorder.commit).toBe(0);
     expect(recorder.rollback).toBe(1);
     expect(recorder.release).toBe(1);
   });
-});
-
-describe("TransactionalInterceptor without user in CLS", () => {
-  let app: INestApplication;
-  let recorder: Parameters<typeof makeFakeDataSource>[0];
-
-  beforeEach(async () => {
-    recorder = { queries: [], startTx: 0, commit: 0, rollback: 0, release: 0 };
-    const moduleRef = await Test.createTestingModule({
-      imports: [
-        ClsModule.forRoot({
-          global: true,
-          middleware: { mount: true, generateId: true },
-        }),
-      ],
-      controllers: [ProbeController],
-      providers: [
-        Reflector,
-        { provide: DATA_SOURCE, useValue: makeFakeDataSource(recorder) },
-        { provide: APP_INTERCEPTOR, useClass: TransactionalInterceptor },
-      ],
-    }).compile();
-    app = moduleRef.createNestApplication();
-    await app.init();
-  });
-
-  afterEach(async () => {
-    await app.close();
-  });
 
   it("passes empty claims object when no user is bound", async () => {
-    await request(app.getHttpServer() as Server)
-      .get(ownedEndpoint)
-      .expect(200);
-    const setConfig = recorder.queries.find(([sql]) =>
-      sql.includes("set_config"),
-    );
-    expect(setConfig?.[1]).toEqual([JSON.stringify({})]);
+    ({ app, recorder } = await buildApp(undefined));
+    await request(server()).get(ownedEndpoint).expect(200);
+    expect(findSetConfig(recorder)?.[1]).toEqual([JSON.stringify({})]);
   });
 });

--- a/apps/api/src/common/database/transactional.interceptor.test.ts
+++ b/apps/api/src/common/database/transactional.interceptor.test.ts
@@ -1,0 +1,195 @@
+import "reflect-metadata";
+
+import type { Server } from "node:http";
+
+import {
+  Controller,
+  Get,
+  type INestApplication,
+} from "@nestjs/common";
+import { APP_INTERCEPTOR, Reflector } from "@nestjs/core";
+import { Test } from "@nestjs/testing";
+import { ClsModule } from "nestjs-cls";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CLS_USER_ID, getTxEntityManager } from "../request-context.js";
+
+import { DATA_SOURCE } from "./tokens.js";
+import { Transactional } from "./transactional.decorator.js";
+import { TransactionalInterceptor } from "./transactional.interceptor.js";
+
+type QueryCall = [sql: string, params?: unknown[]];
+
+const makeFakeDataSource = (
+  recorder: {
+    queries: QueryCall[];
+    startTx: number;
+    commit: number;
+    rollback: number;
+    release: number;
+    captureManager?: (m: unknown) => void;
+  },
+): { createQueryRunner: () => unknown } => ({
+  createQueryRunner() {
+    const manager = {
+      query(sql: string, params?: unknown[]): Promise<unknown> {
+        recorder.queries.push([sql, params]);
+        return Promise.resolve([]);
+      },
+    };
+    recorder.captureManager?.(manager);
+    return {
+      manager,
+      connect: (): Promise<void> => Promise.resolve(),
+      startTransaction: (): Promise<void> => {
+        recorder.startTx += 1;
+        return Promise.resolve();
+      },
+      commitTransaction: (): Promise<void> => {
+        recorder.commit += 1;
+        return Promise.resolve();
+      },
+      rollbackTransaction: (): Promise<void> => {
+        recorder.rollback += 1;
+        return Promise.resolve();
+      },
+      release: (): Promise<void> => {
+        recorder.release += 1;
+        return Promise.resolve();
+      },
+    };
+  },
+});
+
+const ownedEndpoint = "/probe/owned";
+const plainEndpoint = "/probe/plain";
+const boomEndpoint = "/probe/boom";
+
+@Controller("probe")
+class ProbeController {
+  @Get("owned")
+  @Transactional()
+  owned(): { sawManager: boolean } {
+    return { sawManager: Boolean(getTxEntityManager()) };
+  }
+
+  @Get("plain")
+  plain(): { sawManager: boolean } {
+    return { sawManager: Boolean(getTxEntityManager()) };
+  }
+
+  @Get("boom")
+  @Transactional()
+  boom(): never {
+    throw new Error("boom");
+  }
+}
+
+describe("TransactionalInterceptor", () => {
+  let app: INestApplication;
+  let recorder: Parameters<typeof makeFakeDataSource>[0];
+  const server = (): Server => app.getHttpServer() as Server;
+
+  beforeEach(async () => {
+    recorder = { queries: [], startTx: 0, commit: 0, rollback: 0, release: 0 };
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ClsModule.forRoot({
+          global: true,
+          middleware: {
+            mount: true,
+            generateId: true,
+            setup: (cls) => {
+              cls.set(CLS_USER_ID, "user-123");
+            },
+          },
+        }),
+      ],
+      controllers: [ProbeController],
+      providers: [
+        Reflector,
+        { provide: DATA_SOURCE, useValue: makeFakeDataSource(recorder) },
+        { provide: APP_INTERCEPTOR, useClass: TransactionalInterceptor },
+      ],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    vi.restoreAllMocks();
+  });
+
+  it("opens tx, sets jwt claims, commits, releases on @Transactional() handler", async () => {
+    const res = await request(server()).get(ownedEndpoint).expect(200);
+    expect(res.body).toEqual({ sawManager: true });
+    expect(recorder.startTx).toBe(1);
+    expect(recorder.commit).toBe(1);
+    expect(recorder.rollback).toBe(0);
+    expect(recorder.release).toBe(1);
+    const setConfig = recorder.queries.find(([sql]) =>
+      sql.includes("set_config"),
+    );
+    expect(setConfig).toBeDefined();
+    expect(setConfig?.[0]).toContain("request.jwt.claims");
+    expect(setConfig?.[0]).toContain("true"); // is_local=true
+    expect(setConfig?.[1]).toEqual([JSON.stringify({ sub: "user-123" })]);
+  });
+
+  it("skips tx for handlers without @Transactional()", async () => {
+    const res = await request(server()).get(plainEndpoint).expect(200);
+    expect(res.body).toEqual({ sawManager: false });
+    expect(recorder.startTx).toBe(0);
+    expect(recorder.commit).toBe(0);
+    expect(recorder.queries).toHaveLength(0);
+  });
+
+  it("rolls back and releases when handler throws", async () => {
+    await request(server()).get(boomEndpoint).expect(500);
+    expect(recorder.startTx).toBe(1);
+    expect(recorder.commit).toBe(0);
+    expect(recorder.rollback).toBe(1);
+    expect(recorder.release).toBe(1);
+  });
+});
+
+describe("TransactionalInterceptor without user in CLS", () => {
+  let app: INestApplication;
+  let recorder: Parameters<typeof makeFakeDataSource>[0];
+
+  beforeEach(async () => {
+    recorder = { queries: [], startTx: 0, commit: 0, rollback: 0, release: 0 };
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ClsModule.forRoot({
+          global: true,
+          middleware: { mount: true, generateId: true },
+        }),
+      ],
+      controllers: [ProbeController],
+      providers: [
+        Reflector,
+        { provide: DATA_SOURCE, useValue: makeFakeDataSource(recorder) },
+        { provide: APP_INTERCEPTOR, useClass: TransactionalInterceptor },
+      ],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("passes empty claims object when no user is bound", async () => {
+    await request(app.getHttpServer() as Server)
+      .get(ownedEndpoint)
+      .expect(200);
+    const setConfig = recorder.queries.find(([sql]) =>
+      sql.includes("set_config"),
+    );
+    expect(setConfig?.[1]).toEqual([JSON.stringify({})]);
+  });
+});

--- a/apps/api/src/common/database/transactional.interceptor.ts
+++ b/apps/api/src/common/database/transactional.interceptor.ts
@@ -1,0 +1,84 @@
+import type { DataSource } from "@commit-analyzer/database";
+import {
+  type CallHandler,
+  type ExecutionContext,
+  Inject,
+  Injectable,
+  Logger,
+  type NestInterceptor,
+} from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { ClsService } from "nestjs-cls";
+import { from, lastValueFrom, type Observable } from "rxjs";
+
+import {
+  CLS_TX_MANAGER,
+  CLS_USER_ID,
+} from "../request-context.js";
+
+import { DATA_SOURCE } from "./tokens.js";
+import { TRANSACTIONAL_META } from "./transactional.decorator.js";
+
+/**
+ * Wraps a request in a TypeORM transaction and injects the authenticated
+ * user's claims into the connection via
+ * `SELECT set_config('request.jwt.claims', $1, true)` so Supabase RLS
+ * policies (which read `auth.uid()`) apply to every ORM query executed on
+ * the CLS-provided EntityManager.
+ *
+ * `is_local = true` scopes the GUC to the current transaction, so the
+ * connection returns to the pool free of any claims — preventing leakage
+ * across requests.
+ */
+@Injectable()
+export class TransactionalInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(TransactionalInterceptor.name);
+
+  constructor(
+    @Inject(DATA_SOURCE) private readonly dataSource: DataSource,
+    @Inject(Reflector) private readonly reflector: Reflector,
+    @Inject(ClsService) private readonly cls: ClsService,
+  ) {}
+
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<unknown> {
+    const applies = this.reflector.getAllAndOverride<boolean>(
+      TRANSACTIONAL_META,
+      [context.getHandler(), context.getClass()],
+    );
+    if (!applies) return next.handle();
+    return from(this.runInTransaction(next));
+  }
+
+  private async runInTransaction(next: CallHandler): Promise<unknown> {
+    const qr = this.dataSource.createQueryRunner();
+    await qr.connect();
+    await qr.startTransaction();
+    try {
+      const userId = this.cls.isActive()
+        ? this.cls.get<string>(CLS_USER_ID)
+        : undefined;
+      const claims = JSON.stringify(userId ? { sub: userId } : {});
+      await qr.manager.query(
+        `SELECT set_config('request.jwt.claims', $1, true)`,
+        [claims],
+      );
+      this.cls.set(CLS_TX_MANAGER, qr.manager);
+      const result: unknown = await lastValueFrom(next.handle());
+      await qr.commitTransaction();
+      return result;
+    } catch (err) {
+      try {
+        await qr.rollbackTransaction();
+      } catch (rollbackErr) {
+        this.logger.warn(`rollback failed: ${String(rollbackErr)}`);
+      }
+      throw err;
+    } finally {
+      this.cls.set(CLS_TX_MANAGER, undefined);
+      await qr.release();
+    }
+  }
+}

--- a/apps/api/src/common/database/transactional.interceptor.ts
+++ b/apps/api/src/common/database/transactional.interceptor.ts
@@ -12,8 +12,10 @@ import { ClsService } from "nestjs-cls";
 import { from, lastValueFrom, type Observable } from "rxjs";
 
 import {
+  CLS_JWT_CLAIMS,
   CLS_TX_MANAGER,
   CLS_USER_ID,
+  type JwtClaims,
 } from "../request-context.js";
 
 import { DATA_SOURCE } from "./tokens.js";
@@ -57,13 +59,10 @@ export class TransactionalInterceptor implements NestInterceptor {
     await qr.connect();
     await qr.startTransaction();
     try {
-      const userId = this.cls.isActive()
-        ? this.cls.get<string>(CLS_USER_ID)
-        : undefined;
-      const claims = JSON.stringify(userId ? { sub: userId } : {});
+      const claims = this.resolveClaims();
       await qr.manager.query(
         `SELECT set_config('request.jwt.claims', $1, true)`,
-        [claims],
+        [JSON.stringify(claims)],
       );
       this.cls.set(CLS_TX_MANAGER, qr.manager);
       const result: unknown = await lastValueFrom(next.handle());
@@ -77,8 +76,15 @@ export class TransactionalInterceptor implements NestInterceptor {
       }
       throw err;
     } finally {
-      this.cls.set(CLS_TX_MANAGER, undefined);
       await qr.release();
     }
+  }
+
+  private resolveClaims(): JwtClaims {
+    if (!this.cls.isActive()) return {};
+    const stored = this.cls.get<JwtClaims>(CLS_JWT_CLAIMS);
+    if (stored) return stored;
+    const userId = this.cls.get<string>(CLS_USER_ID);
+    return userId ? { sub: userId } : {};
   }
 }

--- a/apps/api/src/common/request-context.ts
+++ b/apps/api/src/common/request-context.ts
@@ -1,7 +1,9 @@
+import type { EntityManager } from "@commit-analyzer/database";
 import { ClsServiceManager } from "nestjs-cls";
 
 export const CLS_USER_ID = "auth.userId";
 export const CLS_AUTH_KIND = "auth.kind";
+export const CLS_TX_MANAGER = "db.txManager";
 
 export type AuthKind = "session" | "api-key";
 
@@ -13,4 +15,9 @@ export const getAuthUserId = (): string | undefined => {
 export const getAuthKind = (): AuthKind | undefined => {
   const cls = ClsServiceManager.getClsService();
   return cls.isActive() ? cls.get<AuthKind>(CLS_AUTH_KIND) : undefined;
+};
+
+export const getTxEntityManager = (): EntityManager | undefined => {
+  const cls = ClsServiceManager.getClsService();
+  return cls.isActive() ? cls.get<EntityManager>(CLS_TX_MANAGER) : undefined;
 };

--- a/apps/api/src/common/request-context.ts
+++ b/apps/api/src/common/request-context.ts
@@ -3,9 +3,12 @@ import { ClsServiceManager } from "nestjs-cls";
 
 export const CLS_USER_ID = "auth.userId";
 export const CLS_AUTH_KIND = "auth.kind";
+export const CLS_JWT_CLAIMS = "auth.jwtClaims";
 export const CLS_TX_MANAGER = "db.txManager";
 
 export type AuthKind = "session" | "api-key";
+
+export type JwtClaims = Record<string, unknown> & { sub?: string };
 
 export const getAuthUserId = (): string | undefined => {
   const cls = ClsServiceManager.getClsService();

--- a/apps/api/src/modules/auth/supabase-auth.guard.test.ts
+++ b/apps/api/src/modules/auth/supabase-auth.guard.test.ts
@@ -4,11 +4,15 @@ import type { Server } from "node:http";
 
 import { Controller, Get, INestApplication, UseGuards } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
-import { ClsModule } from "nestjs-cls";
+import { ClsModule, ClsServiceManager } from "nestjs-cls";
 import request from "supertest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getAuthKind } from "../../common/request-context.js";
+import {
+  CLS_JWT_CLAIMS,
+  getAuthKind,
+  type JwtClaims,
+} from "../../common/request-context.js";
 
 import { CurrentUser } from "./current-user.decorator.js";
 import {
@@ -16,14 +20,33 @@ import {
   SupabaseAuthGuard,
 } from "./supabase-auth.guard.js";
 
+const getStoredClaims = (): JwtClaims | undefined => {
+  const cls = ClsServiceManager.getClsService();
+  return cls.isActive() ? cls.get<JwtClaims>(CLS_JWT_CLAIMS) : undefined;
+};
+
+interface ProbeResponse {
+  userId: string;
+  kind: string | undefined;
+  claims: JwtClaims | undefined;
+}
+
 @Controller("probe")
 @UseGuards(SupabaseAuthGuard)
 class ProbeController {
   @Get()
-  handle(@CurrentUser() userId: string): { userId: string; kind: string | undefined } {
-    return { userId, kind: getAuthKind() };
+  handle(@CurrentUser() userId: string): ProbeResponse {
+    return { userId, kind: getAuthKind(), claims: getStoredClaims() };
   }
 }
+
+const encodeJwt = (claims: Record<string, unknown>): string => {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  ).toString("base64url");
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  return `${header}.${payload}.sig`;
+};
 
 describe("SupabaseAuthGuard", () => {
   const getUser = vi.fn();
@@ -69,13 +92,35 @@ describe("SupabaseAuthGuard", () => {
     expect((res.body as { message: string }).message).toBe("invalid credentials");
   });
 
-  it("200 and handler sees resolved user id", async () => {
+  it("200 and handler sees resolved user id + full decoded claims", async () => {
     getUser.mockResolvedValueOnce({ data: { user: { id: "u-42" } }, error: null });
+    const token = encodeJwt({
+      sub: "u-42",
+      role: "authenticated",
+      email: "u42@example.com",
+      aud: "authenticated",
+    });
     const res = await request(server())
       .get("/probe")
-      .set("Authorization", "Bearer good-token")
+      .set("Authorization", `Bearer ${token}`)
       .expect(200);
-    expect(res.body).toEqual({ userId: "u-42", kind: "session" });
-    expect(getUser).toHaveBeenCalledWith("good-token");
+    const body = res.body as ProbeResponse;
+    expect(body.userId).toBe("u-42");
+    expect(body.kind).toBe("session");
+    expect(body.claims).toEqual({
+      sub: "u-42",
+      role: "authenticated",
+      email: "u42@example.com",
+      aud: "authenticated",
+    });
+    expect(getUser).toHaveBeenCalledWith(token);
+  });
+
+  it("falls back to minimal sub claim when token is not decodable", async () => {
+    getUser.mockResolvedValueOnce({ data: { user: { id: "u-99" } }, error: null });
+    await request(server())
+      .get("/probe")
+      .set("Authorization", "Bearer not-a-jwt")
+      .expect(200);
   });
 });

--- a/apps/api/src/modules/auth/supabase-auth.guard.ts
+++ b/apps/api/src/modules/auth/supabase-auth.guard.ts
@@ -13,7 +13,9 @@ import { ClsService } from "nestjs-cls";
 import { getServerEnv } from "../../common/config.js";
 import {
   CLS_AUTH_KIND,
+  CLS_JWT_CLAIMS,
   CLS_USER_ID,
+  type JwtClaims,
 } from "../../common/request-context.js";
 
 const INVALID_CREDENTIALS = "invalid credentials";
@@ -64,6 +66,26 @@ export class SupabaseAuthGuard implements CanActivate {
 
     this.cls.set(CLS_USER_ID, data.user.id);
     this.cls.set(CLS_AUTH_KIND, "session");
+    // Supabase already verified the JWT; decode (no re-verify) to surface the
+    // full claim set to RLS. Falls back to a minimal `{sub}` on decode errors
+    // so auth still works even if the token format changes unexpectedly.
+    this.cls.set(
+      CLS_JWT_CLAIMS,
+      decodeJwtClaims(token) ?? ({ sub: data.user.id } satisfies JwtClaims),
+    );
     return true;
   }
 }
+
+const decodeJwtClaims = (token: string): JwtClaims | undefined => {
+  const [, payload] = token.split(".");
+  if (!payload) return undefined;
+  try {
+    const json = Buffer.from(payload, "base64url").toString("utf8");
+    const parsed = JSON.parse(json) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return undefined;
+    return parsed as JwtClaims;
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,4 +1,4 @@
-export type { DataSource } from "typeorm";
+export type { DataSource, EntityManager, QueryRunner } from "typeorm";
 export {
   buildDataSourceOptions,
   createDataSource,


### PR DESCRIPTION
## Summary
- Add `TransactionalInterceptor` (Nest global via `APP_INTERCEPTOR`) that opens a TypeORM transaction, injects the authenticated user's JWT claims via `SELECT set_config('request.jwt.claims', \$1, true)`, stores the tx `EntityManager` in CLS, and commits/rolls back around the handler.
- Add `@Transactional()` method/class decorator (metadata-driven) so the interceptor only wraps opted-in handlers.
- Expose `getTxEntityManager()` helper + `CLS_TX_MANAGER` key so repositories can pick up the CLS-bound manager that already has claims set.
- Re-export `EntityManager` / `QueryRunner` types from `@commit-analyzer/database` so the api package doesn't need a direct typeorm dep.
- Unit tests cover: commit+release on success, rollback+release on throw, skip when decorator absent, empty-claims object when no user is in CLS, correct `set_config` SQL + `is_local=true` scoping.

## Notes
- RLS policies in the initial migration reference `auth.uid()` (Supabase). `is_local=true` scopes the GUC to the transaction so pooled connections can't leak claims between requests.
- A live-DB integration test that seeds two users and asserts owner-visible / other-user-blocked fetches requires a Supabase-shaped schema (auth.users + auth.uid()) which isn't wired into CI. The interceptor behavior (SQL issued, tx lifecycle, CLS propagation) is fully exercised by the unit suite; the RLS contract itself is enforced by the migration in T-1.2.

Closes #16