### PR TITLE
feat(T-1.15): throttler tiers + global guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "@nestjs/core": "^11",
     "@nestjs/cqrs": "^11.0.3",
     "@nestjs/platform-express": "^11",
+    "@nestjs/throttler": "^6.5.0",
     "@octokit/plugin-retry": "^8.1.0",
     "@octokit/plugin-throttling": "^11.0.3",
     "@octokit/rest": "^22.0.1",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,6 +3,7 @@ import { Module } from "@nestjs/common";
 import { CacheModule } from "./common/cache/cache.module.js";
 import { RequestClsModule } from "./common/cls.js";
 import { DatabaseModule } from "./common/database/database.module.js";
+import { ThrottlerConfigModule } from "./common/throttler/index.js";
 import { AuditModule } from "./modules/audit/audit.module.js";
 import { AuthModule } from "./modules/auth/auth.module.js";
 import { HealthController } from "./modules/health/health.controller.js";
@@ -13,6 +14,7 @@ import { ReposModule } from "./modules/repos/repos.module.js";
     RequestClsModule,
     DatabaseModule,
     CacheModule,
+    ThrottlerConfigModule,
     AuthModule,
     AuditModule,
     ReposModule,

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,7 +3,7 @@ import { Module } from "@nestjs/common";
 import { CacheModule } from "./common/cache/cache.module.js";
 import { RequestClsModule } from "./common/cls.js";
 import { DatabaseModule } from "./common/database/database.module.js";
-import { ThrottlerConfigModule } from "./common/throttler/index.js";
+import { ThrottlerConfigModule } from "./common/throttler/throttler.module.js";
 import { AuditModule } from "./modules/audit/audit.module.js";
 import { AuthModule } from "./modules/auth/auth.module.js";
 import { HealthController } from "./modules/health/health.controller.js";

--- a/apps/api/src/common/throttler/index.ts
+++ b/apps/api/src/common/throttler/index.ts
@@ -1,3 +1,0 @@
-export { ThrottlerConfigModule } from "./throttler.module.js";
-export { THROTTLE_TIERS, type ThrottleTier } from "./tiers.js";
-export { UserThrottlerGuard } from "./user-throttler.guard.js";

--- a/apps/api/src/common/throttler/index.ts
+++ b/apps/api/src/common/throttler/index.ts
@@ -1,0 +1,3 @@
+export { ThrottlerConfigModule } from "./throttler.module.js";
+export { THROTTLE_TIERS, type ThrottleTier } from "./tiers.js";
+export { UserThrottlerGuard } from "./user-throttler.guard.js";

--- a/apps/api/src/common/throttler/throttle-tier.decorator.ts
+++ b/apps/api/src/common/throttler/throttle-tier.decorator.ts
@@ -1,0 +1,27 @@
+import { applyDecorators } from "@nestjs/common";
+import { SkipThrottle, Throttle } from "@nestjs/throttler";
+
+import { THROTTLE_TIERS, type ThrottleTier } from "./tiers.js";
+
+/**
+ * Activates a single named throttle tier and skips the rest.
+ *
+ * Sets explicit skip=false for the active tier so method-level decorators
+ * correctly override class-level skip metadata (the guard uses
+ * `getAllAndOverride` which falls through to class when handler is unset).
+ */
+export const ThrottleTierDecorator = (tier: ThrottleTier) => {
+  const skip: Record<string, boolean> = {};
+  const throttle: Record<string, { limit: number; ttl: number }> = {};
+
+  for (const [name, def] of Object.entries(THROTTLE_TIERS)) {
+    if (name === tier) {
+      skip[name] = false;
+      throttle[name] = { limit: def.limit, ttl: def.ttl };
+    } else {
+      skip[name] = true;
+    }
+  }
+
+  return applyDecorators(SkipThrottle(skip), Throttle(throttle));
+};

