### PR TITLE
fix(T-1.11): api keys page mobile layout

### DIFF
--- a/apps/web/src/features/api-keys/components/api-key-row.tsx
+++ b/apps/web/src/features/api-keys/components/api-key-row.tsx
@@ -24,10 +24,12 @@ export const ApiKeyRow = ({ apiKey, isRevoking, onRevoke }: Props) => {
   const t = useTranslations("apiKeys");
 
   return (
-    <div className="flex items-center gap-4 rounded-xl border bg-card p-4 transition-colors">
+    <div className="flex items-center gap-3 rounded-xl border bg-card p-3 transition-colors sm:gap-4 sm:p-4">
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <div className="flex items-center gap-2">
-          <span className="truncate font-medium">{apiKey.name}</span>
+          <span className="truncate font-medium text-sm sm:text-base">
+            {apiKey.name}
+          </span>
           <Badge variant="secondary" className="font-mono text-xs shrink-0">
             {apiKey.prefix}…
           </Badge>
@@ -51,7 +53,7 @@ export const ApiKeyRow = ({ apiKey, isRevoking, onRevoke }: Props) => {
         disabled={isRevoking}
       >
         {isRevoking ? <Loader2 className="animate-spin" /> : <Trash2 />}
-        {t("revoke")}
+        <span className="hidden sm:inline">{t("revoke")}</span>
       </Button>
     </div>
   );

--- a/apps/web/src/features/api-keys/components/api-keys-view.tsx
+++ b/apps/web/src/features/api-keys/components/api-keys-view.tsx
@@ -55,7 +55,7 @@ export const ApiKeysView = ({ userId, initialItems }: ApiKeysPageData) => {
 
   return (
     <div className="flex flex-col gap-6">
-      <header className="flex items-end justify-between gap-4">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h2 className="flex items-center gap-2 text-lg font-semibold tracking-tight">
             <Key className="h-5 w-5" />
@@ -63,7 +63,10 @@ export const ApiKeysView = ({ userId, initialItems }: ApiKeysPageData) => {
           </h2>
           <p className="text-sm text-muted-foreground">{t("subtitle")}</p>
         </div>
-        <Button onClick={() => setCreateOpen(true)}>
+        <Button
+          className="w-full sm:w-auto"
+          onClick={() => setCreateOpen(true)}
+        >
           <Plus />
           {t("createKey")}
         </Button>


### PR DESCRIPTION
## Summary
- Header stacks vertically on mobile (title/subtitle on top, full-width button below)
- Key row: tighter padding on mobile, revoke button icon-only on small screens
- Dialog already responsive (`sm:max-w-md`) — no changes needed

Closes #146