### PR TITLE
fix(T-1.13): use local state for instant repo filter updates

### DIFF
--- a/apps/web/src/features/repositories/use-repo-filters.ts
+++ b/apps/web/src/features/repositories/use-repo-filters.ts
@@ -2,7 +2,7 @@
 
 import type { GithubRepo } from "@commit-analyzer/contracts";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export type SortField = "name" | "pushedAt" | "stars";
 export type VisibilityFilter = "all" | "public" | "private";
@@ -76,68 +76,149 @@ function sortRepos(items: GithubRepo[], sortBy: SortField): GithubRepo[] {
   return sorted;
 }
 
+function readParams(searchParams: URLSearchParams): RepoFilterState {
+  return {
+    search: searchParams.get("search") ?? "",
+    sortBy: (searchParams.get("sort") as SortField | null) ?? "name",
+    visibility:
+      (searchParams.get("vis") as VisibilityFilter | null) ?? "all",
+    showArchived: searchParams.get("archived") === "1",
+    page: Math.max(1, Number(searchParams.get("page") ?? "1")),
+  };
+}
+
+function buildQuery(state: RepoFilterState): string {
+  const params = new URLSearchParams();
+  if (state.search) params.set("search", state.search);
+  if (state.sortBy !== "name") params.set("sort", state.sortBy);
+  if (state.visibility !== "all") params.set("vis", state.visibility);
+  if (state.showArchived) params.set("archived", "1");
+  if (state.page > 1) params.set("page", String(state.page));
+  return params.toString();
+}
+
+const SEARCH_DEBOUNCE_MS = 300;
+
 export function useRepoFilters(items: GithubRepo[]): UseRepoFiltersReturn {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const search = searchParams.get("search") ?? "";
-  const sortBy = (searchParams.get("sort") as SortField | null) ?? "name";
-  const visibility =
-    (searchParams.get("vis") as VisibilityFilter | null) ?? "all";
-  const showArchived = searchParams.get("archived") === "1";
-  const page = Math.max(1, Number(searchParams.get("page") ?? "1"));
+  const [state, setState] = useState<RepoFilterState>(() =>
+    readParams(searchParams),
+  );
 
-  const updateParams = useCallback(
-    (updates: Record<string, string | null>) => {
-      const params = new URLSearchParams(searchParams.toString());
-      for (const [key, val] of Object.entries(updates)) {
-        if (val === null) {
-          params.delete(key);
-        } else {
-          params.set(key, val);
-        }
-      }
-      const qs = params.toString();
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  // Sync URL → local state when user navigates back/forward
+  const prevSearchParams = useRef(searchParams.toString());
+  useEffect(() => {
+    const current = searchParams.toString();
+    if (current !== prevSearchParams.current) {
+      prevSearchParams.current = current;
+      setState(readParams(searchParams));
+    }
+  }, [searchParams]);
+
+  // Debounced URL sync for search, immediate for other filters
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
+  const syncUrl = useCallback(
+    (next: RepoFilterState) => {
+      const qs = buildQuery(next);
+      prevSearchParams.current = qs;
       router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
     },
-    [router, pathname, searchParams],
+    [router, pathname],
   );
 
   const setSearch = useCallback(
-    (v: string) => updateParams({ search: v || null, page: null }),
-    [updateParams],
+    (v: string) => {
+      const next: RepoFilterState = {
+        ...stateRef.current,
+        search: v,
+        page: 1,
+      };
+      setState(next);
+      clearTimeout(searchTimerRef.current);
+      searchTimerRef.current = setTimeout(
+        () => syncUrl(next),
+        SEARCH_DEBOUNCE_MS,
+      );
+    },
+    [syncUrl],
   );
+
   const setSortBy = useCallback(
-    (v: SortField) =>
-      updateParams({ sort: v === "name" ? null : v, page: null }),
-    [updateParams],
+    (v: SortField) => {
+      const next = { ...stateRef.current, sortBy: v, page: 1 };
+      setState(next);
+      syncUrl(next);
+    },
+    [syncUrl],
   );
+
   const setVisibility = useCallback(
-    (v: VisibilityFilter) =>
-      updateParams({ vis: v === "all" ? null : v, page: null }),
-    [updateParams],
+    (v: VisibilityFilter) => {
+      const next = { ...stateRef.current, visibility: v, page: 1 };
+      setState(next);
+      syncUrl(next);
+    },
+    [syncUrl],
   );
+
   const setShowArchived = useCallback(
-    (v: boolean) => updateParams({ archived: v ? "1" : null, page: null }),
-    [updateParams],
+    (v: boolean) => {
+      const next = { ...stateRef.current, showArchived: v, page: 1 };
+      setState(next);
+      syncUrl(next);
+    },
+    [syncUrl],
   );
+
   const setPage = useCallback(
-    (v: number) => updateParams({ page: v === 1 ? null : String(v) }),
-    [updateParams],
+    (v: number) => {
+      const next = { ...stateRef.current, page: v };
+      setState(next);
+      syncUrl(next);
+    },
+    [syncUrl],
   );
+
   const reset = useCallback(() => {
+    const next: RepoFilterState = {
+      search: "",
+      sortBy: "name",
+      visibility: "all",
+      showArchived: false,
+      page: 1,
+    };
+    clearTimeout(searchTimerRef.current);
+    setState(next);
+    prevSearchParams.current = "";
     router.replace(pathname, { scroll: false });
   }, [router, pathname]);
 
+  // Cleanup debounce timer
+  useEffect(() => {
+    return () => clearTimeout(searchTimerRef.current);
+  }, []);
+
   const filtered = useMemo(
-    () => sortRepos(filterRepos(items, search, visibility, showArchived), sortBy),
-    [items, search, sortBy, visibility, showArchived],
+    () =>
+      sortRepos(
+        filterRepos(items, state.search, state.visibility, state.showArchived),
+        state.sortBy,
+      ),
+    [items, state.search, state.sortBy, state.visibility, state.showArchived],
   );
 
   const totalFiltered = filtered.length;
   const totalPages = Math.max(1, Math.ceil(totalFiltered / DEFAULT_PAGE_SIZE));
-  const clampedPage = Math.min(page, totalPages);
+  const clampedPage = Math.min(state.page, totalPages);
 
   const paginated = useMemo(() => {
     const start = (clampedPage - 1) * DEFAULT_PAGE_SIZE;
@@ -146,10 +227,7 @@ export function useRepoFilters(items: GithubRepo[]): UseRepoFiltersReturn {
 
   return {
     state: {
-      search,
-      sortBy,
-      visibility,
-      showArchived,
+      ...state,
       page: clampedPage,
     },
     setSearch,


### PR DESCRIPTION
## Summary

- Fixes laggy/unresponsive filter and search interactions on `/repositories` page introduced by #156
- `useRepoFilters` now uses `useState` as primary state source for instant UI updates, with `router.replace()` as a background URL sync
- Search input debounced at 300ms — typing is instant, URL updates after pause
- Discrete filters (sort, visibility, archived) still sync URL immediately but update UI from local state first
- Browser back/forward navigation syncs URL → local state via `useEffect` on `searchParams`

## Test plan

- [ ] Type in search — input responds instantly, URL updates after 300ms pause
- [ ] Change sort/visibility/archived — UI updates instantly, no page flash
- [ ] Refresh page with filter params in URL — state restores correctly
- [ ] Browser back/forward — filter state matches URL
- [ ] Reset filters — clears all state and URL params