### PR TITLE
chore(T-1.13): dev supabase + redis-only compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,16 +7,21 @@ APP_URL=http://localhost:3000
 API_URL=http://localhost:4000
 WEB_ORIGIN=http://localhost:3000
 
-# Database / cache
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/commit_analyzer
+# Postgres is hosted by Supabase — use the Transaction pooler connection string
+# (Dashboard → Project → Settings → Database → Transaction pooler, port 6543).
+# For local dev, always point at the `commit-analyzer-dev` project, NEVER prod.
+DATABASE_URL=postgresql://postgres.<your-dev-project-ref>:<password>@aws-1-<region>.pooler.supabase.com:6543/postgres
+DATABASE_SSL=true
+
+# Redis — BullMQ job queue. `docker compose up -d` starts a local instance.
 REDIS_URL=redis://localhost:6379
 
-# Supabase (auth + RLS)
-SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_ANON_KEY=your-anon-key
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# Supabase (auth + RLS) — dev project credentials
+SUPABASE_URL=https://<your-dev-project-ref>.supabase.co
+SUPABASE_ANON_KEY=<dev-publishable-key>
+SUPABASE_SERVICE_ROLE_KEY=<dev-service-role-key>
 
-# GitHub OAuth app
+# GitHub OAuth app — register a dev app with callback http://localhost:3000/auth/callback
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 
@@ -25,7 +30,8 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 
 # AES-256-GCM key for token/API-key encryption — 32 raw bytes, base64-encoded.
-# Generate: `openssl rand -base64 32`
+# Generate a fresh one per environment: `openssl rand -base64 32`
+# Reusing the prod key locally means prod-encrypted rows decrypt in dev — DON'T.
 ENCRYPTION_KEY_BASE64=
 
 # Extra CSP connect-src entries for staging/prod (comma or whitespace separated).
@@ -36,5 +42,5 @@ CSP_CONNECT_SRC=
 # Next.js public (client) variables — must be safe to ship to the browser
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_API_URL=http://localhost:4000
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+NEXT_PUBLIC_SUPABASE_URL=https://<your-dev-project-ref>.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<dev-publishable-key>

--- a/README.md
+++ b/README.md
@@ -8,13 +8,56 @@ Turborepo monorepo · NestJS API · Next.js web · ts-rest contracts · BullMQ �
 
 ## Quickstart
 
-Requires Node 20, pnpm 9.12+, and Docker.
+Requires Node 20, pnpm 9.12+, Docker, and a Supabase account.
+
+### 1. Provision a dev Supabase project
+
+Local dev must NOT point at the prod Supabase project — every migration or destructive query would hit real user data. Create a separate free-tier project (e.g. `commit-analyzer-dev`) and capture:
+
+- Project URL: `https://<ref>.supabase.co`
+- Publishable (anon) key and service role key: Dashboard → Settings → API
+- Transaction pooler connection string (port 6543): Dashboard → Settings → Database
+
+### 2. Register a dev GitHub OAuth app
+
+Create a dedicated OAuth app at <https://github.com/settings/developers> with:
+
+- Homepage URL: `http://localhost:3000`
+- Authorization callback URL: `http://localhost:3000/auth/callback`
+
+Keep the prod OAuth app separate so rotating one doesn't break the other.
+
+### 3. Bootstrap env files
+
+The `apps/api` and `apps/web` apps each load their own env file. Start from the root template:
+
+```bash
+cp .env.example apps/api/.env
+cp .env.example apps/web/.env.local   # only the NEXT_PUBLIC_* keys are read here
+```
+
+Fill in the values from steps 1–2, then generate a fresh encryption key (do **not** reuse prod's — it would let prod-encrypted rows decrypt in dev):
+
+```bash
+openssl rand -base64 32   # paste into ENCRYPTION_KEY_BASE64 in apps/api/.env
+```
+
+### 4. Run the schema migrations against dev
+
+```bash
+cd packages/database
+DATABASE_URL="<dev pooler connection string>" DATABASE_SSL=true pnpm migration:run
+```
+
+### 5. Boot the stack
 
 ```bash
 pnpm install
-docker compose up -d
+docker compose up -d   # Redis only — Postgres is hosted by Supabase
 pnpm dev
 ```
+
+Web runs on <http://localhost:3000>, API on <http://localhost:4000>.
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,4 @@
 services:
-  postgres:
-    image: postgres:16
-    container_name: commit-analyzer-postgres
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dev}
-      POSTGRES_DB: ${POSTGRES_DB:-app}
-    ports:
-      - "${POSTGRES_PORT:-55432}:5432"
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-app}"]
-      interval: 2s
-      timeout: 3s
-      retries: 10
-      start_period: 2s
-
   redis:
     image: redis:7-alpine
     container_name: commit-analyzer-redis
@@ -28,6 +10,3 @@ services:
       timeout: 3s
       retries: 10
       start_period: 1s
-
-volumes:
-  pgdata:


### PR DESCRIPTION
## Summary
- Isolate local dev from prod Supabase: README now walks through provisioning a separate dev project, registering a dev GitHub OAuth app, generating a fresh encryption key, and running the TypeORM migrations against the dev DB
- Shrink `docker-compose.yml` to Redis only — Postgres is hosted by Supabase, the local pg service was unused
- Rewrite `.env.example` to document the dev-vs-prod split and remove the stale `postgres://localhost:5432` default that nothing read

The dev Supabase project `commit-analyzer-dev` has been provisioned (ref `uhewscvmeifplxbtdijy`, `eu-central-1`) and the schema has been ported via `pnpm migration:run`. Local `apps/api/.env` / `apps/web/.env.local` updates are tracked outside this PR (gitignored); see the new README section for the steps.

Still to do outside this PR (manual):
- Register a dev GitHub OAuth app with `http://localhost:3000/auth/callback`
- Point local `apps/api/.env` + `apps/web/.env.local` at the dev project with a freshly generated `ENCRYPTION_KEY_BASE64`

Closes #139