### PR TITLE
fix(T-1.10): inline NEXT_PUBLIC env refs for client bundle

### DIFF
--- a/apps/web/src/lib/supabase/env.ts
+++ b/apps/web/src/lib/supabase/env.ts
@@ -2,7 +2,24 @@ import { loadClientEnv, type ClientEnv } from "@commit-analyzer/shared-types/env
 
 let cached: ClientEnv | undefined;
 
+/**
+ * Next.js only inlines `process.env.NEXT_PUBLIC_*` into the client bundle when
+ * the reference is a literal `process.env.NEXT_PUBLIC_FOO` access. Passing
+ * `process.env` as an object into a helper defeats the static analyzer: the
+ * client bundle ends up with `process.env === {}`, `loadClientEnv()` throws
+ * "NEXT_PUBLIC_* is required", and every downstream browser Supabase + ts-rest
+ * call fails with "invalid credentials" because no Authorization header is
+ * attached.
+ *
+ * The literal property accesses below are what lets Next inline each value at
+ * build time for both server and client code paths.
+ */
 export const getClientEnv = (): ClientEnv => {
-  cached ??= loadClientEnv();
+  cached ??= loadClientEnv({
+    NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  });
   return cached;
 };


### PR DESCRIPTION
## Root cause (finally)

Console log from prod:

\`\`\`
resolveBrowserToken threw EnvValidationError: Invalid client environment:
  - NEXT_PUBLIC_APP_URL: NEXT_PUBLIC_APP_URL is required
  - NEXT_PUBLIC_API_URL: NEXT_PUBLIC_API_URL is required
  - NEXT_PUBLIC_SUPABASE_URL: NEXT_PUBLIC_SUPABASE_URL is required
  - NEXT_PUBLIC_SUPABASE_ANON_KEY: NEXT_PUBLIC_SUPABASE_ANON_KEY is required
\`\`\`

Next.js only inlines \`process.env.NEXT_PUBLIC_*\` into the client bundle when the reference is a **literal** member access. \`apps/web/src/lib/supabase/env.ts\` called \`loadClientEnv()\` with no arg, which defaults to \`process.env\` inside the shared loader. Static analyzer never sees any literal \`NEXT_PUBLIC_*\` access, so Next inlines nothing, the client runtime \`process.env\` is empty, the Zod schema throws "required", \`createSupabaseBrowserClient\` blows up, no Authorization header is attached, API returns \`401 invalid credentials\`.

Proof: \`tsr.ts\` reads \`process.env.NEXT_PUBLIC_API_URL\` literally and that one value *is* in the bundle (requests go to the correct Railway URL). The rest never got inlined.

Every prior "fix" (#130 error gate, #132 token refresh, #133 isError-only gate, #134 bulletproof browserApi, #135 trim env) was chasing symptoms downstream of this.

## Fix

\`apps/web/src/lib/supabase/env.ts\` now passes a literal-property object to \`loadClientEnv\`:

\`\`\`ts
loadClientEnv({
  NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
  NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
  NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
  NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
});
\`\`\`

Each \`process.env.NEXT_PUBLIC_*\` is now a literal reference Next can inline. Comment in the file documents the foot-gun.

## Test plan
- [ ] \`pnpm -r typecheck\` / \`pnpm --filter @commit-analyzer/web lint\` pass
- [ ] After deploy: \`/repositories\` loads with real data (no error card, no \`[repos] listGithub error\` in console)
- [ ] \`resolveBrowserToken\` no longer logs "EnvValidationError"