### PR TITLE
fix(T-1.10): landing cta posts to /auth/sign-in

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/page.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/page.tsx
@@ -6,7 +6,6 @@ import { AuroraBackground } from "@/components/layout/aurora-background";
 import { LogoMark } from "@/components/layout/logo-mark";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Link } from "@/i18n/navigation";
 
 export default async function LandingPage({
   params,
@@ -38,13 +37,13 @@ export default async function LandingPage({
             {t("tagline")}
           </p>
           <div className="mt-2 flex items-center gap-3">
-            <Button asChild size="lg">
-              <Link href="/login">
+            <form action="/auth/sign-in" method="post">
+              <Button type="submit" size="lg">
                 <Github />
                 {t("cta")}
                 <ArrowRight />
-              </Link>
-            </Button>
+              </Button>
+            </form>
           </div>
         </div>
       </main>

--- a/apps/web/src/app/auth/sign-in/route.ts
+++ b/apps/web/src/app/auth/sign-in/route.ts
@@ -4,9 +4,29 @@ import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 
+const safeOrigin = (url: string): string | null => {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+};
+
 export const POST = async (request: Request) => {
-  const supabase = await createSupabaseServerClient();
   const origin = new URL(request.url).origin;
+
+  const reqOrigin = request.headers.get("origin");
+  const referer = request.headers.get("referer");
+  const refererOrigin = referer ? safeOrigin(referer) : null;
+  const sameOrigin =
+    (reqOrigin !== null && reqOrigin === origin) ||
+    (refererOrigin !== null && refererOrigin === origin);
+
+  if (!sameOrigin) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const supabase = await createSupabaseServerClient();
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: "github",
     options: {


### PR DESCRIPTION
## Summary
- Landing page "Continue with GitHub" now submits a form POST directly to `/auth/sign-in` instead of routing through `/login`.
- `/login` page untouched — still reachable via direct deep-links and the dashboard session-guard redirect.

Closes #126