--- a/apps/api/src/common/throttler/throttler.integration.test.ts
+++ b/apps/api/src/common/throttler/throttler.integration.test.ts
@@ -1,0 +1,159 @@
+import type { Server } from "node:http";
+
+import { Controller, Get, type INestApplication, Module, Post } from "@nestjs/common";
+import { APP_GUARD } from "@nestjs/core";
+import { Test } from "@nestjs/testing";
+import { Throttle, ThrottlerModule } from "@nestjs/throttler";
+import { ClsModule } from "nestjs-cls";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { THROTTLE_TIERS } from "./tiers.js";
+import { UserThrottlerGuard } from "./user-throttler.guard.js";
+
+// ── Stub controllers ──────────────────────────────────────────────
+
+@Controller()
+class DefaultController {
+  @Get("me")
+  me(): { ok: true } {
+    return { ok: true };
+  }
+}
+
+@Controller()
+class AuthController {
+  @Throttle({
+    default: {
+      limit: THROTTLE_TIERS.auth.limit,
+      ttl: THROTTLE_TIERS.auth.ttl,
+    },
+  })
+  @Post("api-keys")
+  create(): { ok: true } {
+    return { ok: true };
+  }
+}
+
+@Controller()
+class GenerateController {
+  @Throttle({
+    default: {
+      limit: THROTTLE_TIERS.generate.limit,
+      ttl: THROTTLE_TIERS.generate.ttl,
+    },
+  })
+  @Post("generate")
+  generate(): { ok: true } {
+    return { ok: true };
+  }
+}
+
+// ── Test module ───────────────────────────────────────────────────
+
+@Module({
+  imports: [
+    ClsModule.forRoot({ global: true, middleware: { mount: true } }),
+    ThrottlerModule.forRoot([
+      {
+        name: THROTTLE_TIERS.default.name,
+        limit: THROTTLE_TIERS.default.limit,
+        ttl: THROTTLE_TIERS.default.ttl,
+      },
+    ]),
+  ],
+  controllers: [DefaultController, AuthController, GenerateController],
+  providers: [{ provide: APP_GUARD, useClass: UserThrottlerGuard }],
+})
+class TestAppModule {}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe("throttler integration", () => {
+  let app: INestApplication;
+  let server: Server;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [TestAppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    server = app.getHttpServer() as Server;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("returns rate-limit headers on 2xx", async () => {
+    const res = await request(server)
+      .get("/me")
+      .set("x-forwarded-for", "10.99.0.1");
+    expect(res.status).toBe(200);
+    expect(res.headers).toHaveProperty("x-ratelimit-limit");
+    expect(res.headers).toHaveProperty("x-ratelimit-remaining");
+  });
+
+  it("11th POST /api-keys within 60s returns 429", async () => {
+    for (let i = 0; i < 10; i++) {
+      const res = await request(server)
+        .post("/api-keys")
+        .set("x-forwarded-for", "10.0.0.42");
+      expect(res.status).toBe(201);
+    }
+
+    const blocked = await request(server)
+      .post("/api-keys")
+      .set("x-forwarded-for", "10.0.0.42");
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers).toHaveProperty("retry-after");
+  });
+
+  it("21st POST /generate within 60s returns 429; 20th succeeds", async () => {
+    for (let i = 0; i < 20; i++) {
+      const res = await request(server)
+        .post("/generate")
+        .set("x-forwarded-for", "10.0.0.99");
+      expect(res.status).toBe(201);
+    }
+
+    const blocked = await request(server)
+      .post("/generate")
+      .set("x-forwarded-for", "10.0.0.99");
+    expect(blocked.status).toBe(429);
+  });
+
+  it("GET /me under default tier allows 60 requests", async () => {
+    for (let i = 0; i < 60; i++) {
+      const res = await request(server)
+        .get("/me")
+        .set("x-forwarded-for", "10.0.0.200");
+      expect(res.status).toBe(200);
+    }
+
+    const blocked = await request(server)
+      .get("/me")
+      .set("x-forwarded-for", "10.0.0.200");
+    expect(blocked.status).toBe(429);
+  });
+
+  it("keying falls back to IP — different IPs are independent", async () => {
+    for (let i = 0; i < 10; i++) {
+      await request(server)
+        .post("/api-keys")
+        .set("x-forwarded-for", "10.0.0.1");
+    }
+
+    const blocked = await request(server)
+      .post("/api-keys")
+      .set("x-forwarded-for", "10.0.0.1");
+    expect(blocked.status).toBe(429);
+
+    const ok = await request(server)
+      .post("/api-keys")
+      .set("x-forwarded-for", "10.0.0.2");
+    expect(ok.status).toBe(201);
+  });
+});

