### PR TITLE
test(T-1.13): playwright e2e for landing and auth

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,23 @@
+name: E2E tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm --filter "./packages/*" build
+      - run: pnpm --filter @commit-analyzer/web e2e:install
+      - run: pnpm --filter @commit-analyzer/web e2e
+        env:
+          CI: "true"
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+          retention-days: 7

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,2 @@
+playwright-report/
+test-results/

--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+
+import { MOCK_ACCESS_TOKEN } from "./mock-server";
+
+// Mirror the session shape @supabase/auth-js stores in the SSR cookie.
+const MOCK_SESSION = {
+  access_token: MOCK_ACCESS_TOKEN,
+  token_type: "bearer",
+  expires_in: 3600,
+  // Far-future expiry so the client never tries to refresh.
+  expires_at: 9_999_999_999,
+  refresh_token: "mock-refresh-token",
+  user: {
+    id: "test-user-id",
+    aud: "authenticated",
+    role: "authenticated",
+    email: "test@example.com",
+    email_confirmed_at: "2024-01-01T00:00:00Z",
+    user_metadata: { full_name: "Test User", avatar_url: null },
+    app_metadata: { provider: "github" },
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+};
+
+/**
+ * Encode a session object into the cookie value format used by @supabase/ssr:
+ * "base64-" + base64url(JSON.stringify(session))
+ */
+function encodeSession(session: typeof MOCK_SESSION): string {
+  return "base64-" + Buffer.from(JSON.stringify(session)).toString("base64url");
+}
+
+test.describe("login page", () => {
+  test("renders sign-in card", async ({ page }) => {
+    await page.goto("/login");
+    // CardTitle renders as <div>, not a heading — match by text.
+    await expect(page.getByText("Sign in")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /continue with github/i }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("stubbed OAuth flow", () => {
+  test("callback with code lands on /dashboard", async ({ page, context }) => {
+    // Inject the session cookie before any navigation so it is included in the
+    // request headers when Next.js loads the dashboard layout.
+    // Cookie name is derived by supabase-js as `sb-${hostname[0]}-auth-token`.
+    // With NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 → "sb-127-auth-token".
+    await context.addCookies([
+      {
+        name: "sb-127-auth-token",
+        value: encodeSession(MOCK_SESSION),
+        domain: "localhost",
+        path: "/",
+        httpOnly: false,
+        secure: false,
+        sameSite: "Lax",
+      },
+    ]);
+
+    // Intercept the OAuth callback before it reaches the Next.js route handler
+    // and redirect straight to /dashboard, bypassing the real PKCE exchange.
+    // The mock Supabase server (started in globalSetup) handles the subsequent
+    // GET /auth/v1/user call made by the dashboard layout.
+    await page.route("**/auth/callback**", async (route) => {
+      await route.fulfill({
+        status: 302,
+        headers: { Location: "http://localhost:3000/dashboard" },
+      });
+    });
+
+    await page.goto("/auth/callback?code=test-code&next=%2Fdashboard");
+
+    await page.waitForURL("**/dashboard");
+    await expect(
+      page.getByRole("heading", { name: /welcome back/i }),
+    ).toBeVisible();
+  });
+});

--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -1,35 +1,4 @@
-import { expect, test } from "@playwright/test";
-
-import { MOCK_ACCESS_TOKEN } from "./mock-server";
-
-// Mirror the session shape @supabase/auth-js stores in the SSR cookie.
-const MOCK_SESSION = {
-  access_token: MOCK_ACCESS_TOKEN,
-  token_type: "bearer",
-  expires_in: 3600,
-  // Far-future expiry so the client never tries to refresh.
-  expires_at: 9_999_999_999,
-  refresh_token: "mock-refresh-token",
-  user: {
-    id: "test-user-id",
-    aud: "authenticated",
-    role: "authenticated",
-    email: "test@example.com",
-    email_confirmed_at: "2024-01-01T00:00:00Z",
-    user_metadata: { full_name: "Test User", avatar_url: null },
-    app_metadata: { provider: "github" },
-    created_at: "2024-01-01T00:00:00Z",
-    updated_at: "2024-01-01T00:00:00Z",
-  },
-};
-
-/**
- * Encode a session object into the cookie value format used by @supabase/ssr:
- * "base64-" + base64url(JSON.stringify(session))
- */
-function encodeSession(session: typeof MOCK_SESSION): string {
-  return "base64-" + Buffer.from(JSON.stringify(session)).toString("base64url");
-}
+import { expect, test } from "./fixtures";
 
 test.describe("login page", () => {
   test("renders sign-in card", async ({ page }) => {
@@ -43,39 +12,22 @@ test.describe("login page", () => {
 });
 
 test.describe("stubbed OAuth flow", () => {
-  test("callback with code lands on /dashboard", async ({ page, context }) => {
-    // Inject the session cookie before any navigation so it is included in the
-    // request headers when Next.js loads the dashboard layout.
-    // Cookie name is derived by supabase-js as `sb-${hostname[0]}-auth-token`.
-    // With NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 → "sb-127-auth-token".
-    await context.addCookies([
-      {
-        name: "sb-127-auth-token",
-        value: encodeSession(MOCK_SESSION),
-        domain: "localhost",
-        path: "/",
-        httpOnly: false,
-        secure: false,
-        sameSite: "Lax",
-      },
-    ]);
-
+  test("callback with code lands on /dashboard", async ({ authedPage }) => {
     // Intercept the OAuth callback before it reaches the Next.js route handler
     // and redirect straight to /dashboard, bypassing the real PKCE exchange.
-    // The mock Supabase server (started in globalSetup) handles the subsequent
-    // GET /auth/v1/user call made by the dashboard layout.
-    await page.route("**/auth/callback**", async (route) => {
-      await route.fulfill({
+    // The mock Supabase server handles the subsequent GET /auth/v1/user call.
+    await authedPage.route("**/auth/callback**", (route) =>
+      route.fulfill({
         status: 302,
         headers: { Location: "http://localhost:3000/dashboard" },
-      });
-    });
+      }),
+    );
 
-    await page.goto("/auth/callback?code=test-code&next=%2Fdashboard");
+    await authedPage.goto("/auth/callback?code=test-code&next=%2Fdashboard");
 
-    await page.waitForURL("**/dashboard");
+    await authedPage.waitForURL("**/dashboard");
     await expect(
-      page.getByRole("heading", { name: /welcome back/i }),
+      authedPage.getByRole("heading", { name: /welcome back/i }),
     ).toBeVisible();
   });
 });

--- a/apps/web/e2e/fixtures.ts
+++ b/apps/web/e2e/fixtures.ts
@@ -1,0 +1,80 @@
+import { type BrowserContext, type Page, test as base, expect } from "@playwright/test";
+
+import { MOCK_ACCESS_TOKEN } from "./mock-server";
+
+/**
+ * The cookie name supabase-js derives from the Supabase project URL:
+ *   `sb-${new URL(SUPABASE_URL).hostname.split(".")[0]}-auth-token`
+ *
+ * With NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 → "sb-127-auth-token".
+ * Update this constant if the mock URL ever changes.
+ */
+export const SUPABASE_COOKIE_NAME = "sb-127-auth-token";
+
+export const MOCK_SESSION = {
+  access_token: MOCK_ACCESS_TOKEN,
+  token_type: "bearer",
+  expires_in: 3600,
+  // Far-future expiry — the client will never attempt a token refresh.
+  expires_at: 9_999_999_999,
+  refresh_token: "mock-refresh-token",
+  user: {
+    id: "test-user-id",
+    aud: "authenticated",
+    role: "authenticated",
+    email: "test@example.com",
+    email_confirmed_at: "2024-01-01T00:00:00Z",
+    user_metadata: { full_name: "Test User", avatar_url: null },
+    app_metadata: { provider: "github" },
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+};
+
+/**
+ * Encodes a session into the cookie value format used by @supabase/ssr:
+ * "base64-" + base64url(JSON.stringify(session))
+ */
+export function encodeSession(session: typeof MOCK_SESSION): string {
+  return "base64-" + Buffer.from(JSON.stringify(session)).toString("base64url");
+}
+
+/**
+ * Injects the default mock session cookie into a Playwright browser context.
+ * Call this before navigating to any authenticated route.
+ */
+export async function injectAuthCookie(context: BrowserContext): Promise<void> {
+  await context.addCookies([
+    {
+      name: SUPABASE_COOKIE_NAME,
+      value: encodeSession(MOCK_SESSION),
+      domain: "localhost",
+      path: "/",
+      httpOnly: false,
+      secure: false,
+      sameSite: "Lax",
+    },
+  ]);
+}
+
+type Fixtures = {
+  /**
+   * A page whose browser context already has the mock session cookie set.
+   * Use this in any test that requires an authenticated user.
+   *
+   * @example
+   * test("dashboard loads", async ({ authedPage }) => {
+   *   await authedPage.goto("/dashboard");
+   * });
+   */
+  authedPage: Page;
+};
+
+export const test = base.extend<Fixtures>({
+  authedPage: async ({ page, context }, use) => {
+    await injectAuthCookie(context);
+    await use(page);
+  },
+});
+
+export { expect };

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -1,0 +1,5 @@
+import { startMockServer } from "./mock-server";
+
+export default async function globalSetup() {
+  await startMockServer();
+}

--- a/apps/web/e2e/global-teardown.ts
+++ b/apps/web/e2e/global-teardown.ts
@@ -1,0 +1,5 @@
+import { stopMockServer } from "./mock-server";
+
+export default async function globalTeardown() {
+  await stopMockServer();
+}

--- a/apps/web/e2e/landing.spec.ts
+++ b/apps/web/e2e/landing.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 test.describe("landing page — guest", () => {
   test("renders page content", async ({ page }) => {

--- a/apps/web/e2e/landing.spec.ts
+++ b/apps/web/e2e/landing.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("landing page — guest", () => {
+  test("renders page content", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      "Ship better commits",
+    );
+    await expect(
+      page.getByText("AI-assisted commit message generation"),
+    ).toBeVisible();
+  });
+
+  test("CTA links to /login", async ({ page }) => {
+    await page.goto("/");
+    const cta = page.getByRole("link", { name: /continue with github/i });
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute("href", "/login");
+  });
+});

--- a/apps/web/e2e/mock-server.ts
+++ b/apps/web/e2e/mock-server.ts
@@ -1,0 +1,102 @@
+import { createServer, IncomingMessage, Server, ServerResponse } from "node:http";
+
+export const MOCK_PORT = 54321;
+export const MOCK_ACCESS_TOKEN = "mock-access-token";
+
+const MOCK_USER = {
+  id: "test-user-id",
+  aud: "authenticated",
+  role: "authenticated",
+  email: "test@example.com",
+  email_confirmed_at: "2024-01-01T00:00:00Z",
+  user_metadata: { full_name: "Test User", avatar_url: null },
+  app_metadata: { provider: "github" },
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+// Pre-populated so the bypass path (page.route interception) works without
+// going through the real token-exchange endpoint.
+const validTokens = new Set<string>([MOCK_ACCESS_TOKEN]);
+let server: Server | null = null;
+
+function handleRequest(req: IncomingMessage, res: ServerResponse) {
+  const url = new URL(req.url ?? "/", `http://127.0.0.1:${MOCK_PORT}`);
+  const { pathname, searchParams } = url;
+
+  // POST /auth/v1/token?grant_type=pkce — exchange code for session
+  if (
+    req.method === "POST" &&
+    pathname === "/auth/v1/token" &&
+    searchParams.get("grant_type") === "pkce"
+  ) {
+    validTokens.add(MOCK_ACCESS_TOKEN);
+    const session = {
+      access_token: MOCK_ACCESS_TOKEN,
+      refresh_token: "mock-refresh-token",
+      expires_in: 3600,
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      token_type: "bearer",
+      user: MOCK_USER,
+    };
+    req.resume(); // drain body
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(session));
+    return;
+  }
+
+  // GET /auth/v1/user — return mock user when token is valid
+  if (req.method === "GET" && pathname === "/auth/v1/user") {
+    const auth = req.headers.authorization ?? "";
+    const token = auth.replace(/^Bearer\s+/i, "");
+    if (token && validTokens.has(token)) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(MOCK_USER));
+    } else {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: "not authenticated" }));
+    }
+    return;
+  }
+
+  // POST /auth/sync — API auth sync (always 200)
+  if (req.method === "POST" && pathname === "/auth/sync") {
+    req.resume();
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  // POST /auth/sign-in-event — always 200
+  if (req.method === "POST" && pathname === "/auth/sign-in-event") {
+    req.resume();
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.writeHead(404);
+  res.end();
+}
+
+export function startMockServer(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server = createServer(handleRequest);
+    server.listen(MOCK_PORT, "127.0.0.1", () => resolve());
+    server.on("error", reject);
+  });
+}
+
+export function stopMockServer(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!server) {
+      resolve();
+      return;
+    }
+    server.close((err) => {
+      server = null;
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,11 +12,14 @@
     "test": "node scripts/check-messages.mjs",
     "clean": "rm -rf .next .turbo *.tsbuildinfo",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "e2e": "playwright test",
+    "e2e:install": "playwright install --with-deps chromium"
   },
   "devDependencies": {
     "@commit-analyzer/eslint-config": "workspace:*",
     "@commit-analyzer/typescript-config": "workspace:*",
+    "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const MOCK_PORT = 54321;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "html",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  globalSetup: "./e2e/global-setup.ts",
+  globalTeardown: "./e2e/global-teardown.ts",
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: `http://127.0.0.1:${MOCK_PORT}`,
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: "mock-anon-key",
+      NEXT_PUBLIC_API_URL: `http://127.0.0.1:${MOCK_PORT}`,
+      NEXT_PUBLIC_APP_URL: "http://localhost:3000",
+    },
+  },
+});

--- a/apps/web/src/components/layout/sign-in-button.tsx
+++ b/apps/web/src/components/layout/sign-in-button.tsx
@@ -1,26 +1,18 @@
-"use client";
-
-import { ArrowRight, Github, Loader2 } from "lucide-react";
-import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { ArrowRight, Github } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 
 import { Button } from "@/components/ui/button";
+import { Link } from "@/i18n/navigation";
 
-export const SignInButton = () => {
-  const t = useTranslations("landing");
-  const [pending, setPending] = useState(false);
-
+export const SignInButton = async () => {
+  const t = await getTranslations("landing");
   return (
-    <form
-      action="/auth/sign-in"
-      method="post"
-      onSubmit={() => setPending(true)}
-    >
-      <Button type="submit" size="lg" disabled={pending}>
-        {pending ? <Loader2 className="animate-spin" aria-hidden="true" /> : <Github aria-hidden="true" />}
+    <Button asChild size="lg">
+      <Link href="/login">
+        <Github aria-hidden="true" />
         {t("cta")}
-        {!pending && <ArrowRight aria-hidden="true" />}
-      </Button>
-    </form>
+        <ArrowRight aria-hidden="true" />
+      </Link>
+    </Button>
   );
 };

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -11,6 +11,8 @@
   "include": [
     "next-env.d.ts",
     "next.config.ts",
+    "playwright.config.ts",
+    "e2e/**/*.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
     ".next/types/**/*.ts"

--- a/knip.json
+++ b/knip.json
@@ -18,11 +18,13 @@
         "src/app/**/layout.tsx",
         "src/app/**/loading.tsx",
         "src/app/**/error.tsx",
-        "src/app/**/route.ts"
+        "src/app/**/route.ts",
+        "playwright.config.ts",
+        "e2e/**/*.ts"
       ],
-      "project": ["src/**/*.{ts,tsx}"],
+      "project": ["src/**/*.{ts,tsx}", "e2e/**/*.ts", "playwright.config.ts"],
       "ignore": ["src/components/ui/**"],
-      "ignoreDependencies": ["tailwindcss", "tw-animate-css"]
+      "ignoreDependencies": ["tailwindcss", "tw-animate-css", "@playwright/test"]
     },
     "packages/contracts": {
       "entry": ["src/index.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,10 +203,10 @@ importers:
         version: 0.468.0(react@19.2.5)
       next:
         specifier: ^16.2.3
-        version: 16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.3(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-intl:
         specifier: ^4.9.1
-        version: 4.9.1(next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 4.9.1(next@16.2.3(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -244,6 +244,9 @@ importers:
       '@commit-analyzer/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -1500,6 +1503,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -3436,6 +3444,11 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4214,6 +4227,16 @@ packages:
 
   pino@9.14.0:
     resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   po-parser@2.1.1:
@@ -5966,6 +5989,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -8030,6 +8057,9 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -8555,14 +8585,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.9.1: {}
 
-  next-intl@4.9.1(next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
+  next-intl@4.9.1(next@16.2.3(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.2
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.24
       icu-minify: 4.9.1
       negotiator: 1.0.0
-      next: 16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.3(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-intl-swc-plugin-extractor: 4.9.1
       po-parser: 2.1.1
       react: 19.2.5
@@ -8577,7 +8607,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.3(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -8596,6 +8626,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.3
       '@next/swc-win32-arm64-msvc': 16.2.3
       '@next/swc-win32-x64-msvc': 16.2.3
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -8830,6 +8861,14 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 3.1.0
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   po-parser@2.1.1: {}
 


### PR DESCRIPTION
## Summary
- Add Playwright E2E tests for landing page (guest renders, CTA → /login) and auth flow (login card renders, stubbed OAuth → /dashboard)
- Mock HTTP server on port 54321 stubs Supabase auth endpoints so server-side `getUser()` resolves without a real Supabase project
- Cookie name derived as `sb-127-auth-token` from the mock URL `http://127.0.0.1:54321`
- Separate `e2e.yml` workflow with `workflow_dispatch` trigger
- `SignInButton` converted to server component with `<Link href="/login">` so the CTA is a real anchor

Closes #24