### PR TITLE
fix(T-1.10): repos error card isError only

### DIFF
--- a/apps/web/src/components/repositories/repositories-view.tsx
+++ b/apps/web/src/components/repositories/repositories-view.tsx
@@ -89,10 +89,8 @@ export const RepositoriesView = ({
     retry: 0,
   });
 
-  const githubHasError =
-    githubQuery.isError || githubQuery.failureReason !== null;
-  const connectedHasError =
-    connectedQuery.isError || connectedQuery.failureReason !== null;
+  const githubHasError = githubQuery.isError;
+  const connectedHasError = connectedQuery.isError;
 
   const githubItems: GithubRepo[] =
     githubQuery.data?.body.items ?? initialGithub;


### PR DESCRIPTION
## Summary
Repos page was showing the error card on first load even though `/repos/github` and `/repos` returned 200. Browser DevTools confirmed all responses succeeded.

Root cause: `failureReason !== null` is not reliably cleared on success in TanStack Query v5 under our ts-rest + `initialData` setup, so gating error UI on it produced false positives. The #130 change followed the issue guidance but that guidance didn't match v5's actual state machine for this combo.

Fix: gate both error cards on `query.isError` alone. `retry: 0` is still set from #130, so real failures surface immediately without flickering.

## Test plan
- [ ] Sign in, open `/repositories` → no error card
- [ ] Kill the API → error card shows and stays