### PR TITLE
fix(T-1.10): bulletproof browser api + log repo errors

### DIFF
--- a/apps/web/src/components/repositories/repositories-view.tsx
+++ b/apps/web/src/components/repositories/repositories-view.tsx
@@ -7,7 +7,7 @@ import type {
 import { useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, Github, Loader2, Plug, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import {
@@ -91,6 +91,19 @@ export const RepositoriesView = ({
 
   const githubHasError = githubQuery.isError;
   const connectedHasError = connectedQuery.isError;
+
+  useEffect(() => {
+    if (githubQuery.error) {
+      // eslint-disable-next-line no-console
+      console.error("[repos] listGithub error", githubQuery.error);
+    }
+  }, [githubQuery.error]);
+  useEffect(() => {
+    if (connectedQuery.error) {
+      // eslint-disable-next-line no-console
+      console.error("[repos] listConnected error", connectedQuery.error);
+    }
+  }, [connectedQuery.error]);
 
   const githubItems: GithubRepo[] =
     githubQuery.data?.body.items ?? initialGithub;

--- a/apps/web/src/lib/api/tsr.ts
+++ b/apps/web/src/lib/api/tsr.ts
@@ -42,20 +42,33 @@ const TOKEN_REFRESH_LEEWAY_SECONDS = 60;
  * stale, which surfaces as a transient error card on screens that gate UI on
  * `isError` / `failureReason`.
  */
-const browserApi: ApiFetcher = async (args) => {
-  const supabase = getBrowserSupabase();
-  const { data } = await supabase.auth.getSession();
-  let session = data.session;
-  const expiresAt = session?.expires_at;
-  if (
-    session &&
-    typeof expiresAt === "number" &&
-    Date.now() / 1000 > expiresAt - TOKEN_REFRESH_LEEWAY_SECONDS
-  ) {
-    const { data: refreshed } = await supabase.auth.refreshSession();
-    session = refreshed.session ?? session;
+const resolveBrowserToken = async (): Promise<string | undefined> => {
+  try {
+    const supabase = getBrowserSupabase();
+    const { data } = await supabase.auth.getSession();
+    let session = data.session;
+    const expiresAt = session?.expires_at;
+    if (
+      session &&
+      typeof expiresAt === "number" &&
+      Date.now() / 1000 > expiresAt - TOKEN_REFRESH_LEEWAY_SECONDS
+    ) {
+      try {
+        const { data: refreshed } = await supabase.auth.refreshSession();
+        session = refreshed.session ?? session;
+      } catch (refreshErr) {
+        console.warn("supabase refreshSession threw", refreshErr);
+      }
+    }
+    return session?.access_token;
+  } catch (err) {
+    console.warn("resolveBrowserToken threw", err);
+    return undefined;
   }
-  const token = session?.access_token;
+};
+
+const browserApi: ApiFetcher = async (args) => {
+  const token = await resolveBrowserToken();
   return tsRestFetchApi({
     ...args,
     headers: {


### PR DESCRIPTION
## Summary
Repos page still shows the error card even though DevTools Network shows `/repos/github` and `/repos` return 200. That means the query errors are coming from something thrown inside `browserApi` (not from the API response).

- Wrap `getSession` and `refreshSession` in try/catch so nothing thrown from the Supabase browser client breaks the query. Worst case: we send the request without `Authorization` and surface a real 401.
- Temporary: `console.error("[repos] listGithub error", ...)` + `[repos] listConnected error` in `RepositoriesView` so we can capture the real error stack from prod. Removed once the root cause is confirmed.

## Test plan
- [ ] Open `/repositories`, check DevTools Console for `[repos] ...` log — share with me