### PR TITLE
feat(T-2.5): quality scorer service + fixtures

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,9 @@ export const name = "@commit-analyzer/api";
 export { parseConventionalCommit } from "./shared/cc-parser.js";
 export type { ParsedCC } from "./shared/cc-parser.js";
 
+export { scoreCommit } from "./shared/quality-scorer.js";
+export type { Score, ScoreDetail } from "./shared/quality-scorer.js";
+
 export { getServerEnv } from "./common/config.js";
 export { createLogger, REDACT_PATHS } from "./common/logger.js";
 export {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,7 +4,7 @@ export { parseConventionalCommit } from "./shared/cc-parser.js";
 export type { ParsedCC } from "./shared/cc-parser.js";
 
 export { scoreCommit } from "./shared/quality-scorer.js";
-export type { Score, ScoreDetail } from "./shared/quality-scorer.js";
+export type { Score, ScoreDetail, RawCommit } from "./shared/quality-scorer.js";
 
 export { getServerEnv } from "./common/config.js";
 export { createLogger, REDACT_PATHS } from "./common/logger.js";

--- a/apps/api/src/shared/quality-scorer.spec.ts
+++ b/apps/api/src/shared/quality-scorer.spec.ts
@@ -1,13 +1,14 @@
-import { createRequire } from "node:module";
-
 import { describe, expect, it } from "vitest";
+
+import fixturesJson from "../../test/algorithms/fixtures/quality-scorer.fixtures.json" with {
+  type: "json",
+};
 
 import { parseConventionalCommit } from "./cc-parser.js";
 import { scoreCommit } from "./quality-scorer.js";
 import type { Score } from "./quality-scorer.js";
 
-const require = createRequire(import.meta.url);
-const fixtures = require("../../test/algorithms/fixtures/quality-scorer.fixtures.json") as Array<{
+const fixtures = fixturesJson as Array<{
   name: string;
   input: string;
   expected: Score;

--- a/apps/api/src/shared/quality-scorer.spec.ts
+++ b/apps/api/src/shared/quality-scorer.spec.ts
@@ -1,0 +1,238 @@
+import { createRequire } from "node:module";
+
+import { describe, expect, it } from "vitest";
+
+import { parseConventionalCommit } from "./cc-parser.js";
+import { scoreCommit } from "./quality-scorer.js";
+import type { Score } from "./quality-scorer.js";
+
+const require = createRequire(import.meta.url);
+const fixtures = require("../../test/algorithms/fixtures/quality-scorer.fixtures.json") as Array<{
+  name: string;
+  input: string;
+  expected: Score;
+}>;
+
+describe("scoreCommit", () => {
+  describe("regression fixtures", () => {
+    for (const { name, input, expected } of fixtures) {
+      it(name, () => {
+        const parsed = parseConventionalCommit(input);
+        expect(scoreCommit(parsed)).toEqual(expected);
+      });
+    }
+  });
+
+  it("great commit scores ≥90", () => {
+    const parsed = parseConventionalCommit(
+      "feat(auth): add oauth2 login flow\n\nImplements Google and GitHub OAuth2 providers.\nUsers can now sign in without a password.\n\nCloses #42",
+    );
+    const { overallScore } = scoreCommit(parsed);
+    expect(overallScore).toBeGreaterThanOrEqual(90);
+  });
+
+  it("bad commit scores ≤30", () => {
+    const parsed = parseConventionalCommit("wip");
+    const { overallScore } = scoreCommit(parsed);
+    expect(overallScore).toBeLessThanOrEqual(30);
+  });
+
+  it("score is deterministic across multiple calls", () => {
+    const message = "fix(db): handle connection timeout";
+    const parsed = parseConventionalCommit(message);
+    const s1 = scoreCommit(parsed);
+    const s2 = scoreCommit(parsed);
+    expect(s1).toEqual(s2);
+  });
+
+  describe("is_conventional component", () => {
+    it("non-CC message gets 0 for is_conventional", () => {
+      const s = scoreCommit(parseConventionalCommit("just a plain message"));
+      const detail = s.details.find((d) => d.component === "is_conventional")!;
+      expect(detail.got).toBe(0);
+    });
+
+    it("valid CC message gets 30 for is_conventional", () => {
+      const s = scoreCommit(parseConventionalCommit("feat: something"));
+      const detail = s.details.find((d) => d.component === "is_conventional")!;
+      expect(detail.got).toBe(30);
+    });
+  });
+
+  describe("type_valid component", () => {
+    it("valid type earns 10 pts", () => {
+      const s = scoreCommit(parseConventionalCommit("feat: something"));
+      const detail = s.details.find((d) => d.component === "type_valid")!;
+      expect(detail.got).toBe(10);
+    });
+
+    it("unknown type earns 0 pts", () => {
+      const s = scoreCommit(parseConventionalCommit("wip: something"));
+      const detail = s.details.find((d) => d.component === "type_valid")!;
+      expect(detail.got).toBe(0);
+    });
+
+    it("all canonical types are valid", () => {
+      const types = [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "test",
+        "chore",
+        "build",
+        "ci",
+        "perf",
+        "revert",
+      ];
+      for (const t of types) {
+        const s = scoreCommit(parseConventionalCommit(`${t}: something`));
+        const detail = s.details.find((d) => d.component === "type_valid")!;
+        expect(detail.got, `${t} should be valid`).toBe(10);
+      }
+    });
+  });
+
+  describe("scope_present component", () => {
+    it("scope present earns 10 pts", () => {
+      const s = scoreCommit(parseConventionalCommit("feat(api): something"));
+      const detail = s.details.find((d) => d.component === "scope_present")!;
+      expect(detail.got).toBe(10);
+    });
+
+    it("no scope earns 0 pts", () => {
+      const s = scoreCommit(parseConventionalCommit("feat: something"));
+      const detail = s.details.find((d) => d.component === "scope_present")!;
+      expect(detail.got).toBe(0);
+    });
+  });
+
+  describe("subject_length component", () => {
+    it("subject 1–50 chars earns 20 pts", () => {
+      // "something" = 9 chars
+      const s = scoreCommit(parseConventionalCommit("feat: something"));
+      const detail = s.details.find((d) => d.component === "subject_length")!;
+      expect(detail.got).toBe(20);
+    });
+
+    it("subject exactly 50 chars earns 20 pts", () => {
+      const subject = "a".repeat(50);
+      const s = scoreCommit(parseConventionalCommit(`feat: ${subject}`));
+      const detail = s.details.find((d) => d.component === "subject_length")!;
+      expect(detail.got).toBe(20);
+    });
+
+    it("subject 51–72 chars earns 15 pts", () => {
+      const subject = "a".repeat(51);
+      const s = scoreCommit(parseConventionalCommit(`feat: ${subject}`));
+      const detail = s.details.find((d) => d.component === "subject_length")!;
+      expect(detail.got).toBe(15);
+    });
+
+    it("subject exactly 72 chars earns 15 pts", () => {
+      const subject = "a".repeat(72);
+      const s = scoreCommit(parseConventionalCommit(`feat: ${subject}`));
+      const detail = s.details.find((d) => d.component === "subject_length")!;
+      expect(detail.got).toBe(15);
+    });
+
+    it("subject >72 chars earns 5 pts", () => {
+      const subject = "a".repeat(73);
+      const s = scoreCommit(parseConventionalCommit(`feat: ${subject}`));
+      const detail = s.details.find((d) => d.component === "subject_length")!;
+      expect(detail.got).toBe(5);
+    });
+
+    it("non-CC commit has subjectLength=0 and earns 0 pts", () => {
+      const s = scoreCommit(parseConventionalCommit("plain commit"));
+      expect(s.subjectLength).toBe(0);
+      const detail = s.details.find((d) => d.component === "subject_length")!;
+      expect(detail.got).toBe(0);
+    });
+  });
+
+  describe("body_present component", () => {
+    it("body present earns 15 pts", () => {
+      const s = scoreCommit(
+        parseConventionalCommit("feat: something\n\nbody text here"),
+      );
+      const detail = s.details.find((d) => d.component === "body_present")!;
+      expect(detail.got).toBe(15);
+    });
+
+    it("no body earns 0 pts", () => {
+      const s = scoreCommit(parseConventionalCommit("feat: something"));
+      const detail = s.details.find((d) => d.component === "body_present")!;
+      expect(detail.got).toBe(0);
+    });
+  });
+
+  describe("footer_present component", () => {
+    it("footer present earns 15 pts", () => {
+      const s = scoreCommit(
+        parseConventionalCommit(
+          "feat: something\n\nbody text\n\nCloses #1",
+        ),
+      );
+      const detail = s.details.find((d) => d.component === "footer_present")!;
+      expect(detail.got).toBe(15);
+    });
+
+    it("no footer earns 0 pts", () => {
+      const s = scoreCommit(
+        parseConventionalCommit("feat: something\n\nbody only"),
+      );
+      const detail = s.details.find((d) => d.component === "footer_present")!;
+      expect(detail.got).toBe(0);
+    });
+  });
+
+  describe("overallScore", () => {
+    it("sums component points correctly", () => {
+      // feat + valid type + no scope + short subject + no body + no footer
+      // 30 + 10 + 0 + 20 + 0 + 0 = 60
+      const s = scoreCommit(parseConventionalCommit("feat: something"));
+      expect(s.overallScore).toBe(60);
+    });
+
+    it("clamped to 100 max", () => {
+      const s = scoreCommit(
+        parseConventionalCommit(
+          "feat(scope): add something\n\nbody\n\nCloses #1",
+        ),
+      );
+      expect(s.overallScore).toBeLessThanOrEqual(100);
+    });
+
+    it("clamped to 0 min", () => {
+      const s = scoreCommit(parseConventionalCommit(""));
+      expect(s.overallScore).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("details array", () => {
+    it("always contains exactly 6 entries", () => {
+      const s = scoreCommit(parseConventionalCommit("feat: something"));
+      expect(s.details).toHaveLength(6);
+    });
+
+    it("all weight fields are positive", () => {
+      const s = scoreCommit(parseConventionalCommit("feat: something"));
+      for (const d of s.details) {
+        expect(d.weight).toBeGreaterThan(0);
+      }
+    });
+
+    it("got never exceeds weight for each component", () => {
+      const s = scoreCommit(
+        parseConventionalCommit(
+          "feat(scope): add something\n\nbody\n\nCloses #1",
+        ),
+      );
+      for (const d of s.details) {
+        expect(d.got).toBeLessThanOrEqual(d.weight);
+      }
+    });
+  });
+});

--- a/apps/api/src/shared/quality-scorer.ts
+++ b/apps/api/src/shared/quality-scorer.ts
@@ -1,5 +1,13 @@
 import type { ParsedCC } from "./cc-parser.js";
 
+/** Minimal raw-commit fields the scorer may use in future criteria (e.g. diff size). */
+export type RawCommit = {
+  message: string;
+  subject?: string | null;
+  body?: string | null;
+  footer?: string | null;
+};
+
 export type ScoreDetail = {
   component: string;
   weight: number;
@@ -38,7 +46,7 @@ function subjectLengthPoints(len: number): number {
   return 5;
 }
 
-export function scoreCommit(parsed: ParsedCC): Score {
+export function scoreCommit(parsed: ParsedCC, _commit?: RawCommit): Score {
   const isConventional = parsed.ok;
 
   const ccType = parsed.ok ? parsed.type : undefined;

--- a/apps/api/src/shared/quality-scorer.ts
+++ b/apps/api/src/shared/quality-scorer.ts
@@ -1,0 +1,100 @@
+import type { ParsedCC } from "./cc-parser.js";
+
+export type ScoreDetail = {
+  component: string;
+  weight: number;
+  got: number;
+};
+
+export type Score = {
+  isConventional: boolean;
+  ccType?: string;
+  ccScope?: string;
+  subjectLength: number;
+  hasBody: boolean;
+  hasFooter: boolean;
+  overallScore: number;
+  details: ScoreDetail[];
+};
+
+const VALID_TYPES = new Set([
+  "feat",
+  "fix",
+  "docs",
+  "style",
+  "refactor",
+  "test",
+  "chore",
+  "build",
+  "ci",
+  "perf",
+  "revert",
+]);
+
+function subjectLengthPoints(len: number): number {
+  if (len === 0) return 0;
+  if (len <= 50) return 20;
+  if (len <= 72) return 15;
+  return 5;
+}
+
+export function scoreCommit(parsed: ParsedCC): Score {
+  const isConventional = parsed.ok;
+
+  const ccType = parsed.ok ? parsed.type : undefined;
+  const ccScope = parsed.ok ? parsed.scope : undefined;
+  const subject = parsed.ok ? parsed.subject : "";
+  const hasBody = parsed.ok ? (parsed.body?.length ?? 0) > 0 : false;
+  const hasFooter = parsed.ok ? (parsed.footer?.length ?? 0) > 0 : false;
+
+  const subjectLength = subject.length;
+
+  const details: ScoreDetail[] = [
+    {
+      component: "is_conventional",
+      weight: 30,
+      got: isConventional ? 30 : 0,
+    },
+    {
+      component: "type_valid",
+      weight: 10,
+      got: ccType !== undefined && VALID_TYPES.has(ccType) ? 10 : 0,
+    },
+    {
+      component: "scope_present",
+      weight: 10,
+      got: ccScope !== undefined && ccScope.length > 0 ? 10 : 0,
+    },
+    {
+      component: "subject_length",
+      weight: 20,
+      got: subjectLengthPoints(subjectLength),
+    },
+    {
+      component: "body_present",
+      weight: 15,
+      got: hasBody ? 15 : 0,
+    },
+    {
+      component: "footer_present",
+      weight: 15,
+      got: hasFooter ? 15 : 0,
+    },
+  ];
+
+  const overallScore = Math.min(
+    100,
+    Math.max(0, details.reduce((sum, d) => sum + d.got, 0)),
+  );
+
+  return {
+    isConventional,
+    ...(ccType !== undefined ? { ccType } : {}),
+    ...(ccScope !== undefined ? { ccScope } : {}),
+    subjectLength,
+    hasBody,
+    hasFooter,
+    overallScore,
+    details,
+  };
+}

--- a/apps/api/test/algorithms/fixtures/quality-scorer.fixtures.json
+++ b/apps/api/test/algorithms/fixtures/quality-scorer.fixtures.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "great commit — all criteria met",
+    "input": "feat(auth): add oauth2 login flow\n\nImplements Google and GitHub OAuth2 providers.\nUsers can now sign in without a password.\n\nCloses #42",
+    "expected": {
+      "isConventional": true,
+      "ccType": "feat",
+      "ccScope": "auth",
+      "subjectLength": 21,
+      "hasBody": true,
+      "hasFooter": true,
+      "overallScore": 100,
+      "details": [
+        { "component": "is_conventional", "weight": 30, "got": 30 },
+        { "component": "type_valid",      "weight": 10, "got": 10 },
+        { "component": "scope_present",   "weight": 10, "got": 10 },
+        { "component": "subject_length",  "weight": 20, "got": 20 },
+        { "component": "body_present",    "weight": 15, "got": 15 },
+        { "component": "footer_present",  "weight": 15, "got": 15 }
+      ]
+    }
+  },
+  {
+    "name": "bad commit — plain message no colon",
+    "input": "wip",
+    "expected": {
+      "isConventional": false,
+      "subjectLength": 0,
+      "hasBody": false,
+      "hasFooter": false,
+      "overallScore": 0,
+      "details": [
+        { "component": "is_conventional", "weight": 30, "got": 0 },
+        { "component": "type_valid",      "weight": 10, "got": 0 },
+        { "component": "scope_present",   "weight": 10, "got": 0 },
+        { "component": "subject_length",  "weight": 20, "got": 0 },
+        { "component": "body_present",    "weight": 15, "got": 0 },
+        { "component": "footer_present",  "weight": 15, "got": 0 }
+      ]
+    }
+  }
+]

--- a/apps/api/test/algorithms/fixtures/quality-scorer.fixtures.json
+++ b/apps/api/test/algorithms/fixtures/quality-scorer.fixtures.json
@@ -21,6 +21,26 @@
     }
   },
   {
+    "name": "mid-range commit — valid type, short subject, no scope/body/footer",
+    "input": "feat: add dark mode toggle",
+    "expected": {
+      "isConventional": true,
+      "ccType": "feat",
+      "subjectLength": 20,
+      "hasBody": false,
+      "hasFooter": false,
+      "overallScore": 60,
+      "details": [
+        { "component": "is_conventional", "weight": 30, "got": 30 },
+        { "component": "type_valid",      "weight": 10, "got": 10 },
+        { "component": "scope_present",   "weight": 10, "got": 0  },
+        { "component": "subject_length",  "weight": 20, "got": 20 },
+        { "component": "body_present",    "weight": 15, "got": 0  },
+        { "component": "footer_present",  "weight": 15, "got": 0  }
+      ]
+    }
+  },
+  {
     "name": "bad commit — plain message no colon",
     "input": "wip",
     "expected": {


### PR DESCRIPTION
## Summary
- Pure `scoreCommit(parsed: ParsedCC): Score` function with 6 weighted components (total 100 pts)
- Components: `is_conventional` (30), `type_valid` (10), `scope_present` (10), `subject_length` (20), `body_present` (15), `footer_present` (15)
- Returns `Score` with `overallScore`, `details[]`, and CC metadata fields
- Two regression fixtures locked: "great" commit (100 pts) and "bad" commit (0 pts)
- 28 unit tests covering all components, edge cases, determinism, and clamping
- Exported from `@commit-analyzer/api` index

Closes #31