### PR TITLE
fix(T-1.10): logo svg, client token refresh, icon route

### DIFF
--- a/apps/web/src/app/[locale]/icon.tsx
+++ b/apps/web/src/app/[locale]/icon.tsx
@@ -1,6 +1,5 @@
 import { ImageResponse } from "next/og";
 
-export const runtime = "edge";
 export const size = { width: 32, height: 32 };
 export const contentType = "image/png";
 

--- a/apps/web/src/app/[locale]/opengraph-image.tsx
+++ b/apps/web/src/app/[locale]/opengraph-image.tsx
@@ -1,6 +1,5 @@
 import { ImageResponse } from "next/og";
 
-export const runtime = "edge";
 export const alt = "Commit Analyzer";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";

--- a/apps/web/src/components/layout/logo-mark.tsx
+++ b/apps/web/src/components/layout/logo-mark.tsx
@@ -1,54 +1,61 @@
+import { useId } from "react";
+
 import { cn } from "@/lib/utils";
 
-export const LogoMark = ({ className }: { className?: string }) => (
-  <svg
-    viewBox="0 0 40 40"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-    className={cn("h-8 w-8", className)}
-  >
-    <defs>
-      <linearGradient id="logo-grad" x1="0" y1="0" x2="1" y2="1">
-        <stop offset="0%" stopColor="var(--primary)" />
-        <stop offset="100%" stopColor="oklch(0.7 0.22 330)" />
-      </linearGradient>
-    </defs>
-    <rect
-      x="1"
-      y="1"
-      width="38"
-      height="38"
-      rx="10"
-      stroke="url(#logo-grad)"
-      strokeWidth="2"
-      style={{ ["--dash" as string]: "152" }}
-      className="animate-draw-in"
-    />
-    <path
-      d="M14 15 L9 20 L14 25"
-      stroke="url(#logo-grad)"
-      strokeWidth="2.2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      style={{ ["--dash" as string]: "30" }}
-      className="animate-draw-in"
-    />
-    <path
-      d="M26 15 L31 20 L26 25"
-      stroke="url(#logo-grad)"
-      strokeWidth="2.2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      style={{ ["--dash" as string]: "30" }}
-      className="animate-draw-in"
-    />
-    <circle
-      cx="20"
-      cy="20"
-      r="1.8"
-      fill="url(#logo-grad)"
-      className="animate-pulse-ring origin-center"
-    />
-  </svg>
-);
+export const LogoMark = ({ className }: { className?: string }) => {
+  const gradId = useId();
+  const stroke = `url(#${gradId})`;
+
+  return (
+    <svg
+      viewBox="0 0 40 40"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      className={cn("h-8 w-8", className)}
+    >
+      <defs>
+        <linearGradient id={gradId} x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="var(--primary)" />
+          <stop offset="100%" stopColor="oklch(0.7 0.22 330)" />
+        </linearGradient>
+      </defs>
+      <rect
+        x="1"
+        y="1"
+        width="38"
+        height="38"
+        rx="10"
+        stroke={stroke}
+        strokeWidth="2"
+        style={{ ["--dash" as string]: "152" }}
+        className="animate-draw-in"
+      />
+      <path
+        d="M14 15 L9 20 L14 25"
+        stroke={stroke}
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ ["--dash" as string]: "30" }}
+        className="animate-draw-in"
+      />
+      <path
+        d="M26 15 L31 20 L26 25"
+        stroke={stroke}
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ ["--dash" as string]: "30" }}
+        className="animate-draw-in"
+      />
+      <circle
+        cx="20"
+        cy="20"
+        r="1.8"
+        fill={stroke}
+        className="animate-pulse-ring origin-center"
+      />
+    </svg>
+  );
+};

--- a/apps/web/src/lib/api/tsr.ts
+++ b/apps/web/src/lib/api/tsr.ts
@@ -28,16 +28,34 @@ const getBrowserSupabase = (): AppSupabaseClient => {
   return browserSupabase;
 };
 
+const TOKEN_REFRESH_LEEWAY_SECONDS = 60;
+
 /**
  * Browser fetcher: resolves the current Supabase session and injects
  * `Authorization: Bearer <access_token>` into every request. The Nest API's
  * SupabaseAuthGuard rejects cookie-only requests, so the token must ride as a
  * header.
+ *
+ * Proactively refreshes the session when the access token is within
+ * TOKEN_REFRESH_LEEWAY_SECONDS of expiry. Without this, the first request
+ * after mount frequently fails with 401 because the cached session JWT is
+ * stale, which surfaces as a transient error card on screens that gate UI on
+ * `isError` / `failureReason`.
  */
 const browserApi: ApiFetcher = async (args) => {
   const supabase = getBrowserSupabase();
   const { data } = await supabase.auth.getSession();
-  const token = data.session?.access_token;
+  let session = data.session;
+  const expiresAt = session?.expires_at;
+  if (
+    session &&
+    typeof expiresAt === "number" &&
+    Date.now() / 1000 > expiresAt - TOKEN_REFRESH_LEEWAY_SECONDS
+  ) {
+    const { data: refreshed } = await supabase.auth.refreshSession();
+    session = refreshed.session ?? session;
+  }
+  const token = session?.access_token;
   return tsRestFetchApi({
     ...args,
     headers: {


### PR DESCRIPTION
## Summary
Follow-ups to #130.

- **LogoMark SVG invisible in mobile `Sheet`** — desktop + mobile both rendered `<linearGradient id="logo-grad">`; duplicate SVG ids made `url(#logo-grad)` resolve to a non-painted instance in some browsers. Switched to `useId()` so every instance gets a unique gradient id.
- **Repositories page shows the error card on mount** — the browser Supabase client reads the cached JWT from cookies; when it is within the expiry window, the first API call 401s. #130's `retry: 0` + `failureReason` gate exposed what retry previously masked. Proactively refresh the session in `browserApi` when `expires_at` is within 60 s of now, so the first request always carries a fresh token.
- **`/icon` 404** — `runtime = "edge"` plus root-level `app/icon.tsx` did not resolve correctly (there is no root `layout.tsx` in this project; `[locale]/layout.tsx` is the effective root). Removed the edge runtime export and moved `icon.tsx` + `opengraph-image.tsx` under `[locale]/`.

## Test plan
- [ ] `pnpm -r typecheck` / `pnpm --filter @commit-analyzer/web lint` pass
- [ ] Open the mobile drawer — `LogoMark` is visible next to "Commit Analyzer"
- [ ] `/repositories` loads with no error card on first mount after sign-in
- [ ] `/icon` and `/opengraph-image.png` return 200 in prod