### PR TITLE
fix(T-1.10): dont crash page on missing client env

### DIFF
--- a/apps/web/src/lib/api/tsr.ts
+++ b/apps/web/src/lib/api/tsr.ts
@@ -10,9 +10,17 @@ import {
   createSupabaseBrowserClient,
   type AppSupabaseClient,
 } from "@/lib/supabase/browser";
-import { getClientEnv } from "@/lib/supabase/env";
 
-const getBaseUrl = (): string => getClientEnv().NEXT_PUBLIC_API_URL;
+/**
+ * Read NEXT_PUBLIC_API_URL directly from process.env instead of going through
+ * the zod-validated `getClientEnv()` loader. The loader throws synchronously
+ * on any missing NEXT_PUBLIC_* var, which would crash the React tree on every
+ * page render (this module is imported by the root QueryProvider). Here we
+ * tolerate an unset value at module eval — requests will simply fail at call
+ * time, which is recoverable, and the auth pages can still render so the user
+ * can sign in and report the misconfiguration.
+ */
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 let browserSupabase: AppSupabaseClient | null = null;
 const getBrowserSupabase = (): AppSupabaseClient => {
@@ -44,7 +52,7 @@ const browserApi: ApiFetcher = async (args) => {
  * `browserApi` so each call picks up the freshest Supabase access token.
  */
 export const tsr = initTsrReactQuery(contracts, {
-  baseUrl: getBaseUrl(),
+  baseUrl: API_BASE_URL,
   baseHeaders: {},
   api: browserApi,
 });
@@ -56,6 +64,6 @@ export const tsr = initTsrReactQuery(contracts, {
  */
 export const createServerTsRestClient = (accessToken: string | null) =>
   initClient(contracts, {
-    baseUrl: getBaseUrl(),
+    baseUrl: API_BASE_URL,
     baseHeaders: accessToken ? { authorization: `Bearer ${accessToken}` } : {},
   });


### PR DESCRIPTION
## Summary
- `apps/web/src/lib/api/tsr.ts` now reads `NEXT_PUBLIC_API_URL` directly from `process.env` instead of the zod-validated `getClientEnv()` loader. The loader throws synchronously on any missing `NEXT_PUBLIC_*` var, and because this module is imported by the root `QueryProvider`, every page render was crashing on Vercel when env vars weren't set — not just the dashboard.
- Graceful degradation: requests fail at call time with an empty base URL, but the React tree renders, so the user can still see the landing / login pages and actionable errors.

## Follow-up (outside this patch)
- Verify Vercel project env vars: `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`. The production deploy needs these set for the dashboard + auth flows to actually work.

Refs #21