### PR TITLE
fix(T-1.7): mark cryptoservice key param optional

### DIFF
--- a/apps/api/src/shared/crypto.service.ts
+++ b/apps/api/src/shared/crypto.service.ts
@@ -1,6 +1,6 @@
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 
-import { Injectable } from "@nestjs/common";
+import { Injectable, Optional } from "@nestjs/common";
 
 import { getServerEnv } from "../common/config.js";
 
@@ -26,7 +26,11 @@ export class DecryptionError extends Error {
 export class CryptoService {
   private readonly key: Buffer;
 
-  constructor(key?: Buffer) {
+  // `@Optional()` tells Nest to skip DI for this parameter — otherwise the
+  // `emitDecoratorMetadata` type hint leaks `Buffer` as an injection token and
+  // bootstrap dies with `UnknownDependenciesException`. Tests still pass a key
+  // directly via `new CryptoService(buf)`.
+  constructor(@Optional() key?: Buffer) {
     const resolved = key ?? Buffer.from(getServerEnv().ENCRYPTION_KEY_BASE64, "base64");
     if (resolved.length !== KEY_LENGTH) {
       throw new Error(`encryption key must be ${KEY_LENGTH} bytes`);


### PR DESCRIPTION
## Summary
Hotfix for the Railway deploy failure from #119. `CryptoService` is now registered as a Nest provider (T-1.7), so Nest inspects its constructor metadata and tries to inject the optional `key: Buffer` parameter — no `Buffer` provider exists, so bootstrap dies with `UnknownDependenciesException` before the logger is wired.

`main.ts` uses `logger: false`, so the error was completely silent on Railway (healthcheck just timed out on `/health`). Reproduced locally by running `dist/bootstrap.js` against the prod env with the default Nest logger enabled — confirmed the same exception.

Fix: `@Optional()` on the `key` parameter. Tests still pass a key directly (`new CryptoService(buf)`), runtime path still falls through to `getServerEnv().ENCRYPTION_KEY_BASE64`.

## Test plan
- [x] `pnpm --filter @commit-analyzer/api build` — clean
- [x] `pnpm --filter @commit-analyzer/api test` — 79 passed
- [x] `pnpm --filter @commit-analyzer/api lint` — clean
- [x] Local `NestFactory.create(AppModule)` against prod env — `CREATED OK` (no exception)
- [ ] Railway Deploy API succeeds on merge
- [ ] `/health` returns 200 post-deploy