### PR TITLE
fix(T-1.10.3): filter reset + scroll on page

### DIFF
--- a/apps/web/messages/en/repositories.json
+++ b/apps/web/messages/en/repositories.json
@@ -35,7 +35,8 @@
     "filterAll": "All",
     "filterPublic": "Public",
     "filterPrivate": "Private",
-    "showArchived": "Show archived"
+    "showArchived": "Show archived",
+    "reset": "Reset filters"
   },
   "pagination": {
     "page": "Page {current} of {total}",

--- a/apps/web/messages/uk/repositories.json
+++ b/apps/web/messages/uk/repositories.json
@@ -35,7 +35,8 @@
     "filterAll": "Усі",
     "filterPublic": "Публічні",
     "filterPrivate": "Приватні",
-    "showArchived": "Показати архівні"
+    "showArchived": "Показати архівні",
+    "reset": "Скинути фільтри"
   },
   "pagination": {
     "page": "Сторінка {current} із {total}",

--- a/apps/web/src/features/repositories/components/repo-toolbar.tsx
+++ b/apps/web/src/features/repositories/components/repo-toolbar.tsx
@@ -30,6 +30,7 @@ type RepoToolbarProps = {
   onSortChange: (v: SortField) => void;
   onVisibilityChange: (v: VisibilityFilter) => void;
   onArchivedChange: (v: boolean) => void;
+  onReset: () => void;
 };
 
 export const RepoToolbar = ({
@@ -38,6 +39,7 @@ export const RepoToolbar = ({
   onSortChange,
   onVisibilityChange,
   onArchivedChange,
+  onReset,
 }: RepoToolbarProps) => {
   const t = useTranslations("repositories.toolbar");
 
@@ -126,6 +128,17 @@ export const RepoToolbar = ({
               />
             </button>
           </label>
+
+          {hasActiveFilters && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full"
+              onClick={onReset}
+            >
+              {t("reset")}
+            </Button>
+          )}
         </PopoverContent>
       </Popover>
     </div>

--- a/apps/web/src/features/repositories/components/repositories-view.tsx
+++ b/apps/web/src/features/repositories/components/repositories-view.tsx
@@ -3,7 +3,7 @@
 import type { ConnectedRepo } from "@commit-analyzer/contracts";
 import { AlertCircle, Github, Loader2, Plug, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -50,6 +50,15 @@ export const RepositoriesView = ({
   }, [connectedItems]);
 
   const filters = useRepoFilters(githubItems);
+  const githubSectionRef = useRef<HTMLElement>(null);
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      filters.setPage(page);
+      githubSectionRef.current?.scrollIntoView({ behavior: "smooth" });
+    },
+    [filters],
+  );
 
   const filteredConnected = useMemo(() => {
     if (!filters.state.search.trim()) return connectedItems;
@@ -71,6 +80,7 @@ export const RepositoriesView = ({
         onSortChange={filters.setSortBy}
         onVisibilityChange={filters.setVisibility}
         onArchivedChange={filters.setShowArchived}
+        onReset={filters.reset}
       />
 
       <section className="flex flex-col gap-4">
@@ -137,7 +147,7 @@ export const RepositoriesView = ({
         )}
       </section>
 
-      <section className="flex flex-col gap-4">
+      <section ref={githubSectionRef} className="flex flex-col gap-4">
         <header>
           <h2 className="flex items-center gap-2 text-lg font-semibold tracking-tight">
             <Github className="h-5 w-5" />
@@ -223,7 +233,7 @@ export const RepositoriesView = ({
               page={filters.state.page}
               totalPages={filters.totalPages}
               totalFiltered={filters.totalFiltered}
-              onPageChange={filters.setPage}
+              onPageChange={handlePageChange}
             />
           </>
         )}

--- a/apps/web/src/features/repositories/use-repo-filters.ts
+++ b/apps/web/src/features/repositories/use-repo-filters.ts
@@ -23,6 +23,7 @@ type UseRepoFiltersReturn = {
   setVisibility: (v: VisibilityFilter) => void;
   setShowArchived: (v: boolean) => void;
   setPage: (v: number) => void;
+  reset: () => void;
   filtered: GithubRepo[];
   paginated: GithubRepo[];
   totalFiltered: number;
@@ -98,6 +99,14 @@ export function useRepoFilters(items: GithubRepo[]): UseRepoFiltersReturn {
     setPage(1);
   };
 
+  const reset = () => {
+    setSearchRaw("");
+    setSortByRaw("name");
+    setVisibilityRaw("all");
+    setShowArchivedRaw(false);
+    setPage(1);
+  };
+
   const filtered = useMemo(
     () => sortRepos(filterRepos(items, search, visibility, showArchived), sortBy),
     [items, search, sortBy, visibility, showArchived],
@@ -128,6 +137,7 @@ export function useRepoFilters(items: GithubRepo[]): UseRepoFiltersReturn {
     setVisibility,
     setShowArchived,
     setPage,
+    reset,
     filtered,
     paginated,
     totalFiltered,


### PR DESCRIPTION
## Summary
- Added "Reset filters" button inside the filter popover (appears when any filter is active)
- Scroll to top of GitHub repos section on page change so user doesn't land at the bottom

Closes #148