### PR TITLE
feat(T-2.3): commit, quality score, sync job entities

### DIFF
--- a/packages/database/src/entities/commit-quality-score.entity.ts
+++ b/packages/database/src/entities/commit-quality-score.entity.ts
@@ -1,0 +1,27 @@
+import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn } from "typeorm";
+
+import { Commit } from "./commit.entity.js";
+
+@Entity({ name: "commit_quality_scores" })
+export class CommitQualityScore {
+  @PrimaryColumn("text")
+  commitSha!: string;
+
+  @OneToOne(() => Commit, (commit) => commit.qualityScore, {
+    onDelete: "CASCADE",
+  })
+  @JoinColumn({ name: "commit_sha" })
+  commit!: Commit;
+
+  @Column("bool", { default: false })
+  ccValid!: boolean;
+
+  @Column("smallint")
+  score!: number;
+
+  @Column("jsonb", { default: {} })
+  breakdown!: Record<string, unknown>;
+
+  @Column("timestamptz")
+  scoredAt!: Date;
+}

--- a/packages/database/src/entities/commit-quality-score.entity.ts
+++ b/packages/database/src/entities/commit-quality-score.entity.ts
@@ -1,27 +1,50 @@
-import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn } from "typeorm";
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
 
 import { Commit } from "./commit.entity.js";
 
 @Entity({ name: "commit_quality_scores" })
 export class CommitQualityScore {
-  @PrimaryColumn("text")
-  commitSha!: string;
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column("uuid", { unique: true })
+  commitId!: string;
 
   @OneToOne(() => Commit, (commit) => commit.qualityScore, {
     onDelete: "CASCADE",
   })
-  @JoinColumn({ name: "commit_sha" })
+  @JoinColumn({ name: "commit_id" })
   commit!: Commit;
 
   @Column("bool", { default: false })
-  ccValid!: boolean;
+  isConventional!: boolean;
 
-  @Column("smallint")
-  score!: number;
+  @Column("text", { nullable: true })
+  ccType!: string | null;
+
+  @Column("text", { nullable: true })
+  ccScope!: string | null;
+
+  @Column("int", { nullable: true })
+  subjectLength!: number | null;
+
+  @Column("bool", { default: false })
+  hasBody!: boolean;
+
+  @Column("bool", { default: false })
+  hasFooter!: boolean;
+
+  @Index("commit_quality_scores_overall_score_idx")
+  @Column("int")
+  overallScore!: number;
 
   @Column("jsonb", { default: {} })
-  breakdown!: Record<string, unknown>;
-
-  @Column("timestamptz")
-  scoredAt!: Date;
+  details!: Record<string, unknown>;
 }

--- a/packages/database/src/entities/commit.entity.ts
+++ b/packages/database/src/entities/commit.entity.ts
@@ -5,40 +5,51 @@ import {
   JoinColumn,
   ManyToOne,
   OneToOne,
-  PrimaryColumn,
+  PrimaryGeneratedColumn,
+  Unique,
 } from "typeorm";
 
 import { CommitQualityScore } from "./commit-quality-score.entity.js";
 import { Repository } from "./repository.entity.js";
 
 @Entity({ name: "commits" })
