### PR TITLE
fix(T-1.13): prevent pagination race on rapid clicks

### DIFF
--- a/apps/web/src/features/repositories/use-repo-filters.ts
+++ b/apps/web/src/features/repositories/use-repo-filters.ts
@@ -111,14 +111,19 @@ export function useRepoFilters(items: GithubRepo[]): UseRepoFiltersReturn {
   const stateRef = useRef(state);
   stateRef.current = state;
 
-  // Sync URL → local state when user navigates back/forward
-  const prevSearchParams = useRef(searchParams.toString());
+  // Track all pending URL pushes so stale router.replace echoes
+  // don't overwrite local state during rapid interactions
+  const pendingUrls = useRef(new Set<string>());
+
+  // Sync URL → local state only for external navigation (back/forward)
   useEffect(() => {
     const current = searchParams.toString();
-    if (current !== prevSearchParams.current) {
-      prevSearchParams.current = current;
-      setState(readParams(searchParams));
+    if (pendingUrls.current.has(current)) {
+      pendingUrls.current.delete(current);
+      return;
     }
+    pendingUrls.current.clear();
+    setState(readParams(searchParams));
   }, [searchParams]);
 
   // Debounced URL sync for search, immediate for other filters
@@ -129,7 +134,7 @@ export function useRepoFilters(items: GithubRepo[]): UseRepoFiltersReturn {
   const syncUrl = useCallback(
     (next: RepoFilterState) => {
       const qs = buildQuery(next);
-      prevSearchParams.current = qs;
+      pendingUrls.current.add(qs);
       router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
     },
     [router, pathname],
@@ -198,7 +203,7 @@ export function useRepoFilters(items: GithubRepo[]): UseRepoFiltersReturn {
     };
     clearTimeout(searchTimerRef.current);
     setState(next);
-    prevSearchParams.current = "";
+    pendingUrls.current.add("");
     router.replace(pathname, { scroll: false });
   }, [router, pathname]);
 


### PR DESCRIPTION
## Summary

- Fixes pagination jumping backwards when clicking page buttons rapidly
- Race condition: `prevSearchParams` ref stored only the latest pushed URL, so when an earlier `router.replace` resolved after a newer one was queued, the `useEffect` mistook the stale echo for external navigation and synced state backwards
- Replace single-value ref with a `Set<string>` of all pending URL pushes — each `router.replace` echo is consumed from the set, and only truly external navigation (back/forward) triggers a state sync

## Test plan

- [ ] Click pagination buttons rapidly — page never jumps backwards
- [ ] Browser back/forward still syncs filter state correctly
- [ ] Filter changes (sort, visibility, archived) still update URL immediately
- [ ] Search debounce still works
- [ ] Reset clears all state and URL params