### PR TITLE
fix(T-1.10.3): simplify repo toolbar ux

### DIFF
--- a/apps/web/messages/en/repositories.json
+++ b/apps/web/messages/en/repositories.json
@@ -16,9 +16,7 @@
     "connect": "Connect",
     "connecting": "Connecting…",
     "disconnect": "Disconnect",
-    "disconnecting": "Disconnecting…",
-    "refresh": "Refresh",
-    "refreshing": "Refreshing…"
+    "disconnecting": "Disconnecting…"
   },
   "badge": {
     "private": "Private",
@@ -28,6 +26,7 @@
   },
   "toolbar": {
     "search": "Search repositories…",
+    "filters": "Filters",
     "sort": "Sort by",
     "sortName": "Name",
     "sortPushed": "Recently pushed",
@@ -41,9 +40,7 @@
   "pagination": {
     "page": "Page {current} of {total}",
     "prev": "Previous",
-    "next": "Next",
-    "perPage": "{count} per page",
-    "showing": "Showing {from}–{to} of {total}"
+    "next": "Next"
   },
   "disconnectDialog": {
     "title": "Disconnect repository?",
@@ -55,9 +52,7 @@
     "connected": "Repository connected",
     "disconnected": "Repository disconnected",
     "connectError": "Could not connect repository",
-    "disconnectError": "Could not disconnect repository",
-    "refreshed": "Repositories refreshed",
-    "refreshError": "Could not refresh repositories"
+    "disconnectError": "Could not disconnect repository"
   },
   "error": {
     "load": "We couldn't load your repositories. Please try again."

--- a/apps/web/messages/uk/repositories.json
+++ b/apps/web/messages/uk/repositories.json
@@ -16,9 +16,7 @@
     "connect": "Підключити",
     "connecting": "Підключення…",
     "disconnect": "Відʼєднати",
-    "disconnecting": "Відʼєднання…",
-    "refresh": "Оновити",
-    "refreshing": "Оновлення…"
+    "disconnecting": "Відʼєднання…"
   },
   "badge": {
     "private": "Приватний",
@@ -28,6 +26,7 @@
   },
   "toolbar": {
     "search": "Шукати репозиторії…",
+    "filters": "Фільтри",
     "sort": "Сортувати",
     "sortName": "Назва",
     "sortPushed": "Нещодавно оновлені",
@@ -41,9 +40,7 @@
   "pagination": {
     "page": "Сторінка {current} із {total}",
     "prev": "Попередня",
-    "next": "Наступна",
-    "perPage": "{count} на сторінку",
-    "showing": "Показано {from}–{to} з {total}"
+    "next": "Наступна"
   },
   "disconnectDialog": {
     "title": "Відʼєднати репозиторій?",
@@ -55,9 +52,7 @@
     "connected": "Репозиторій підключено",
     "disconnected": "Репозиторій відʼєднано",
     "connectError": "Не вдалося підключити репозиторій",
-    "disconnectError": "Не вдалося відʼєднати репозиторій",
-    "refreshed": "Репозиторії оновлено",
-    "refreshError": "Не вдалося оновити репозиторії"
+    "disconnectError": "Не вдалося відʼєднати репозиторій"
   },
   "error": {
     "load": "Не вдалося завантажити репозиторії. Спробуйте ще раз."

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.1.1",
     "@supabase/ssr": "^0.10.2",

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import type { ComponentPropsWithoutRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export const Popover = PopoverPrimitive.Root;
+export const PopoverTrigger = PopoverPrimitive.Trigger;
+export const PopoverAnchor = PopoverPrimitive.Anchor;
+
+export const PopoverContent = ({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+        "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+);

--- a/apps/web/src/features/repositories/components/repo-pagination.tsx
+++ b/apps/web/src/features/repositories/components/repo-pagination.tsx
@@ -4,87 +4,49 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 
-import { PAGE_SIZES, type PageSize } from "../use-repo-filters";
+import { DEFAULT_PAGE_SIZE } from "../use-repo-filters";
 
 type RepoPaginationProps = {
   page: number;
   totalPages: number;
-  pageSize: PageSize;
   totalFiltered: number;
   onPageChange: (page: number) => void;
-  onPageSizeChange: (size: PageSize) => void;
 };
 
 export const RepoPagination = ({
   page,
   totalPages,
-  pageSize,
   totalFiltered,
   onPageChange,
-  onPageSizeChange,
 }: RepoPaginationProps) => {
   const t = useTranslations("repositories.pagination");
 
-  if (totalFiltered <= PAGE_SIZES[0]) return null;
-
-  const from = (page - 1) * pageSize + 1;
-  const to = Math.min(page * pageSize, totalFiltered);
+  if (totalFiltered <= DEFAULT_PAGE_SIZE) return null;
 
   return (
-    <div className="flex flex-col items-center justify-between gap-3 sm:flex-row">
-      <span className="text-sm text-muted-foreground">
-        {t("showing", { from, to, total: totalFiltered })}
+    <div className="flex items-center justify-center gap-1">
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={() => onPageChange(page - 1)}
+        disabled={page <= 1}
+        aria-label={t("prev")}
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+      <span className="px-2 text-sm text-muted-foreground">
+        {t("page", { current: page, total: totalPages })}
       </span>
-
-      <div className="flex items-center gap-2">
-        <Select
-          value={String(pageSize)}
-          onValueChange={(v) => onPageSizeChange(Number(v) as PageSize)}
-        >
-          <SelectTrigger className="w-[120px]">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {PAGE_SIZES.map((size) => (
-              <SelectItem key={size} value={String(size)}>
-                {t("perPage", { count: size })}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <div className="flex items-center gap-1">
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={() => onPageChange(page - 1)}
-            disabled={page <= 1}
-            aria-label={t("prev")}
-          >
-            <ChevronLeft className="h-4 w-4" />
-          </Button>
-          <span className="px-2 text-sm text-muted-foreground">
-            {t("page", { current: page, total: totalPages })}
-          </span>
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={() => onPageChange(page + 1)}
-            disabled={page >= totalPages}
-            aria-label={t("next")}
-          >
-            <ChevronRight className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={() => onPageChange(page + 1)}
+        disabled={page >= totalPages}
+        aria-label={t("next")}
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
     </div>
   );
 };

--- a/apps/web/src/features/repositories/components/repo-toolbar.tsx
+++ b/apps/web/src/features/repositories/components/repo-toolbar.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { Loader2, RefreshCw, Search } from "lucide-react";
+import { SlidersHorizontal, Search } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -25,8 +30,6 @@ type RepoToolbarProps = {
   onSortChange: (v: SortField) => void;
   onVisibilityChange: (v: VisibilityFilter) => void;
   onArchivedChange: (v: boolean) => void;
-  onRefresh: () => void;
-  isRefreshing: boolean;
 };
 
 export const RepoToolbar = ({
@@ -35,14 +38,16 @@ export const RepoToolbar = ({
   onSortChange,
   onVisibilityChange,
   onArchivedChange,
-  onRefresh,
-  isRefreshing,
 }: RepoToolbarProps) => {
   const t = useTranslations("repositories.toolbar");
-  const tActions = useTranslations("repositories.actions");
+
+  const hasActiveFilters =
+    state.sortBy !== "name" ||
+    state.visibility !== "all" ||
+    state.showArchived;
 
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+    <div className="flex items-center gap-3">
       <div className="relative flex-1">
         <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
@@ -54,57 +59,75 @@ export const RepoToolbar = ({
         />
       </div>
 
-      <div className="flex flex-wrap items-center gap-2">
-        <Select
-          value={state.sortBy}
-          onValueChange={(v) => onSortChange(v as SortField)}
-        >
-          <SelectTrigger className="w-[160px]">
-            <SelectValue placeholder={t("sort")} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="name">{t("sortName")}</SelectItem>
-            <SelectItem value="pushedAt">{t("sortPushed")}</SelectItem>
-            <SelectItem value="stars">{t("sortStars")}</SelectItem>
-          </SelectContent>
-        </Select>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm" className="gap-2">
+            <SlidersHorizontal className="h-4 w-4" />
+            {t("filters")}
+            {hasActiveFilters && (
+              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] font-medium text-primary-foreground">
+                {Number(state.sortBy !== "name") +
+                  Number(state.visibility !== "all") +
+                  Number(state.showArchived)}
+              </span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-64 space-y-4">
+          <div className="space-y-2">
+            <p className="text-sm font-medium">{t("sort")}</p>
+            <Select
+              value={state.sortBy}
+              onValueChange={(v) => onSortChange(v as SortField)}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="name">{t("sortName")}</SelectItem>
+                <SelectItem value="pushedAt">{t("sortPushed")}</SelectItem>
+                <SelectItem value="stars">{t("sortStars")}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
 
-        <Select
-          value={state.visibility}
-          onValueChange={(v) => onVisibilityChange(v as VisibilityFilter)}
-        >
-          <SelectTrigger className="w-[130px]">
-            <SelectValue placeholder={t("filterVisibility")} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">{t("filterAll")}</SelectItem>
-            <SelectItem value="public">{t("filterPublic")}</SelectItem>
-            <SelectItem value="private">{t("filterPrivate")}</SelectItem>
-          </SelectContent>
-        </Select>
+          <div className="space-y-2">
+            <p className="text-sm font-medium">{t("filterVisibility")}</p>
+            <Select
+              value={state.visibility}
+              onValueChange={(v) => onVisibilityChange(v as VisibilityFilter)}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{t("filterAll")}</SelectItem>
+                <SelectItem value="public">{t("filterPublic")}</SelectItem>
+                <SelectItem value="private">{t("filterPrivate")}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
 
-        <Button
-          variant={state.showArchived ? "secondary" : "outline"}
-          size="sm"
-          onClick={() => onArchivedChange(!state.showArchived)}
-        >
-          {t("showArchived")}
-        </Button>
-
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onRefresh}
-          disabled={isRefreshing}
-        >
-          {isRefreshing ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <RefreshCw className="h-4 w-4" />
-          )}
-          {isRefreshing ? tActions("refreshing") : tActions("refresh")}
-        </Button>
-      </div>
+          <label className="flex cursor-pointer items-center justify-between">
+            <span className="text-sm font-medium">{t("showArchived")}</span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={state.showArchived}
+              onClick={() => onArchivedChange(!state.showArchived)}
+              className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent transition-colors ${
+                state.showArchived ? "bg-primary" : "bg-input"
+              }`}
+            >
+              <span
+                className={`pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform ${
+                  state.showArchived ? "translate-x-4" : "translate-x-0"
+                }`}
+              />
+            </button>
+          </label>
+        </PopoverContent>
+      </Popover>
     </div>
   );
 };

--- a/apps/web/src/features/repositories/components/repositories-view.tsx
+++ b/apps/web/src/features/repositories/components/repositories-view.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import type { ConnectedRepo } from "@commit-analyzer/contracts";
-import { useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, Github, Loader2, Plug, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
-import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -16,7 +14,6 @@ import {
   useDisconnectRepoMutation,
   useGithubReposQuery,
 } from "@/features/repositories/hooks";
-import { repositoryQueryKeys } from "@/features/repositories/queries";
 import type { RepositoriesPageData } from "@/features/repositories/types";
 import { useRepoFilters } from "@/features/repositories/use-repo-filters";
 
@@ -37,7 +34,6 @@ export const RepositoriesView = ({
   initialConnected,
 }: RepositoriesPageData) => {
   const t = useTranslations("repositories");
-  const queryClient = useQueryClient();
 
   const githubQuery = useGithubReposQuery(userId, initialGithub);
   const connectedQuery = useConnectedReposQuery(userId, initialConnected);
@@ -63,29 +59,6 @@ export const RepositoriesView = ({
     );
   }, [connectedItems, filters.state.search]);
 
-  const [isRefreshing, setIsRefreshing] = useState(false);
-
-  const handleRefresh = () => {
-    setIsRefreshing(true);
-    void Promise.all([
-      queryClient.invalidateQueries({
-        queryKey: [...repositoryQueryKeys.github(userId)],
-      }),
-      queryClient.invalidateQueries({
-        queryKey: [...repositoryQueryKeys.connected(userId)],
-      }),
-    ])
-      .then(() => {
-        toast.success(t("toast.refreshed"));
-      })
-      .catch(() => {
-        toast.error(t("toast.refreshError"));
-      })
-      .finally(() => {
-        setIsRefreshing(false);
-      });
-  };
-
   const [pendingDisconnect, setPendingDisconnect] = useState<
     ConnectedRepo | null
   >(null);
@@ -98,8 +71,6 @@ export const RepositoriesView = ({
         onSortChange={filters.setSortBy}
         onVisibilityChange={filters.setVisibility}
         onArchivedChange={filters.setShowArchived}
-        onRefresh={handleRefresh}
-        isRefreshing={isRefreshing}
       />
 
       <section className="flex flex-col gap-4">
@@ -251,10 +222,8 @@ export const RepositoriesView = ({
             <RepoPagination
               page={filters.state.page}
               totalPages={filters.totalPages}
-              pageSize={filters.state.pageSize}
               totalFiltered={filters.totalFiltered}
               onPageChange={filters.setPage}
-              onPageSizeChange={filters.setPageSize}
             />
           </>
         )}

--- a/apps/web/src/features/repositories/use-repo-filters.ts
+++ b/apps/web/src/features/repositories/use-repo-filters.ts
@@ -16,7 +16,7 @@ export type RepoFilterState = {
   page: number;
 };
 
-export type UseRepoFiltersReturn = {
+type UseRepoFiltersReturn = {
   state: RepoFilterState;
   setSearch: (v: string) => void;
   setSortBy: (v: SortField) => void;
@@ -29,7 +29,7 @@ export type UseRepoFiltersReturn = {
   totalPages: number;
 };
 
-export function filterRepos(
+function filterRepos(
   items: GithubRepo[],
   search: string,
   visibility: VisibilityFilter,
@@ -54,7 +54,7 @@ export function filterRepos(
   return result;
 }
 
-export function sortRepos(items: GithubRepo[], sortBy: SortField): GithubRepo[] {
+function sortRepos(items: GithubRepo[], sortBy: SortField): GithubRepo[] {
   const sorted = [...items];
   switch (sortBy) {
     case "name":

--- a/apps/web/src/features/repositories/use-repo-filters.ts
+++ b/apps/web/src/features/repositories/use-repo-filters.ts
@@ -6,9 +6,7 @@ import { useMemo, useState } from "react";
 export type SortField = "name" | "pushedAt" | "stars";
 export type VisibilityFilter = "all" | "public" | "private";
 
-const PAGE_SIZES = [12, 24, 48] as const;
-export type PageSize = (typeof PAGE_SIZES)[number];
-export { PAGE_SIZES };
+export const DEFAULT_PAGE_SIZE = 12;
 
 export type RepoFilterState = {
   search: string;
@@ -16,7 +14,6 @@ export type RepoFilterState = {
   visibility: VisibilityFilter;
   showArchived: boolean;
   page: number;
-  pageSize: PageSize;
 };
 
 export type UseRepoFiltersReturn = {
@@ -26,7 +23,6 @@ export type UseRepoFiltersReturn = {
   setVisibility: (v: VisibilityFilter) => void;
   setShowArchived: (v: boolean) => void;
   setPage: (v: number) => void;
-  setPageSize: (v: PageSize) => void;
   filtered: GithubRepo[];
   paginated: GithubRepo[];
   totalFiltered: number;
@@ -84,7 +80,6 @@ export function useRepoFilters(items: GithubRepo[]): UseRepoFiltersReturn {
   const [visibility, setVisibilityRaw] = useState<VisibilityFilter>("all");
   const [showArchived, setShowArchivedRaw] = useState(false);
   const [page, setPage] = useState(1);
-  const [pageSize, setPageSizeRaw] = useState<PageSize>(12);
 
   const setSearch = (v: string) => {
     setSearchRaw(v);
@@ -102,10 +97,6 @@ export function useRepoFilters(items: GithubRepo[]): UseRepoFiltersReturn {
     setShowArchivedRaw(v);
     setPage(1);
   };
-  const setPageSize = (v: PageSize) => {
-    setPageSizeRaw(v);
-    setPage(1);
-  };
 
   const filtered = useMemo(
     () => sortRepos(filterRepos(items, search, visibility, showArchived), sortBy),
@@ -113,15 +104,15 @@ export function useRepoFilters(items: GithubRepo[]): UseRepoFiltersReturn {
   );
 
   const totalFiltered = filtered.length;
-  const totalPages = Math.max(1, Math.ceil(totalFiltered / pageSize));
+  const totalPages = Math.max(1, Math.ceil(totalFiltered / DEFAULT_PAGE_SIZE));
   const clampedPage = Math.min(page, totalPages);
 
   const paginated = useMemo(
     () => {
-      const start = (clampedPage - 1) * pageSize;
-      return filtered.slice(start, start + pageSize);
+      const start = (clampedPage - 1) * DEFAULT_PAGE_SIZE;
+      return filtered.slice(start, start + DEFAULT_PAGE_SIZE);
     },
-    [filtered, clampedPage, pageSize],
+    [filtered, clampedPage],
   );
 
   return {
@@ -131,14 +122,12 @@ export function useRepoFilters(items: GithubRepo[]): UseRepoFiltersReturn {
       visibility,
       showArchived,
       page: clampedPage,
-      pageSize,
     },
     setSearch,
     setSortBy,
     setVisibility,
     setShowArchived,
     setPage,
-    setPageSize,
     filtered,
     paginated,
     totalFiltered,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.4
         version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1691,6 +1694,19 @@ packages:
 
   '@radix-ui/react-menu@2.1.16':
     resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6126,6 +6142,29 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      aria-hidden: 1.2.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
       aria-hidden: 1.2.6
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)


### PR DESCRIPTION
## Summary
- Collapsed sort, visibility, and archived toggle behind a single filter popover button
- Removed the refresh button (React Query handles refetch on window focus)
- Removed per-page selector from pagination, fixed page size at 12
- Added `@radix-ui/react-popover` + `popover.tsx` UI component
- Updated en/uk i18n files (added `filters` key, removed unused keys)
- Toolbar is now: `[Search...] [Filters]`

Closes #148