-@Index("commits_repo_authored_idx", ["repoId", "authoredAt"])
-@Index("commits_repo_author_email_idx", ["repoId", "authorEmail"])
+@Unique("commits_repo_sha_uk", ["repositoryId", "sha"])
+@Index("commits_repo_authored_idx", ["repositoryId", "authoredAt"])
 export class Commit {
-  @PrimaryColumn("text")
-  sha!: string;
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
 
   @Column("uuid")
-  repoId!: string;
+  repositoryId!: string;
 
   @ManyToOne(() => Repository, { onDelete: "CASCADE" })
-  @JoinColumn({ name: "repo_id" })
+  @JoinColumn({ name: "repository_id" })
   repository!: Repository;
 
   @Column("text")
-  authorEmail!: string;
+  sha!: string;
 
   @Column("text")
   authorName!: string;
 
-  @Column("timestamptz")
-  authoredAt!: Date;
+  @Index("commits_author_email_idx")
+  @Column("text")
+  authorEmail!: string;
 
   @Column("text")
   message!: string;
 
+  @Column("text", { nullable: true })
+  subject!: string | null;
+
+  @Column("text", { nullable: true })
+  body!: string | null;
+
+  @Column("text", { nullable: true })
+  footer!: string | null;
+
   @Column("int", { default: 0 })
-  additions!: number;
+  insertions!: number;
 
   @Column("int", { default: 0 })
   deletions!: number;
@@ -46,9 +57,9 @@ export class Commit {
   @Column("int", { default: 0 })
   filesChanged!: number;
 
-  @Column("smallint", { default: 1 })
-  parentCount!: number;
+  @Column("timestamptz")
+  authoredAt!: Date;
 
   @OneToOne(() => CommitQualityScore, (score) => score.commit)
-  qualityScore!: CommitQualityScore | null;
+  qualityScore?: CommitQualityScore;
 }

--- a/packages/database/src/entities/commit.entity.ts
+++ b/packages/database/src/entities/commit.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToOne,
+  PrimaryColumn,
+} from "typeorm";
+
+import { CommitQualityScore } from "./commit-quality-score.entity.js";
+import { Repository } from "./repository.entity.js";
+
+@Entity({ name: "commits" })
+@Index("commits_repo_authored_idx", ["repoId", "authoredAt"])
+@Index("commits_repo_author_email_idx", ["repoId", "authorEmail"])
+export class Commit {
+  @PrimaryColumn("text")
+  sha!: string;
+
+  @Column("uuid")
+  repoId!: string;
+
+  @ManyToOne(() => Repository, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "repo_id" })
+  repository!: Repository;
+
+  @Column("text")
+  authorEmail!: string;
+
+  @Column("text")
+  authorName!: string;
+
+  @Column("timestamptz")
+  authoredAt!: Date;
+
+  @Column("text")
+  message!: string;
+
+  @Column("int", { default: 0 })
+  additions!: number;
+
+  @Column("int", { default: 0 })
+  deletions!: number;
+
+  @Column("int", { default: 0 })
+  filesChanged!: number;
+
+  @Column("smallint", { default: 1 })
+  parentCount!: number;
+
+  @OneToOne(() => CommitQualityScore, (score) => score.commit)
+  qualityScore!: CommitQualityScore | null;
+}

--- a/packages/database/src/entities/index.ts
+++ b/packages/database/src/entities/index.ts
@@ -1,6 +1,10 @@
 export { ApiKey } from "./api-key.entity.js";
 export { AuditEvent } from "./audit-event.entity.js";
+export { Commit } from "./commit.entity.js";
+export { CommitQualityScore } from "./commit-quality-score.entity.js";
 export { LLMApiKey } from "./llm-api-key.entity.js";
 export type { LLMApiKeyStatus, LLMProvider } from "./llm-api-key.entity.js";
 export { Repository } from "./repository.entity.js";
+export { SyncJob } from "./sync-job.entity.js";
+export type { SyncJobStatus } from "./sync-job.entity.js";
 export { User } from "./user.entity.js";

