### PR TITLE
fix(T-1.10.3): reset filters button style

### DIFF
--- a/apps/web/src/features/repositories/components/repo-toolbar.tsx
+++ b/apps/web/src/features/repositories/components/repo-toolbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SlidersHorizontal, Search } from "lucide-react";
+import { RotateCcw, SlidersHorizontal, Search } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
@@ -131,11 +131,12 @@ export const RepoToolbar = ({
 
           {hasActiveFilters && (
             <Button
-              variant="ghost"
+              variant="outline"
               size="sm"
               className="w-full"
               onClick={onReset}
             >
+              <RotateCcw className="h-3.5 w-3.5" />
               {t("reset")}
             </Button>
           )}


### PR DESCRIPTION
## Summary
- `variant="ghost"` on dark popover background rendered reset button as invisible plain text — switched to `variant="outline"` with a `RotateCcw` icon for clear affordance

Closes #148