### PR TITLE
test(T-1.12): rls smoke + auth/crypto suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,21 @@ jobs:
   unit:
     name: Unit tests
     runs-on: ubuntu-latest
+    env:
+      SKIP_INTEGRATION: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - run: pnpm test -- -- --run
+
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm --filter "./packages/*" build
+      - run: pnpm --filter api test -- -- --run
 
   knip:
     name: Knip (unused exports)

--- a/apps/api/src/common/database/rls.integration.test.ts
+++ b/apps/api/src/common/database/rls.integration.test.ts
@@ -1,0 +1,214 @@
+import "reflect-metadata";
+
+import {
+  ApiKey,
+  LLMApiKey,
+  Repository,
+  User,
+  buildDataSourceOptions,
+} from "@commit-analyzer/database";
+import {
+  PostgreSqlContainer,
+  type StartedPostgreSqlContainer,
+} from "@testcontainers/postgresql";
+import { DataSource } from "typeorm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const SKIP = process.env.SKIP_INTEGRATION === "1";
+
+const USER_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const USER_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+const PHASE_1_TABLES = ["users", "repositories", "api_keys", "llm_api_keys"];
+
+describe.skipIf(SKIP)("RLS isolation (integration)", () => {
+  let container: StartedPostgreSqlContainer;
+  let ds: DataSource;
+
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer("postgres:16").start();
+
+    const baseOptions = buildDataSourceOptions({
+      url: container.getConnectionUri(),
+    });
+    ds = new DataSource({
+      ...baseOptions,
+      entities: [ApiKey, LLMApiKey, Repository, User],
+    });
+    await ds.initialize();
+
+    await ds.query(`CREATE SCHEMA IF NOT EXISTS auth`);
+    await ds.query(
+      `CREATE TABLE IF NOT EXISTS auth.users (id uuid PRIMARY KEY, email text, raw_user_meta_data jsonb)`,
+    );
+
+    // Production-equivalent auth.uid(): reads sub from request.jwt.claims GUC.
+    await ds.query(`
+      CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid
+      LANGUAGE sql STABLE
+      AS $$
+        SELECT COALESCE(
+          (current_setting('request.jwt.claims', true)::jsonb ->> 'sub')::uuid,
+          NULL
+        )
+      $$
+    `);
+
+    await ds.runMigrations();
+
+    // Drop the trigger so we can seed directly.
+    await ds.query(
+      `DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users`,
+    );
+
+    // Disable RLS temporarily to seed data as superuser.
+    for (const table of PHASE_1_TABLES) {
+      await ds.query(`ALTER TABLE "${table}" DISABLE ROW LEVEL SECURITY`);
+    }
+
+    // Seed auth.users
+    for (const [id, email] of [
+      [USER_A, "alice@example.com"],
+      [USER_B, "bob@example.com"],
+    ] as const) {
+      await ds.query(
+        `INSERT INTO auth.users (id, email, raw_user_meta_data) VALUES ($1, $2, '{}'::jsonb)`,
+        [id, email],
+      );
+      await ds.query(
+        `INSERT INTO public.users (id, email, username) VALUES ($1, $2, $3)`,
+        [id, email, email.split("@")[0]],
+      );
+    }
+
+    // Seed repositories
+    await ds.query(
+      `INSERT INTO repositories (user_id, github_repo_id, full_name) VALUES ($1, 1001, 'alice/repo-a')`,
+      [USER_A],
+    );
+    await ds.query(
+      `INSERT INTO repositories (user_id, github_repo_id, full_name) VALUES ($1, 2001, 'bob/repo-b')`,
+      [USER_B],
+    );
+
+    // Re-enable RLS for test assertions.
+    for (const table of PHASE_1_TABLES) {
+      await ds.query(`ALTER TABLE "${table}" ENABLE ROW LEVEL SECURITY`);
+    }
+
+    // Superuser bypasses RLS. Create a restricted role that respects policies.
+    await ds.query(`CREATE ROLE app_user NOLOGIN`);
+    for (const table of PHASE_1_TABLES) {
+      await ds.query(`GRANT SELECT, INSERT, UPDATE, DELETE ON "${table}" TO app_user`);
+    }
+    await ds.query(`GRANT USAGE ON SCHEMA public TO app_user`);
+    await ds.query(`GRANT USAGE ON SCHEMA auth TO app_user`);
+    await ds.query(`GRANT EXECUTE ON FUNCTION auth.uid() TO app_user`);
+  }, 120_000);
+
+  afterAll(async () => {
+    if (ds?.isInitialized) await ds.destroy();
+    if (container) await container.stop();
+  }, 30_000);
+
+  async function queryAs<T>(userId: string, sql: string): Promise<T[]> {
+    const qr = ds.createQueryRunner();
+    await qr.connect();
+    await qr.startTransaction();
+    try {
+      await qr.manager.query(`SET LOCAL ROLE app_user`);
+      await qr.manager.query(
+        `SELECT set_config('request.jwt.claims', $1, true)`,
+        [JSON.stringify({ sub: userId })],
+      );
+      return await qr.manager.query(sql);
+    } finally {
+      await qr.rollbackTransaction();
+      await qr.release();
+    }
+  }
+
+  it("user A sees only own repositories", async () => {
+    const rows = await queryAs<{ full_name: string }>(
+      USER_A,
+      `SELECT full_name FROM repositories`,
+    );
+    expect(rows.map((r) => r.full_name)).toEqual(["alice/repo-a"]);
+  });
+
+  it("user B sees only own repositories", async () => {
+    const rows = await queryAs<{ full_name: string }>(
+      USER_B,
+      `SELECT full_name FROM repositories`,
+    );
+    expect(rows.map((r) => r.full_name)).toEqual(["bob/repo-b"]);
+  });
+
+  it("user B cannot select user A's repositories", async () => {
+    const rows = await queryAs<{ full_name: string }>(
+      USER_B,
+      `SELECT full_name FROM repositories WHERE full_name = 'alice/repo-a'`,
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it("user A cannot select user B's user row", async () => {
+    const rows = await queryAs<{ id: string }>(
+      USER_A,
+      `SELECT id FROM users WHERE id = '${USER_B}'`,
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it("unauthenticated session (no claims) sees no rows", async () => {
+    const qr = ds.createQueryRunner();
+    await qr.connect();
+    await qr.startTransaction();
+    try {
+      await qr.manager.query(`SET LOCAL ROLE app_user`);
+      await qr.manager.query(
+        `SELECT set_config('request.jwt.claims', '{}', true)`,
+      );
+      const repos: unknown[] = await qr.manager.query(
+        `SELECT * FROM repositories`,
+      );
+      const users: unknown[] = await qr.manager.query(
+        `SELECT * FROM users`,
+      );
+      expect(repos).toHaveLength(0);
+      expect(users).toHaveLength(0);
+    } finally {
+      await qr.rollbackTransaction();
+      await qr.release();
+    }
+  });
+
+  describe("RLS must be enabled on all Phase-1 tables", () => {
+    for (const table of PHASE_1_TABLES) {
+      it(`${table} has RLS enabled`, async () => {
+        const result: { relrowsecurity: boolean; relforcerowsecurity: boolean }[] =
+          await ds.query(
+            `SELECT relrowsecurity, relforcerowsecurity
+             FROM pg_class WHERE relname = $1`,
+            [table],
+          );
+        expect(result[0]!.relrowsecurity).toBe(true);
+        expect(result[0]!.relforcerowsecurity).toBe(true);
+      });
+    }
+  });
+
+  describe("RLS policies exist on all Phase-1 tables", () => {
+    for (const table of PHASE_1_TABLES) {
+      it(`${table} has an owner policy`, async () => {
+        const rows: { polname: string }[] = await ds.query(
+          `SELECT polname FROM pg_policy
+           WHERE polrelid = $1::regclass`,
+          [table],
+        );
+        expect(rows.length).toBeGreaterThanOrEqual(1);
+        expect(rows.some((r) => r.polname.includes("owner"))).toBe(true);
+      });
+    }
+  });
+});

--- a/apps/api/src/common/database/rls.integration.test.ts
+++ b/apps/api/src/common/database/rls.integration.test.ts
@@ -11,6 +11,7 @@ import {
   PostgreSqlContainer,
   type StartedPostgreSqlContainer,
 } from "@testcontainers/postgresql";
+import argon2 from "argon2";
 import { DataSource } from "typeorm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -91,6 +92,31 @@ describe.skipIf(SKIP)("RLS isolation (integration)", () => {
       [USER_B],
     );
 
+    // Seed api_keys
+    const hashA = await argon2.hash("git_AAAAsecretA");
+    const hashB = await argon2.hash("git_BBBBsecretB");
+    await ds.query(
+      `INSERT INTO api_keys (user_id, name, key_prefix, key_hash) VALUES ($1, 'alice-key', 'git_AAAA', $2)`,
+      [USER_A, hashA],
+    );
+    await ds.query(
+      `INSERT INTO api_keys (user_id, name, key_prefix, key_hash) VALUES ($1, 'bob-key', 'git_BBBB', $2)`,
+      [USER_B, hashB],
+    );
+
+    // Seed llm_api_keys
+    const dummyEnc = Buffer.from("enc");
+    const dummyIv = Buffer.from("iv");
+    const dummyTag = Buffer.from("tag");
+    await ds.query(
+      `INSERT INTO llm_api_keys (user_id, provider, key_enc, key_iv, key_tag) VALUES ($1, 'openai', $2, $3, $4)`,
+      [USER_A, dummyEnc, dummyIv, dummyTag],
+    );
+    await ds.query(
+      `INSERT INTO llm_api_keys (user_id, provider, key_enc, key_iv, key_tag) VALUES ($1, 'anthropic', $2, $3, $4)`,
+      [USER_B, dummyEnc, dummyIv, dummyTag],
+    );
+
     // Re-enable RLS for test assertions.
     for (const table of PHASE_1_TABLES) {
       await ds.query(`ALTER TABLE "${table}" ENABLE ROW LEVEL SECURITY`);
@@ -111,7 +137,11 @@ describe.skipIf(SKIP)("RLS isolation (integration)", () => {
     if (container) await container.stop();
   }, 30_000);
 
-  async function queryAs<T>(userId: string, sql: string): Promise<T[]> {
+  async function queryAs<T>(
+    userId: string,
+    sql: string,
+    params?: unknown[],
+  ): Promise<T[]> {
     const qr = ds.createQueryRunner();
     await qr.connect();
     await qr.startTransaction();
@@ -121,7 +151,7 @@ describe.skipIf(SKIP)("RLS isolation (integration)", () => {
         `SELECT set_config('request.jwt.claims', $1, true)`,
         [JSON.stringify({ sub: userId })],
       );
-      return await qr.manager.query(sql);
+      return await qr.manager.query(sql, params);
     } finally {
       await qr.rollbackTransaction();
       await qr.release();
@@ -155,7 +185,25 @@ describe.skipIf(SKIP)("RLS isolation (integration)", () => {
   it("user A cannot select user B's user row", async () => {
     const rows = await queryAs<{ id: string }>(
       USER_A,
-      `SELECT id FROM users WHERE id = '${USER_B}'`,
+      `SELECT id FROM users WHERE id = $1`,
+      [USER_B],
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it("user B cannot see user A's api_keys", async () => {
+    const rows = await queryAs<{ name: string }>(
+      USER_B,
+      `SELECT name FROM api_keys WHERE key_prefix = $1`,
+      ["git_AAAA"],
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it("user A cannot see user B's llm_api_keys", async () => {
+    const rows = await queryAs<{ provider: string }>(
+      USER_A,
+      `SELECT provider FROM llm_api_keys WHERE provider = 'anthropic'`,
     );
     expect(rows).toHaveLength(0);
   });

--- a/apps/api/src/modules/auth/api-key.guard.test.ts
+++ b/apps/api/src/modules/auth/api-key.guard.test.ts
@@ -103,6 +103,28 @@ describe("ApiKeyGuard", () => {
     expect(touchLastUsed).not.toHaveBeenCalled();
   });
 
+  it("401 when key is exactly PREFIX_LENGTH (no secret part)", async () => {
+    await request(server())
+      .get("/probe")
+      .set("x-api-key", "git_abcd")
+      .expect(401);
+    expect(findActiveByPrefix).not.toHaveBeenCalled();
+  });
+
+  it("401 when argon2.verify throws (corrupted hash)", async () => {
+    findActiveByPrefix.mockResolvedValueOnce({
+      id: "k-1",
+      userId: "u-1",
+      keyPrefix: "git_abcd",
+      keyHash: "not-a-valid-hash",
+    });
+    await request(server())
+      .get("/probe")
+      .set("x-api-key", validKey)
+      .expect(401);
+    expect(touchLastUsed).not.toHaveBeenCalled();
+  });
+
   it("200 with valid key: handler sees user id, last_used_at updated", async () => {
     findActiveByPrefix.mockResolvedValueOnce({
       id: "k-1",

--- a/apps/api/src/modules/auth/supabase-auth.guard.test.ts
+++ b/apps/api/src/modules/auth/supabase-auth.guard.test.ts
@@ -83,6 +83,24 @@ describe("SupabaseAuthGuard", () => {
     expect(getUser).not.toHaveBeenCalled();
   });
 
+  it("401 with empty bearer token", async () => {
+    const res = await request(server())
+      .get("/probe")
+      .set("Authorization", "Bearer ")
+      .expect(401);
+    expect((res.body as { message: string }).message).toBe("invalid credentials");
+    expect(getUser).not.toHaveBeenCalled();
+  });
+
+  it("401 with non-Bearer scheme", async () => {
+    const res = await request(server())
+      .get("/probe")
+      .set("Authorization", "Basic abc123")
+      .expect(401);
+    expect((res.body as { message: string }).message).toBe("invalid credentials");
+    expect(getUser).not.toHaveBeenCalled();
+  });
+
   it("401 on invalid token", async () => {
     getUser.mockResolvedValueOnce({ data: null, error: { message: "bad" } });
     const res = await request(server())
@@ -118,9 +136,33 @@ describe("SupabaseAuthGuard", () => {
 
   it("falls back to minimal sub claim when token is not decodable", async () => {
     getUser.mockResolvedValueOnce({ data: { user: { id: "u-99" } }, error: null });
-    await request(server())
+    const res = await request(server())
       .get("/probe")
       .set("Authorization", "Bearer not-a-jwt")
       .expect(200);
+    const body = res.body as ProbeResponse;
+    expect(body.userId).toBe("u-99");
+    expect(body.claims).toEqual({ sub: "u-99" });
+  });
+
+  it("falls back to minimal sub when payload is non-object JSON", async () => {
+    getUser.mockResolvedValueOnce({ data: { user: { id: "u-77" } }, error: null });
+    const header = Buffer.from('{"alg":"HS256"}').toString("base64url");
+    const payload = Buffer.from('"just a string"').toString("base64url");
+    const token = `${header}.${payload}.sig`;
+    const res = await request(server())
+      .get("/probe")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    const body = res.body as ProbeResponse;
+    expect(body.claims).toEqual({ sub: "u-77" });
+  });
+
+  it("401 when supabase returns null user without error", async () => {
+    getUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+    await request(server())
+      .get("/probe")
+      .set("Authorization", "Bearer some-token")
+      .expect(401);
   });
 });

--- a/apps/api/src/shared/crypto.service.spec.ts
+++ b/apps/api/src/shared/crypto.service.spec.ts
@@ -82,4 +82,35 @@ describe("CryptoService", () => {
   it("rejects key of wrong length", () => {
     expect(() => new CryptoService(Buffer.alloc(16))).toThrow(/32 bytes/);
   });
+
+  it("encryptParts/decryptParts round-trip", () => {
+    const svc = new CryptoService(makeKey());
+    const plain = "structured data";
+    const parts = svc.encryptParts(plain);
+    expect(parts.ciphertext).toBeInstanceOf(Buffer);
+    expect(parts.iv).toBeInstanceOf(Buffer);
+    expect(parts.tag).toBeInstanceOf(Buffer);
+    expect(svc.decryptParts(parts)).toBe(plain);
+  });
+
+  it("decryptParts throws on wrong iv length", () => {
+    const svc = new CryptoService(makeKey());
+    const parts = svc.encryptParts("x");
+    parts.iv = Buffer.alloc(8);
+    expect(() => svc.decryptParts(parts)).toThrow(DecryptionError);
+  });
+
+  it("decryptParts throws on wrong tag length", () => {
+    const svc = new CryptoService(makeKey());
+    const parts = svc.encryptParts("x");
+    parts.tag = Buffer.alloc(8);
+    expect(() => svc.decryptParts(parts)).toThrow(DecryptionError);
+  });
+
+  it("decryptParts throws on tampered iv", () => {
+    const svc = new CryptoService(makeKey());
+    const parts = svc.encryptParts("secret");
+    parts.iv[0] = (parts.iv[0] ?? 0) ^ 0xff;
+    expect(() => svc.decryptParts(parts)).toThrow(DecryptionError);
+  });
 });


### PR DESCRIPTION
## Summary
- RLS integration test: spins up Postgres via testcontainers, seeds two users with repos, asserts user B cannot read user A's rows via request-scoped transaction with `SET LOCAL ROLE` to a non-superuser role
- Verifies RLS is enabled + forced on all Phase-1 tables (`users`, `repositories`, `api_keys`, `llm_api_keys`) and owner policies exist
- Unauthenticated session (empty claims) sees zero rows
- CryptoService edge cases: `encryptParts`/`decryptParts` round-trip, wrong IV/tag length, tampered IV
- ApiKeyGuard edge cases: key exactly prefix length (boundary), corrupted argon2 hash
- SupabaseAuthGuard edge cases: empty bearer, non-Bearer scheme, non-object JWT payload, null user without error

Closes #23