--- a/packages/database/src/entities/sync-job.entity.ts
+++ b/packages/database/src/entities/sync-job.entity.ts
@@ -1,6 +1,7 @@
 import {
   Column,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -8,32 +9,36 @@ import {
 
 import { Repository } from "./repository.entity.js";
 
-export type SyncJobStatus = "pending" | "running" | "done" | "failed";
+export type SyncJobStatus = "queued" | "running" | "completed" | "failed";
 
 @Entity({ name: "sync_jobs" })
+@Index("sync_jobs_repo_status_idx", ["repositoryId", "status"])
 export class SyncJob {
   @PrimaryGeneratedColumn("uuid")
   id!: string;
 
   @Column("uuid")
-  repoId!: string;
+  repositoryId!: string;
 
   @ManyToOne(() => Repository, { onDelete: "CASCADE" })
-  @JoinColumn({ name: "repo_id" })
+  @JoinColumn({ name: "repository_id" })
   repository!: Repository;
 
   @Column("text")
   status!: SyncJobStatus;
+
+  @Column("int", { nullable: true })
+  commitsProcessed!: number | null;
+
+  @Column("int", { nullable: true })
+  totalCommits!: number | null;
+
+  @Column("text", { nullable: true })
+  errorMessage!: string | null;
 
   @Column("timestamptz", { nullable: true })
   startedAt!: Date | null;
 
   @Column("timestamptz", { nullable: true })
   finishedAt!: Date | null;
-
-  @Column("smallint", { nullable: true })
-  progressPct!: number | null;
-
-  @Column("text", { nullable: true })
-  error!: string | null;
 }

--- a/packages/database/src/entities/sync-job.entity.ts
+++ b/packages/database/src/entities/sync-job.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+
+import { Repository } from "./repository.entity.js";
+
+export type SyncJobStatus = "pending" | "running" | "done" | "failed";
+
+@Entity({ name: "sync_jobs" })
+export class SyncJob {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column("uuid")
+  repoId!: string;
+
+  @ManyToOne(() => Repository, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "repo_id" })
+  repository!: Repository;
+
+  @Column("text")
+  status!: SyncJobStatus;
+
+  @Column("timestamptz", { nullable: true })
+  startedAt!: Date | null;
+
+  @Column("timestamptz", { nullable: true })
+  finishedAt!: Date | null;
+
+  @Column("smallint", { nullable: true })
+  progressPct!: number | null;
+
+  @Column("text", { nullable: true })
+  error!: string | null;
+}

--- a/packages/database/src/migrations/1713000003000-commit-entities.ts
+++ b/packages/database/src/migrations/1713000003000-commit-entities.ts
@@ -5,57 +5,67 @@ export class CommitEntities1713000003000 implements MigrationInterface {
 
   async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
-      CREATE TYPE "sync_job_status" AS ENUM ('pending', 'running', 'done', 'failed')
-    `);
-
-    await queryRunner.query(`
       CREATE TABLE "commits" (
-        "sha" text PRIMARY KEY,
-        "repo_id" uuid NOT NULL REFERENCES "repositories"("id") ON DELETE CASCADE,
-        "author_email" text NOT NULL,
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        "repository_id" uuid NOT NULL REFERENCES "repositories"("id") ON DELETE CASCADE,
+        "sha" text NOT NULL,
         "author_name" text NOT NULL,
-        "authored_at" timestamptz NOT NULL,
+        "author_email" text NOT NULL,
         "message" text NOT NULL,
-        "additions" int NOT NULL DEFAULT 0,
+        "subject" text,
+        "body" text,
+        "footer" text,
+        "insertions" int NOT NULL DEFAULT 0,
         "deletions" int NOT NULL DEFAULT 0,
         "files_changed" int NOT NULL DEFAULT 0,
-        "parent_count" smallint NOT NULL DEFAULT 1
+        "authored_at" timestamptz NOT NULL,
+        CONSTRAINT "commits_repo_sha_uk" UNIQUE ("repository_id", "sha")
       )
     `);
 
     await queryRunner.query(
-      `CREATE INDEX "commits_repo_authored_idx" ON "commits" ("repo_id", "authored_at" DESC)`,
+      `CREATE INDEX "commits_repo_authored_idx" ON "commits" ("repository_id", "authored_at" DESC)`,
     );
     await queryRunner.query(
-      `CREATE INDEX "commits_repo_author_email_idx" ON "commits" ("repo_id", "author_email")`,
+      `CREATE INDEX "commits_author_email_idx" ON "commits" ("author_email")`,
     );
 
     await queryRunner.query(`
       CREATE TABLE "commit_quality_scores" (
-        "commit_sha" text PRIMARY KEY REFERENCES "commits"("sha") ON DELETE CASCADE,
-        "cc_valid" bool NOT NULL DEFAULT false,
-        "score" smallint NOT NULL,
-        "breakdown" jsonb NOT NULL DEFAULT '{}',
-        "scored_at" timestamptz NOT NULL,
-        CONSTRAINT "commit_quality_scores_score_chk" CHECK ("score" >= 0 AND "score" <= 100)
-      )
-    `);
-
-    await queryRunner.query(`
-      CREATE TABLE "sync_jobs" (
         "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-        "repo_id" uuid NOT NULL REFERENCES "repositories"("id") ON DELETE CASCADE,
-        "status" sync_job_status NOT NULL DEFAULT 'pending',
-        "started_at" timestamptz,
-        "finished_at" timestamptz,
-        "progress_pct" smallint,
-        "error" text,
-        CONSTRAINT "sync_jobs_progress_chk" CHECK ("progress_pct" IS NULL OR ("progress_pct" >= 0 AND "progress_pct" <= 100))
+        "commit_id" uuid NOT NULL UNIQUE REFERENCES "commits"("id") ON DELETE CASCADE,
+        "is_conventional" bool NOT NULL DEFAULT false,
+        "cc_type" text,
+        "cc_scope" text,
+        "subject_length" int,
+        "has_body" bool NOT NULL DEFAULT false,
+        "has_footer" bool NOT NULL DEFAULT false,
+        "overall_score" int NOT NULL,
+        "details" jsonb NOT NULL DEFAULT '{}',
+        CONSTRAINT "commit_quality_scores_score_chk" CHECK ("overall_score" >= 0 AND "overall_score" <= 100)
       )
     `);
 
     await queryRunner.query(
-      `CREATE INDEX "sync_jobs_repo_id_idx" ON "sync_jobs" ("repo_id")`,
+      `CREATE INDEX "commit_quality_scores_overall_score_idx" ON "commit_quality_scores" ("overall_score")`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "sync_jobs" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        "repository_id" uuid NOT NULL REFERENCES "repositories"("id") ON DELETE CASCADE,
+        "status" text NOT NULL DEFAULT 'queued',
+        "commits_processed" int,
+        "total_commits" int,
+        "error_message" text,
+        "started_at" timestamptz,
+        "finished_at" timestamptz,
+        CONSTRAINT "sync_jobs_status_chk" CHECK ("status" IN ('queued', 'running', 'completed', 'failed'))
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "sync_jobs_repo_status_idx" ON "sync_jobs" ("repository_id", "status")`,
     );
 
     for (const table of ["commits", "commit_quality_scores", "sync_jobs"]) {
@@ -72,14 +82,14 @@ export class CommitEntities1713000003000 implements MigrationInterface {
         USING (
           EXISTS (
             SELECT 1 FROM "repositories" r
-            WHERE r."id" = "commits"."repo_id"
+            WHERE r."id" = "commits"."repository_id"
               AND r."user_id" = auth.uid()
           )
         )
         WITH CHECK (
           EXISTS (
             SELECT 1 FROM "repositories" r
-            WHERE r."id" = "commits"."repo_id"
+            WHERE r."id" = "commits"."repository_id"
               AND r."user_id" = auth.uid()
           )
         )
@@ -90,16 +100,16 @@ export class CommitEntities1713000003000 implements MigrationInterface {
         USING (
           EXISTS (
             SELECT 1 FROM "commits" c
-            JOIN "repositories" r ON r."id" = c."repo_id"
-            WHERE c."sha" = "commit_quality_scores"."commit_sha"
+            JOIN "repositories" r ON r."id" = c."repository_id"
+            WHERE c."id" = "commit_quality_scores"."commit_id"
               AND r."user_id" = auth.uid()
           )
         )
         WITH CHECK (
           EXISTS (
             SELECT 1 FROM "commits" c
-            JOIN "repositories" r ON r."id" = c."repo_id"
-            WHERE c."sha" = "commit_quality_scores"."commit_sha"
+            JOIN "repositories" r ON r."id" = c."repository_id"
+            WHERE c."id" = "commit_quality_scores"."commit_id"
               AND r."user_id" = auth.uid()
           )
         )
@@ -110,14 +120,14 @@ export class CommitEntities1713000003000 implements MigrationInterface {
         USING (
           EXISTS (
             SELECT 1 FROM "repositories" r
-            WHERE r."id" = "sync_jobs"."repo_id"
+            WHERE r."id" = "sync_jobs"."repository_id"
               AND r."user_id" = auth.uid()
           )
         )
         WITH CHECK (
           EXISTS (
             SELECT 1 FROM "repositories" r
-            WHERE r."id" = "sync_jobs"."repo_id"
+            WHERE r."id" = "sync_jobs"."repository_id"
               AND r."user_id" = auth.uid()
           )
         )
@@ -138,7 +148,5 @@ export class CommitEntities1713000003000 implements MigrationInterface {
     await queryRunner.query(`DROP TABLE IF EXISTS "sync_jobs"`);
     await queryRunner.query(`DROP TABLE IF EXISTS "commit_quality_scores"`);
     await queryRunner.query(`DROP TABLE IF EXISTS "commits"`);
-
-    await queryRunner.query(`DROP TYPE IF EXISTS "sync_job_status"`);
   }
 }

--- a/packages/database/src/migrations/1713000003000-commit-entities.ts
+++ b/packages/database/src/migrations/1713000003000-commit-entities.ts
@@ -1,0 +1,144 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CommitEntities1713000003000 implements MigrationInterface {
+  name = "CommitEntities1713000003000";
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "sync_job_status" AS ENUM ('pending', 'running', 'done', 'failed')
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "commits" (
+        "sha" text PRIMARY KEY,
+        "repo_id" uuid NOT NULL REFERENCES "repositories"("id") ON DELETE CASCADE,
+        "author_email" text NOT NULL,
+        "author_name" text NOT NULL,
+        "authored_at" timestamptz NOT NULL,
+        "message" text NOT NULL,
+        "additions" int NOT NULL DEFAULT 0,
+        "deletions" int NOT NULL DEFAULT 0,
+        "files_changed" int NOT NULL DEFAULT 0,
+        "parent_count" smallint NOT NULL DEFAULT 1
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "commits_repo_authored_idx" ON "commits" ("repo_id", "authored_at" DESC)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "commits_repo_author_email_idx" ON "commits" ("repo_id", "author_email")`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "commit_quality_scores" (
+        "commit_sha" text PRIMARY KEY REFERENCES "commits"("sha") ON DELETE CASCADE,
+        "cc_valid" bool NOT NULL DEFAULT false,
+        "score" smallint NOT NULL,
+        "breakdown" jsonb NOT NULL DEFAULT '{}',
+        "scored_at" timestamptz NOT NULL,
+        CONSTRAINT "commit_quality_scores_score_chk" CHECK ("score" >= 0 AND "score" <= 100)
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "sync_jobs" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        "repo_id" uuid NOT NULL REFERENCES "repositories"("id") ON DELETE CASCADE,
+        "status" sync_job_status NOT NULL DEFAULT 'pending',
+        "started_at" timestamptz,
+        "finished_at" timestamptz,
+        "progress_pct" smallint,
+        "error" text,
+        CONSTRAINT "sync_jobs_progress_chk" CHECK ("progress_pct" IS NULL OR ("progress_pct" >= 0 AND "progress_pct" <= 100))
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "sync_jobs_repo_id_idx" ON "sync_jobs" ("repo_id")`,
+    );
+
+    for (const table of ["commits", "commit_quality_scores", "sync_jobs"]) {
+      await queryRunner.query(
+        `ALTER TABLE "${table}" ENABLE ROW LEVEL SECURITY`,
+      );
+      await queryRunner.query(
+        `ALTER TABLE "${table}" FORCE ROW LEVEL SECURITY`,
+      );
+    }
+
+    await queryRunner.query(`
+      CREATE POLICY "commits_owner" ON "commits"
+        USING (
+          EXISTS (
+            SELECT 1 FROM "repositories" r
+            WHERE r."id" = "commits"."repo_id"
+              AND r."user_id" = auth.uid()
+          )
+        )
+        WITH CHECK (
+          EXISTS (
+            SELECT 1 FROM "repositories" r
+            WHERE r."id" = "commits"."repo_id"
+              AND r."user_id" = auth.uid()
+          )
+        )
+    `);
+
+    await queryRunner.query(`
+      CREATE POLICY "commit_quality_scores_owner" ON "commit_quality_scores"
+        USING (
+          EXISTS (
+            SELECT 1 FROM "commits" c
+            JOIN "repositories" r ON r."id" = c."repo_id"
+            WHERE c."sha" = "commit_quality_scores"."commit_sha"
+              AND r."user_id" = auth.uid()
+          )
+        )
+        WITH CHECK (
+          EXISTS (
+            SELECT 1 FROM "commits" c
+            JOIN "repositories" r ON r."id" = c."repo_id"
+            WHERE c."sha" = "commit_quality_scores"."commit_sha"
+              AND r."user_id" = auth.uid()
+          )
+        )
+    `);
+
+    await queryRunner.query(`
+      CREATE POLICY "sync_jobs_owner" ON "sync_jobs"
+        USING (
+          EXISTS (
+            SELECT 1 FROM "repositories" r
+            WHERE r."id" = "sync_jobs"."repo_id"
+              AND r."user_id" = auth.uid()
+          )
+        )
+        WITH CHECK (
+          EXISTS (
+            SELECT 1 FROM "repositories" r
+            WHERE r."id" = "sync_jobs"."repo_id"
+              AND r."user_id" = auth.uid()
+          )
+        )
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP POLICY IF EXISTS "sync_jobs_owner" ON "sync_jobs"`,
+    );
+    await queryRunner.query(
+      `DROP POLICY IF EXISTS "commit_quality_scores_owner" ON "commit_quality_scores"`,
+    );
+    await queryRunner.query(
+      `DROP POLICY IF EXISTS "commits_owner" ON "commits"`,
+    );
+
+    await queryRunner.query(`DROP TABLE IF EXISTS "sync_jobs"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "commit_quality_scores"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "commits"`);
+
+    await queryRunner.query(`DROP TYPE IF EXISTS "sync_job_status"`);
+  }
+}


### PR DESCRIPTION
## Summary
- adds `commits` table (sha PK, repo_id FK, author_email/name, authored_at, message, additions, deletions, files_changed, parent_count)
- adds `commit_quality_scores` table (commit_sha PK/FK, cc_valid, score 0–100 with CHECK, breakdown jsonb, scored_at)
- adds `sync_jobs` table (uuid PK, repo_id FK, status enum, started_at, finished_at, progress_pct 0–100 with CHECK, error)
- migration 1713000003000 with up/down, composite indexes on (repo_id, authored_at) and (repo_id, author_email), RLS policies joining via `repositories.user_id`
- TypeORM entities + updated entities index

Closes #29