--- a/apps/api/src/common/throttler/throttler.integration.test.ts
+++ b/apps/api/src/common/throttler/throttler.integration.test.ts
@@ -101,6 +101,8 @@ describe("throttler integration", () => {
       .post("/api-keys")
       .set("x-forwarded-for", "10.0.0.42");
     expect(blocked.status).toBe(429);
+    // v6 named tiers suffix all headers: Retry-After-{name}, X-RateLimit-Limit-{name}
+    // Clients must parse the tier-suffixed header, not bare Retry-After.
     expect(blocked.headers).toHaveProperty("retry-after-auth");
   });
 

--- a/apps/api/src/common/throttler/throttler.integration.test.ts
+++ b/apps/api/src/common/throttler/throttler.integration.test.ts
@@ -3,17 +3,19 @@ import type { Server } from "node:http";
 import { Controller, Get, type INestApplication, Module, Post } from "@nestjs/common";
 import { APP_GUARD } from "@nestjs/core";
 import { Test } from "@nestjs/testing";
-import { Throttle, ThrottlerModule } from "@nestjs/throttler";
+import { ThrottlerModule } from "@nestjs/throttler";
 import { ClsModule } from "nestjs-cls";
 import request from "supertest";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { ThrottleTierDecorator } from "./throttle-tier.decorator.js";
 import { THROTTLE_TIERS } from "./tiers.js";
 import { UserThrottlerGuard } from "./user-throttler.guard.js";
 
 // ── Stub controllers ──────────────────────────────────────────────
 
 @Controller()
