### PR TITLE
fix(T-1.10): trim env values, tsx --env-file

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "start": "node --enable-source-maps dist/bootstrap.js",
     "predev": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/contracts build",
-    "dev": "tsx watch src/bootstrap.ts",
+    "dev": "tsx watch --env-file=.env src/bootstrap.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist .turbo *.tsbuildinfo",

--- a/packages/shared-types/src/env/schema.ts
+++ b/packages/shared-types/src/env/schema.ts
@@ -1,11 +1,15 @@
 import { z } from "zod";
 
 const nonEmpty = (field: string) =>
-  z.string({ required_error: `${field} is required` }).min(1, `${field} must not be empty`);
+  z
+    .string({ required_error: `${field} is required` })
+    .trim()
+    .min(1, `${field} must not be empty`);
 
 const urlField = (field: string) =>
   z
     .string({ required_error: `${field} is required` })
+    .trim()
     .url(`${field} must be a valid URL`);
 
 const optionalString = z


### PR DESCRIPTION
## Summary
Found the actual root cause of the production repositories error while setting up local dev — **two Vercel env vars have a literal trailing newline** baked in:

\`\`\`
NEXT_PUBLIC_SUPABASE_URL="https://alsmiysaubvlrmwsjokz.supabase.co\n"
NEXT_PUBLIC_SUPABASE_ANON_KEY="sb_publishable_..._7Kjfz5Zp\n"
\`\`\`

The browser Supabase client was being initialized with a URL ending in \`\n\`, so every auth / session request went to a malformed URL. `refreshSession` / `getSession` behaved erratically, which cascaded into `browserApi` throwing or returning a session without a token — react-query marked the repos queries as errored even though the raw `/repos` HTTP responses in DevTools looked 200 on cached paths. That's why #130 / #132 / #133 couldn't fix it: we were treating symptoms.

Fixes:
- **`packages/shared-types/src/env/schema.ts`** — `.trim()` on every `nonEmpty` and `urlField`, so any leading/trailing whitespace (notably the trailing newline stored in Vercel) is stripped at validation time for both server and client env. This repairs the existing deployment without requiring anyone to touch Vercel env config.
- **`apps/api/package.json`** — `dev` now runs `tsx watch --env-file=.env src/bootstrap.ts` so `pnpm --filter @commit-analyzer/api dev` actually loads the local `.env`. Node 20+ / tsx 4 pass-through.

Follow-up (not in this PR): `vercel env rm NEXT_PUBLIC_SUPABASE_URL/ANON_KEY` and re-add without the trailing newline so the stored value is clean.

## Test plan
- [ ] `pnpm -r typecheck` / `pnpm --filter @commit-analyzer/shared-types test` pass (14/14 passing locally)
- [ ] After deploy, `/repositories` loads without the error card
- [ ] `pnpm --filter @commit-analyzer/api dev` boots using `apps/api/.env`