### PR TITLE
fix(T-1.10.2): landing cta posts to /auth/sign-in

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/page.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/page.tsx
@@ -6,7 +6,6 @@ import { AuroraBackground } from "@/components/layout/aurora-background";
 import { LogoMark } from "@/components/layout/logo-mark";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Link } from "@/i18n/navigation";
 
 export default async function LandingPage({
   params,
@@ -38,13 +37,13 @@ export default async function LandingPage({
             {t("tagline")}
           </p>
           <div className="mt-2 flex items-center gap-3">
-            <Button asChild size="lg">
-              <Link href="/login">
+            <form action="/auth/sign-in" method="post">
+              <Button type="submit" size="lg">
                 <Github />
                 {t("cta")}
                 <ArrowRight />
-              </Link>
-            </Button>
+              </Button>
+            </form>
           </div>
         </div>
       </main>


### PR DESCRIPTION
## Summary
- Landing page "Continue with GitHub" now submits a form POST directly to `/auth/sign-in` instead of routing through `/login`.
- `/login` page untouched — still reachable via direct deep-links and the dashboard session-guard redirect.

Closes #126