### PR TITLE
fix: rename proxy export for next.js 16

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -25,7 +25,7 @@ const GUEST_ONLY_PATHS = ["/", "/login"];
 
 const intlMiddleware = createMiddleware(routing);
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const { strippedPath, localePrefix } = parseLocale(pathname);
 


### PR DESCRIPTION
## Summary
- `proxy.ts` must export a function named `proxy` (or default), not `middleware`
- Next.js 16 renamed middleware to proxy — the export name must match

## Change
`export async function middleware` → `export async function proxy`