+@ThrottleTierDecorator("default")
 class DefaultController {
   @Get("me")
   me(): { ok: true } {
@@ -22,13 +24,9 @@ class DefaultController {
 }
 
 @Controller()
+@ThrottleTierDecorator("default")
 class AuthController {
-  @Throttle({
-    default: {
-      limit: THROTTLE_TIERS.auth.limit,
-      ttl: THROTTLE_TIERS.auth.ttl,
-    },
-  })
+  @ThrottleTierDecorator("auth")
   @Post("api-keys")
   create(): { ok: true } {
     return { ok: true };
@@ -36,30 +34,25 @@ class AuthController {
 }
 
 @Controller()
+@ThrottleTierDecorator("default")
 class GenerateController {
-  @Throttle({
-    default: {
-      limit: THROTTLE_TIERS.generate.limit,
-      ttl: THROTTLE_TIERS.generate.ttl,
-    },
-  })
+  @ThrottleTierDecorator("generate")
   @Post("generate")
   generate(): { ok: true } {
     return { ok: true };
   }
 }
 
-// ── Test module ───────────────────────────────────────────────────
+// ── Test module (registers all four named tiers) ─────────────────
 
 @Module({
   imports: [
     ClsModule.forRoot({ global: true, middleware: { mount: true } }),
     ThrottlerModule.forRoot([
-      {
-        name: THROTTLE_TIERS.default.name,
-        limit: THROTTLE_TIERS.default.limit,
-        ttl: THROTTLE_TIERS.default.ttl,
-      },
+      THROTTLE_TIERS.default,
+      THROTTLE_TIERS.auth,
+      THROTTLE_TIERS.generate,
+      THROTTLE_TIERS.analytics,
     ]),
   ],
   controllers: [DefaultController, AuthController, GenerateController],
@@ -96,7 +89,7 @@ describe("throttler integration", () => {
     expect(res.headers).toHaveProperty("x-ratelimit-remaining");
   });
 
-  it("11th POST /api-keys within 60s returns 429", async () => {
+  it("11th POST /api-keys within 60s returns 429 (auth tier)", async () => {
     for (let i = 0; i < 10; i++) {
       const res = await request(server)
         .post("/api-keys")
@@ -108,10 +101,10 @@ describe("throttler integration", () => {
       .post("/api-keys")
       .set("x-forwarded-for", "10.0.0.42");
     expect(blocked.status).toBe(429);
-    expect(blocked.headers).toHaveProperty("retry-after");
+    expect(blocked.headers).toHaveProperty("retry-after-auth");
   });
 
-  it("21st POST /generate within 60s returns 429; 20th succeeds", async () => {
+  it("21st POST /generate within 60s returns 429 (generate tier)", async () => {
     for (let i = 0; i < 20; i++) {
       const res = await request(server)
         .post("/generate")

--- a/apps/api/src/common/throttler/throttler.module.ts
+++ b/apps/api/src/common/throttler/throttler.module.ts
@@ -1,0 +1,20 @@
+import { Module } from "@nestjs/common";
+import { APP_GUARD } from "@nestjs/core";
+import { ThrottlerModule } from "@nestjs/throttler";
+
+import { THROTTLE_TIERS } from "./tiers.js";
+import { UserThrottlerGuard } from "./user-throttler.guard.js";
+
+@Module({
+  imports: [
+    ThrottlerModule.forRoot([
+      {
+        name: THROTTLE_TIERS.default.name,
+        limit: THROTTLE_TIERS.default.limit,
+        ttl: THROTTLE_TIERS.default.ttl,
+      },
+    ]),
+  ],
+  providers: [{ provide: APP_GUARD, useClass: UserThrottlerGuard }],
+})
+export class ThrottlerConfigModule {}

--- a/apps/api/src/common/throttler/throttler.module.ts
+++ b/apps/api/src/common/throttler/throttler.module.ts
@@ -8,11 +8,10 @@ import { UserThrottlerGuard } from "./user-throttler.guard.js";
 @Module({
   imports: [
     ThrottlerModule.forRoot([
-      {
-        name: THROTTLE_TIERS.default.name,
-        limit: THROTTLE_TIERS.default.limit,
-        ttl: THROTTLE_TIERS.default.ttl,
-      },
+      THROTTLE_TIERS.default,
+      THROTTLE_TIERS.auth,
+      THROTTLE_TIERS.generate,
+      THROTTLE_TIERS.analytics,
     ]),
   ],
   providers: [{ provide: APP_GUARD, useClass: UserThrottlerGuard }],

--- a/apps/api/src/common/throttler/tiers.ts
+++ b/apps/api/src/common/throttler/tiers.ts
@@ -1,0 +1,8 @@
+export const THROTTLE_TIERS = {
+  default: { name: "default", limit: 60, ttl: 60_000 },
+  auth: { name: "auth", limit: 10, ttl: 60_000 },
+  generate: { name: "generate", limit: 20, ttl: 60_000 },
+  analytics: { name: "analytics", limit: 120, ttl: 60_000 },
+} as const;
+
+export type ThrottleTier = keyof typeof THROTTLE_TIERS;

--- a/apps/api/src/common/throttler/user-throttler.guard.ts
+++ b/apps/api/src/common/throttler/user-throttler.guard.ts
@@ -1,0 +1,30 @@
+import { Injectable } from "@nestjs/common";
+import { ThrottlerGuard } from "@nestjs/throttler";
+
+import { getAuthUserId } from "../request-context.js";
+
+/**
+ * Keys rate-limiting by authenticated userId (from CLS, populated by
+ * SupabaseAuthGuard / ApiKeyGuard). Falls back to x-forwarded-for / IP
+ * for pre-auth error paths.
+ */
+@Injectable()
+export class UserThrottlerGuard extends ThrottlerGuard {
+  // Must match parent's async signature (returns Promise<string>)
+  // eslint-disable-next-line @typescript-eslint/require-await
+  protected override async getTracker(req: Record<string, unknown>): Promise<string> {
+    const userId = getAuthUserId();
+    if (userId) return `user:${userId}`;
+
+    const forwarded = req.headers
+      ? (req.headers as Record<string, string | string[] | undefined>)[
+          "x-forwarded-for"
+        ]
+      : undefined;
+    if (typeof forwarded === "string") return forwarded.split(",")[0]!.trim();
+    if (Array.isArray(forwarded) && forwarded.length > 0)
+      return forwarded[0]!.trim();
+
+    return (req as Record<string, string>).ip ?? "unknown";
+  }
+}

--- a/apps/api/src/common/throttler/user-throttler.guard.ts
+++ b/apps/api/src/common/throttler/user-throttler.guard.ts
@@ -16,6 +16,10 @@ export class UserThrottlerGuard extends ThrottlerGuard {
     const userId = getAuthUserId();
     if (userId) return `user:${userId}`;
 
+    // NOTE: x-forwarded-for is spoofable without `trust proxy` configured in
+    // Express. Acceptable for now — authenticated requests key by userId above;
+    // IP fallback only applies to pre-auth error paths. Enable `trust proxy`
+    // when deploying behind a reverse proxy (Railway / Vercel).
     const forwarded = req.headers
       ? (req.headers as Record<string, string | string[] | undefined>)[
           "x-forwarded-for"

--- a/apps/api/src/modules/audit/audit.controller.ts
+++ b/apps/api/src/modules/audit/audit.controller.ts
@@ -2,6 +2,7 @@ import { auditContract } from "@commit-analyzer/contracts";
 import { Controller, UseGuards } from "@nestjs/common";
 import { TsRestHandler, tsRestHandler } from "@ts-rest/nest";
 
+import { ThrottleTierDecorator } from "../../common/throttler/throttle-tier.decorator.js";
 import { CurrentUser } from "../auth/current-user.decorator.js";
 import { SupabaseAuthGuard } from "../auth/supabase-auth.guard.js";
 
@@ -10,6 +11,7 @@ import { AuditService } from "./audit.service.js";
 
 @Controller()
 @UseGuards(SupabaseAuthGuard)
+@ThrottleTierDecorator("default")
 export class AuditController {
   constructor(private readonly auditService: AuditService) {}
 

--- a/apps/api/src/modules/auth/auth-ts-rest.controller.ts
+++ b/apps/api/src/modules/auth/auth-ts-rest.controller.ts
@@ -1,6 +1,9 @@
 import { authContract } from "@commit-analyzer/contracts";
 import { Controller, UseGuards } from "@nestjs/common";
+import { Throttle } from "@nestjs/throttler";
 import { TsRestHandler, tsRestHandler } from "@ts-rest/nest";
+
+import { THROTTLE_TIERS } from "../../common/throttler/tiers.js";
 
 import { toApiKeyDto, toUserDto } from "./auth.mappers.js";
 import { AuthService } from "./auth.service.js";
@@ -12,6 +15,7 @@ import { SupabaseAuthGuard } from "./supabase-auth.guard.js";
 export class AuthTsRestController {
   constructor(private readonly authService: AuthService) {}
 
+  // GET /me — default tier (not auth), per 05-api-contracts.md §5
   @TsRestHandler(authContract.me)
   me(@CurrentUser() userId: string): unknown {
     return tsRestHandler(authContract.me, async () => {
@@ -39,6 +43,7 @@ export class AuthTsRestController {
     });
   }
 
+  @Throttle({ default: { limit: THROTTLE_TIERS.auth.limit, ttl: THROTTLE_TIERS.auth.ttl } })
   @TsRestHandler(authContract.apiKeys.create)
   createApiKey(@CurrentUser() userId: string): unknown {
     return tsRestHandler(authContract.apiKeys.create, async ({ body }) => {

--- a/apps/api/src/modules/auth/auth-ts-rest.controller.ts
+++ b/apps/api/src/modules/auth/auth-ts-rest.controller.ts
@@ -1,9 +1,8 @@
 import { authContract } from "@commit-analyzer/contracts";
 import { Controller, UseGuards } from "@nestjs/common";
-import { Throttle } from "@nestjs/throttler";
 import { TsRestHandler, tsRestHandler } from "@ts-rest/nest";
 
-import { THROTTLE_TIERS } from "../../common/throttler/tiers.js";
+import { ThrottleTierDecorator } from "../../common/throttler/throttle-tier.decorator.js";
 
 import { toApiKeyDto, toUserDto } from "./auth.mappers.js";
 import { AuthService } from "./auth.service.js";
@@ -12,6 +11,7 @@ import { SupabaseAuthGuard } from "./supabase-auth.guard.js";
 
 @Controller()
 @UseGuards(SupabaseAuthGuard)
+@ThrottleTierDecorator("default")
 export class AuthTsRestController {
   constructor(private readonly authService: AuthService) {}
 
@@ -43,7 +43,7 @@ export class AuthTsRestController {
     });
   }
 
-  @Throttle({ default: { limit: THROTTLE_TIERS.auth.limit, ttl: THROTTLE_TIERS.auth.ttl } })
+  @ThrottleTierDecorator("auth")
   @TsRestHandler(authContract.apiKeys.create)
   createApiKey(@CurrentUser() userId: string): unknown {
     return tsRestHandler(authContract.apiKeys.create, async ({ body }) => {

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -9,6 +9,8 @@ import {
 } from "@nestjs/common";
 import { EventBus } from "@nestjs/cqrs";
 
+import { ThrottleTierDecorator } from "../../common/throttler/throttle-tier.decorator.js";
+
 import { signInEventSchema } from "./auth.schemas.js";
 import { CurrentUser } from "./current-user.decorator.js";
 import { AuthLoggedInEvent } from "./events/auth-logged-in.event.js";
@@ -17,6 +19,7 @@ import { SupabaseAuthGuard } from "./supabase-auth.guard.js";
 
 @Controller("auth")
 @UseGuards(SupabaseAuthGuard)
+@ThrottleTierDecorator("default")
 export class AuthController {
   constructor(@Inject(EventBus) private readonly eventBus: EventBus) {}
 

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get } from "@nestjs/common";
+import { SkipThrottle } from "@nestjs/throttler";
 
 @Controller("health")
+@SkipThrottle()
 export class HealthController {
   @Get()
   check(): { status: "ok" } {

--- a/apps/api/src/modules/repos/repos.controller.ts
+++ b/apps/api/src/modules/repos/repos.controller.ts
@@ -2,6 +2,7 @@ import { reposContract } from "@commit-analyzer/contracts";
 import { Controller, UseGuards } from "@nestjs/common";
 import { TsRestHandler, tsRestHandler } from "@ts-rest/nest";
 
+import { ThrottleTierDecorator } from "../../common/throttler/throttle-tier.decorator.js";
 import { CurrentUser } from "../auth/current-user.decorator.js";
 import { SupabaseAuthGuard } from "../auth/supabase-auth.guard.js";
 
@@ -10,6 +11,7 @@ import { ReposService } from "./repos.service.js";
 
 @Controller()
 @UseGuards(SupabaseAuthGuard)
+@ThrottleTierDecorator("default")
 export class ReposController {
   constructor(private readonly repos: ReposService) {}
 

--- a/packages/contracts/src/audit.contract.test.ts
+++ b/packages/contracts/src/audit.contract.test.ts
@@ -61,6 +61,6 @@ describe("auditContract", () => {
   });
 
   it("tags with jwt auth", () => {
-    expect(auditContract.list.metadata).toEqual({ auth: "jwt" });
+    expect(auditContract.list.metadata).toEqual({ auth: "jwt", rateLimit: "default" });
   });
 });

--- a/packages/contracts/src/audit.contract.ts
+++ b/packages/contracts/src/audit.contract.ts
@@ -48,7 +48,7 @@ export const auditContract = c.router(
         401: errorEnvelopeSchema,
       },
       summary: "List audit events for the current user",
-      metadata: { auth: "jwt" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
     },
   },
   { strictStatusCodes: true },

--- a/packages/contracts/src/auth.contract.test.ts
+++ b/packages/contracts/src/auth.contract.test.ts
@@ -81,9 +81,9 @@ describe("authContract", () => {
   });
 
   it("tags every auth endpoint with jwt", () => {
-    expect(authContract.me.metadata).toEqual({ auth: "jwt" });
-    expect(authContract.apiKeys.list.metadata).toEqual({ auth: "jwt" });
-    expect(authContract.apiKeys.create.metadata).toEqual({ auth: "jwt" });
-    expect(authContract.apiKeys.revoke.metadata).toEqual({ auth: "jwt" });
+    expect(authContract.me.metadata).toEqual({ auth: "jwt", rateLimit: "default" });
+    expect(authContract.apiKeys.list.metadata).toEqual({ auth: "jwt", rateLimit: "default" });
+    expect(authContract.apiKeys.create.metadata).toEqual({ auth: "jwt", rateLimit: "auth" });
+    expect(authContract.apiKeys.revoke.metadata).toEqual({ auth: "jwt", rateLimit: "default" });
   });
 });

--- a/packages/contracts/src/auth.contract.ts
+++ b/packages/contracts/src/auth.contract.ts
@@ -47,7 +47,7 @@ export const authContract = c.router(
         401: errorEnvelopeSchema,
       },
       summary: "Get the currently authenticated user",
-      metadata: { auth: "jwt" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
     },
     sync: {
       method: "POST",
@@ -59,7 +59,7 @@ export const authContract = c.router(
       },
       summary:
         "Mirror the authenticated Supabase user into public.users and store the encrypted GitHub provider token",
-      metadata: { auth: "jwt" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
     },
     apiKeys: c.router(
       {
@@ -71,7 +71,7 @@ export const authContract = c.router(
             401: errorEnvelopeSchema,
           },
           summary: "List API keys for the current user",
-          metadata: { auth: "jwt" } as const,
+          metadata: { auth: "jwt", rateLimit: "default" } as const,
         },
         create: {
           method: "POST",
@@ -83,7 +83,7 @@ export const authContract = c.router(
             401: errorEnvelopeSchema,
           },
           summary: "Create a new API key (plaintext returned once)",
-          metadata: { auth: "jwt" } as const,
+          metadata: { auth: "jwt", rateLimit: "auth" } as const,
         },
         revoke: {
           method: "DELETE",
@@ -96,7 +96,7 @@ export const authContract = c.router(
             404: errorEnvelopeSchema,
           },
           summary: "Revoke an API key",
-          metadata: { auth: "jwt" } as const,
+          metadata: { auth: "jwt", rateLimit: "default" } as const,
         },
       },
       { pathPrefix: "" },

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -42,3 +42,5 @@ export {
 
 export { errorEnvelopeSchema } from "./shared/error.js";
 export type { ErrorEnvelope } from "./shared/error.js";
+
+export type { RateLimitTier, RouteMetadata } from "./shared/metadata.js";

--- a/packages/contracts/src/repos.contract.test.ts
+++ b/packages/contracts/src/repos.contract.test.ts
@@ -75,9 +75,9 @@ describe("reposContract", () => {
   });
 
   it("tags every repo endpoint with jwt", () => {
-    expect(reposContract.listGithub.metadata).toEqual({ auth: "jwt" });
-    expect(reposContract.listConnected.metadata).toEqual({ auth: "jwt" });
-    expect(reposContract.connect.metadata).toEqual({ auth: "jwt" });
-    expect(reposContract.disconnect.metadata).toEqual({ auth: "jwt" });
+    expect(reposContract.listGithub.metadata).toEqual({ auth: "jwt", rateLimit: "default" });
+    expect(reposContract.listConnected.metadata).toEqual({ auth: "jwt", rateLimit: "default" });
+    expect(reposContract.connect.metadata).toEqual({ auth: "jwt", rateLimit: "default" });
+    expect(reposContract.disconnect.metadata).toEqual({ auth: "jwt", rateLimit: "default" });
   });
 });

--- a/packages/contracts/src/repos.contract.ts
+++ b/packages/contracts/src/repos.contract.ts
@@ -45,7 +45,7 @@ export const reposContract = c.router(
         502: errorEnvelopeSchema,
       },
       summary: "List the authenticated user's GitHub repositories",
-      metadata: { auth: "jwt" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
     },
     listConnected: {
       method: "GET",
@@ -55,7 +55,7 @@ export const reposContract = c.router(
         401: errorEnvelopeSchema,
       },
       summary: "List repositories connected to the current user",
-      metadata: { auth: "jwt" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
     },
     connect: {
       method: "POST",
@@ -71,7 +71,7 @@ export const reposContract = c.router(
         409: errorEnvelopeSchema,
       },
       summary: "Connect a GitHub repository to the current user",
-      metadata: { auth: "jwt" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
     },
     disconnect: {
       method: "DELETE",
@@ -84,7 +84,7 @@ export const reposContract = c.router(
         404: errorEnvelopeSchema,
       },
       summary: "Disconnect a repository",
-      metadata: { auth: "jwt" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
     },
   },
   { strictStatusCodes: true },

--- a/packages/contracts/src/shared/metadata.ts
+++ b/packages/contracts/src/shared/metadata.ts
@@ -1,6 +1,6 @@
 export type RateLimitTier = "default" | "auth" | "generate" | "analytics";
 
 export interface RouteMetadata {
-  readonly auth: "jwt" | "jwtOrApiKey" | "none";
+  readonly auth: "jwt" | "apiKey" | "jwtOrApiKey" | "public";
   readonly rateLimit: RateLimitTier;
 }

--- a/packages/contracts/src/shared/metadata.ts
+++ b/packages/contracts/src/shared/metadata.ts
@@ -1,0 +1,6 @@
+export type RateLimitTier = "default" | "auth" | "generate" | "analytics";
+
+export interface RouteMetadata {
+  readonly auth: "jwt" | "jwtOrApiKey" | "none";
+  readonly rateLimit: RateLimitTier;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11
         version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+      '@nestjs/throttler':
+        specifier: ^6.5.0
+        version: 6.5.0(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.2.2)
       '@octokit/plugin-retry':
         specifier: ^8.1.0
         version: 8.1.0(@octokit/core@7.0.6)
@@ -1049,6 +1052,13 @@ packages:
         optional: true
       '@nestjs/platform-express':
         optional: true
+
+  '@nestjs/throttler@6.5.0':
+    resolution: {integrity: sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
 
   '@next/env@16.2.3':
     resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
@@ -5666,6 +5676,12 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nestjs/platform-express': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+
+  '@nestjs/throttler@6.5.0(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
 
   '@next/env@16.2.3': {}
 


### PR DESCRIPTION
## Summary
- Install `@nestjs/throttler` with four named rate-limit tiers: `default` (60/60s), `auth` (10/60s), `generate` (20/60s), `analytics` (120/60s)
- Custom `UserThrottlerGuard` keyed by `userId` from CLS (populated by `SupabaseAuthGuard`/`ApiKeyGuard`), falling back to `x-forwarded-for` / IP pre-auth
- Registered as global `APP_GUARD` via `ThrottlerConfigModule`
- `ThrottleTierDecorator(tier)` helper activates one named tier and skips the rest — applied at class level (default) with method-level overrides
- `@SkipThrottle()` on health endpoint
- Contract metadata extended with `rateLimit` field as single source of truth (`RouteMetadata` type exported from contracts)
- Rate-limit headers set automatically; named tiers use suffixed headers (`X-RateLimit-Limit-auth`, `Retry-After-auth`)

## Deferred to follow-up PRs
These endpoints don't exist on `main` yet — apply `@ThrottleTierDecorator` when their controllers land:
- `PUT /llm-keys/:provider` → `auth` tier
- `POST /generate` → `generate` tier
- `GET /repos/:id/analytics/*` → `analytics` tier

## Test plan
- [x] Integration test: 11th `POST /api-keys` within 60s from same IP → 429 (auth tier)
- [x] Integration test: 21st `POST /generate` within 60s → 429; 20th succeeds (generate tier)
- [x] `GET /me` under `default` tier (allows 60 req/60s, not auth's 10)
- [x] Rate-limit headers present on 2xx responses
- [x] Keying falls back to IP — different IPs have independent counters

Closes #26