### PR TITLE
feat(T-2.10): analytics cache getorset + metrics

### DIFF
--- a/apps/api/src/common/cache/cache.module.ts
+++ b/apps/api/src/common/cache/cache.module.ts
@@ -24,6 +24,9 @@ class NoopRedis {
   scan(): Promise<[string, string[]]> {
     return Promise.resolve(["0", []]);
   }
+  incr(): Promise<number> {
+    return Promise.resolve(0);
+  }
   on(): void {}
   quit(): Promise<"OK"> {
     return Promise.resolve("OK");

--- a/apps/api/src/common/cache/cache.service.ts
+++ b/apps/api/src/common/cache/cache.service.ts
@@ -36,6 +36,25 @@ export class CacheService {
     }
   }
 
+  async incr(key: string): Promise<number> {
+    try {
+      return await this.redis.incr(key);
+    } catch (err) {
+      this.logger.warn(`cache.incr failed key=${key}: ${String(err)}`);
+      return 0;
+    }
+  }
+
+  async getNumber(key: string): Promise<number> {
+    try {
+      const raw = await this.redis.get(key);
+      return raw ? Number(raw) : 0;
+    } catch (err) {
+      this.logger.warn(`cache.getNumber failed key=${key}: ${String(err)}`);
+      return 0;
+    }
+  }
+
   /** Delete all keys matching a glob `pattern` using SCAN (non-blocking). */
   async delByPattern(pattern: string): Promise<number> {
     let deleted = 0;

--- a/apps/api/src/modules/git-analysis/analytics.controller.ts
+++ b/apps/api/src/modules/git-analysis/analytics.controller.ts
@@ -1,5 +1,5 @@
 import { analyticsContract, type Summary } from "@commit-analyzer/contracts";
-import { Controller, UseGuards } from "@nestjs/common";
+import { Controller, Get, UseGuards } from "@nestjs/common";
 import { QueryBus } from "@nestjs/cqrs";
 import { TsRestHandler, tsRestHandler } from "@ts-rest/nest";
 
@@ -14,12 +14,21 @@ import { GetQualityScoresQuery } from "./queries/get-quality-scores.query.js";
 import { GetQualityTrendsQuery } from "./queries/get-quality-trends.query.js";
 import { GetSummaryQuery } from "./queries/get-summary.query.js";
 import { GetTimelineQuery } from "./queries/get-timeline.query.js";
+import { AnalyticsCacheService } from "./services/analytics-cache.service.js";
 
 @Controller()
 @UseGuards(SupabaseAuthGuard)
 @ThrottleTierDecorator("analytics")
 export class AnalyticsController {
-  constructor(private readonly queryBus: QueryBus) {}
+  constructor(
+    private readonly queryBus: QueryBus,
+    private readonly analyticsCache: AnalyticsCacheService,
+  ) {}
+
+  @Get("analytics/cache-metrics")
+  cacheMetrics(): Promise<{ hits: number; misses: number; hitRate: number }> {
+    return this.analyticsCache.metrics();
+  }
 
   @TsRestHandler(analyticsContract.timeline)
   timeline(@CurrentUser() userId: string): unknown {

--- a/apps/api/src/modules/git-analysis/analytics.integration.test.ts
+++ b/apps/api/src/modules/git-analysis/analytics.integration.test.ts
@@ -48,6 +48,7 @@ const noopRedis = {
   set: vi.fn(() => Promise.resolve("OK")),
   del: vi.fn(() => Promise.resolve(0)),
   scan: vi.fn(() => Promise.resolve(["0", []])),
+  incr: vi.fn(() => Promise.resolve(1)),
 };
 
 describe.skipIf(SKIP)("Git-analysis query handlers (integration)", () => {

--- a/apps/api/src/modules/git-analysis/queries/get-contributors.handler.ts
+++ b/apps/api/src/modules/git-analysis/queries/get-contributors.handler.ts
@@ -19,36 +19,36 @@ export class GetContributorsHandler implements IQueryHandler<GetContributorsQuer
   async execute(query: GetContributorsQuery): Promise<Contributor[]> {
     await assertRepoOwnership(this.ds, query.repoId, query.userId);
 
-    const suffix = String(query.limit);
-    const cached = await this.analyticsCache.get<Contributor[]>("contributors", query.repoId, suffix);
-    if (cached) return cached;
-
-    const rows: {
-      author_name: string;
-      author_email: string;
-      commit_count: string;
-      avg_quality: string;
-    }[] = await this.ds.query(
-      `SELECT c.author_name,
-              c.author_email,
-              count(*)::text AS commit_count,
-              coalesce(round(avg(qs.overall_score), 2), 0)::text AS avg_quality
-         FROM commits c
-         LEFT JOIN commit_quality_scores qs ON qs.commit_id = c.id
-        WHERE c.repository_id = $1
-        GROUP BY c.author_name, c.author_email
-        ORDER BY count(*) DESC
-        LIMIT $2`,
-      [query.repoId, query.limit],
+    return this.analyticsCache.getOrSet(
+      "contributors",
+      query.repoId,
+      async () => {
+        const rows: {
+          author_name: string;
+          author_email: string;
+          commit_count: string;
+          avg_quality: string;
+        }[] = await this.ds.query(
+          `SELECT c.author_name,
+                  c.author_email,
+                  count(*)::text AS commit_count,
+                  coalesce(round(avg(qs.overall_score), 2), 0)::text AS avg_quality
+             FROM commits c
+             LEFT JOIN commit_quality_scores qs ON qs.commit_id = c.id
+            WHERE c.repository_id = $1
+            GROUP BY c.author_name, c.author_email
+            ORDER BY count(*) DESC
+            LIMIT $2`,
+          [query.repoId, query.limit],
+        );
+        return rows.map((r) => ({
+          authorName: r.author_name,
+          authorEmail: r.author_email,
+          commitCount: Number(r.commit_count),
+          avgQuality: Number(r.avg_quality),
+        }));
+      },
+      String(query.limit),
     );
-
-    const result = rows.map((r) => ({
-      authorName: r.author_name,
-      authorEmail: r.author_email,
-      commitCount: Number(r.commit_count),
-      avgQuality: Number(r.avg_quality),
-    }));
-    await this.analyticsCache.set("contributors", query.repoId, result, suffix);
-    return result;
   }
 }

--- a/apps/api/src/modules/git-analysis/queries/get-heatmap.handler.ts
+++ b/apps/api/src/modules/git-analysis/queries/get-heatmap.handler.ts
@@ -19,27 +19,24 @@ export class GetHeatmapHandler implements IQueryHandler<GetHeatmapQuery> {
   async execute(query: GetHeatmapQuery): Promise<HeatmapCell[]> {
     await assertRepoOwnership(this.ds, query.repoId, query.userId);
 
-    const cached = await this.analyticsCache.get<HeatmapCell[]>("heatmap", query.repoId);
-    if (cached) return cached;
+    return this.analyticsCache.getOrSet("heatmap", query.repoId, async () => {
+      const rows: { day: string; hour: string; count: string }[] =
+        await this.ds.query(
+          `SELECT extract(dow FROM c.authored_at)::int AS day,
+                  extract(hour FROM c.authored_at)::int AS hour,
+                  count(*)::text AS count
+             FROM commits c
+            WHERE c.repository_id = $1
+            GROUP BY 1, 2
+            ORDER BY 1, 2`,
+          [query.repoId],
+        );
 
-    const rows: { day: string; hour: string; count: string }[] =
-      await this.ds.query(
-        `SELECT extract(dow FROM c.authored_at)::int AS day,
-                extract(hour FROM c.authored_at)::int AS hour,
-                count(*)::text AS count
-           FROM commits c
-          WHERE c.repository_id = $1
-          GROUP BY 1, 2
-          ORDER BY 1, 2`,
-        [query.repoId],
-      );
-
-    const result = rows.map((r) => ({
-      day: Number(r.day),
-      hour: Number(r.hour),
-      count: Number(r.count),
-    }));
-    await this.analyticsCache.set("heatmap", query.repoId, result);
-    return result;
+      return rows.map((r) => ({
+        day: Number(r.day),
+        hour: Number(r.hour),
+        count: Number(r.count),
+      }));
+    });
   }
 }

--- a/apps/api/src/modules/git-analysis/queries/get-quality-scores.handler.ts
+++ b/apps/api/src/modules/git-analysis/queries/get-quality-scores.handler.ts
@@ -19,26 +19,29 @@ export class GetQualityScoresHandler implements IQueryHandler<GetQualityScoresQu
   async execute(query: GetQualityScoresQuery): Promise<QualityBucket[]> {
     await assertRepoOwnership(this.ds, query.repoId, query.userId);
 
-    const cached = await this.analyticsCache.get<QualityBucket[]>("qualityScores", query.repoId);
-    if (cached) return cached;
-
-    const rows: { bucket: string; count: string }[] = await this.ds.query(
-      `SELECT CASE
-                WHEN qs.overall_score >= 80 THEN 'good'
-                WHEN qs.overall_score >= 50 THEN 'average'
-                ELSE 'poor'
-              END AS bucket,
-              count(*)::text AS count
-         FROM commits c
-         JOIN commit_quality_scores qs ON qs.commit_id = c.id
-        WHERE c.repository_id = $1
-        GROUP BY 1
-        ORDER BY 1`,
-      [query.repoId],
+    return this.analyticsCache.getOrSet(
+      "qualityScores",
+      query.repoId,
+      async () => {
+        const rows: { bucket: string; count: string }[] = await this.ds.query(
+          `SELECT CASE
+                    WHEN qs.overall_score >= 80 THEN 'good'
+                    WHEN qs.overall_score >= 50 THEN 'average'
+                    ELSE 'poor'
+                  END AS bucket,
+                  count(*)::text AS count
+             FROM commits c
+             JOIN commit_quality_scores qs ON qs.commit_id = c.id
+            WHERE c.repository_id = $1
+            GROUP BY 1
+            ORDER BY 1`,
+          [query.repoId],
+        );
+        return rows.map((r) => ({
+          bucket: r.bucket as "good" | "average" | "poor",
+          count: Number(r.count),
+        }));
+      },
     );
-
-    const result = rows.map((r) => ({ bucket: r.bucket as "good" | "average" | "poor", count: Number(r.count) }));
-    await this.analyticsCache.set("qualityScores", query.repoId, result);
-    return result;
   }
 }

--- a/apps/api/src/modules/git-analysis/queries/get-quality-trends.handler.ts
+++ b/apps/api/src/modules/git-analysis/queries/get-quality-trends.handler.ts
@@ -19,26 +19,26 @@ export class GetQualityTrendsHandler implements IQueryHandler<GetQualityTrendsQu
   async execute(query: GetQualityTrendsQuery): Promise<QualityTrendPoint[]> {
     await assertRepoOwnership(this.ds, query.repoId, query.userId);
 
-    const suffix = query.granularity;
-    const cached = await this.analyticsCache.get<QualityTrendPoint[]>("qualityTrends", query.repoId, suffix);
-    if (cached) return cached;
-
-    const rows: { date: string; avg_score: string }[] = await this.ds.query(
-      `SELECT date_trunc($1, c.authored_at)::date::text AS date,
-              round(avg(qs.overall_score), 2)::text AS avg_score
-         FROM commits c
-         JOIN commit_quality_scores qs ON qs.commit_id = c.id
-        WHERE c.repository_id = $2
-        GROUP BY 1
-        ORDER BY 1`,
-      [query.granularity, query.repoId],
+    return this.analyticsCache.getOrSet(
+      "qualityTrends",
+      query.repoId,
+      async () => {
+        const rows: { date: string; avg_score: string }[] = await this.ds.query(
+          `SELECT date_trunc($1, c.authored_at)::date::text AS date,
+                  round(avg(qs.overall_score), 2)::text AS avg_score
+             FROM commits c
+             JOIN commit_quality_scores qs ON qs.commit_id = c.id
+            WHERE c.repository_id = $2
+            GROUP BY 1
+            ORDER BY 1`,
+          [query.granularity, query.repoId],
+        );
+        return rows.map((r) => ({
+          date: r.date,
+          avgScore: Number(r.avg_score),
+        }));
+      },
+      query.granularity,
     );
-
-    const result = rows.map((r) => ({
-      date: r.date,
-      avgScore: Number(r.avg_score),
-    }));
-    await this.analyticsCache.set("qualityTrends", query.repoId, result, suffix);
-    return result;
   }
 }

--- a/apps/api/src/modules/git-analysis/queries/get-summary.handler.ts
+++ b/apps/api/src/modules/git-analysis/queries/get-summary.handler.ts
@@ -19,39 +19,36 @@ export class GetSummaryHandler implements IQueryHandler<GetSummaryQuery> {
   async execute(query: GetSummaryQuery): Promise<Summary> {
     await assertRepoOwnership(this.ds, query.repoId, query.userId);
 
-    const cached = await this.analyticsCache.get<Summary>("summary", query.repoId);
-    if (cached) return cached;
+    return this.analyticsCache.getOrSet("summary", query.repoId, async () => {
+      const [row]: [
+        {
+          total_commits: string;
+          total_contributors: string;
+          avg_quality: string;
+          cc_compliance: string;
+        },
+      ] = await this.ds.query(
+        `SELECT count(*)::text AS total_commits,
+                count(DISTINCT c.author_email)::text AS total_contributors,
+                coalesce(round(avg(qs.overall_score), 2), 0)::text AS avg_quality,
+                CASE WHEN count(*) = 0 THEN '0'
+                     ELSE round(
+                       100.0 * count(*) FILTER (WHERE qs.is_conventional) / count(*),
+                       2
+                     )::text
+                END AS cc_compliance
+           FROM commits c
+           LEFT JOIN commit_quality_scores qs ON qs.commit_id = c.id
+          WHERE c.repository_id = $1`,
+        [query.repoId],
+      );
 
-    const [row]: [
-      {
-        total_commits: string;
-        total_contributors: string;
-        avg_quality: string;
-        cc_compliance: string;
-      },
-    ] = await this.ds.query(
-      `SELECT count(*)::text AS total_commits,
-              count(DISTINCT c.author_email)::text AS total_contributors,
-              coalesce(round(avg(qs.overall_score), 2), 0)::text AS avg_quality,
-              CASE WHEN count(*) = 0 THEN '0'
-                   ELSE round(
-                     100.0 * count(*) FILTER (WHERE qs.is_conventional) / count(*),
-                     2
-                   )::text
-              END AS cc_compliance
-         FROM commits c
-         LEFT JOIN commit_quality_scores qs ON qs.commit_id = c.id
-        WHERE c.repository_id = $1`,
-      [query.repoId],
-    );
-
-    const result: Summary = {
-      totalCommits: Number(row.total_commits),
-      totalContributors: Number(row.total_contributors),
-      avgQuality: Number(row.avg_quality),
-      ccCompliancePercent: Number(row.cc_compliance),
-    };
-    await this.analyticsCache.set("summary", query.repoId, result);
-    return result;
+      return {
+        totalCommits: Number(row.total_commits),
+        totalContributors: Number(row.total_contributors),
+        avgQuality: Number(row.avg_quality),
+        ccCompliancePercent: Number(row.cc_compliance),
+      };
+    });
   }
 }

--- a/apps/api/src/modules/git-analysis/queries/get-timeline.handler.ts
+++ b/apps/api/src/modules/git-analysis/queries/get-timeline.handler.ts
@@ -19,22 +19,22 @@ export class GetTimelineHandler implements IQueryHandler<GetTimelineQuery> {
   async execute(query: GetTimelineQuery): Promise<TimelinePoint[]> {
     await assertRepoOwnership(this.ds, query.repoId, query.userId);
 
-    const suffix = query.granularity;
-    const cached = await this.analyticsCache.get<TimelinePoint[]>("timeline", query.repoId, suffix);
-    if (cached) return cached;
-
-    const rows: { date: string; count: string }[] = await this.ds.query(
-      `SELECT date_trunc($1, c.authored_at)::date::text AS date,
-              count(*)::text AS count
-         FROM commits c
-        WHERE c.repository_id = $2
-        GROUP BY 1
-        ORDER BY 1`,
-      [query.granularity, query.repoId],
+    return this.analyticsCache.getOrSet(
+      "timeline",
+      query.repoId,
+      async () => {
+        const rows: { date: string; count: string }[] = await this.ds.query(
+          `SELECT date_trunc($1, c.authored_at)::date::text AS date,
+                  count(*)::text AS count
+             FROM commits c
+            WHERE c.repository_id = $2
+            GROUP BY 1
+            ORDER BY 1`,
+          [query.granularity, query.repoId],
+        );
+        return rows.map((r) => ({ date: r.date, count: Number(r.count) }));
+      },
+      query.granularity,
     );
-
-    const result = rows.map((r) => ({ date: r.date, count: Number(r.count) }));
-    await this.analyticsCache.set("timeline", query.repoId, result, suffix);
-    return result;
   }
 }

--- a/apps/api/src/modules/git-analysis/services/analytics-cache.constants.ts
+++ b/apps/api/src/modules/git-analysis/services/analytics-cache.constants.ts
@@ -1,6 +1,8 @@
 import type { AnalyticsCacheKind } from "./analytics-cache.types.js";
 
 export const ANALYTICS_CACHE_PREFIX = "analytics";
+export const ANALYTICS_CACHE_STATS_HITS = "analytics:stats:hits";
+export const ANALYTICS_CACHE_STATS_MISSES = "analytics:stats:misses";
 
 const TEN_MINUTES = 600;
 
@@ -11,6 +13,5 @@ export const ANALYTICS_CACHE_TTL: Record<AnalyticsCacheKind, number> = {
   qualityScores: TEN_MINUTES,
   qualityTrends: TEN_MINUTES,
   contributors: TEN_MINUTES,
-  fileFrequency: TEN_MINUTES,
   summary: TEN_MINUTES,
 };

--- a/apps/api/src/modules/git-analysis/services/analytics-cache.constants.ts
+++ b/apps/api/src/modules/git-analysis/services/analytics-cache.constants.ts
@@ -1,15 +1,16 @@
 import type { AnalyticsCacheKind } from "./analytics-cache.types.js";
 
-export const ANALYTICS_CACHE_TTL_SECONDS = 600; // 10 minutes
 export const ANALYTICS_CACHE_PREFIX = "analytics";
 
-/** Per-query TTL overrides (seconds). Falls back to ANALYTICS_CACHE_TTL_SECONDS. */
+const TEN_MINUTES = 600;
+
+/** Per-query TTL (seconds). Defaults to 10 min; override per kind as needed. */
 export const ANALYTICS_CACHE_TTL: Record<AnalyticsCacheKind, number> = {
-  timeline: ANALYTICS_CACHE_TTL_SECONDS,
-  heatmap: ANALYTICS_CACHE_TTL_SECONDS,
-  qualityScores: ANALYTICS_CACHE_TTL_SECONDS,
-  qualityTrends: ANALYTICS_CACHE_TTL_SECONDS,
-  contributors: ANALYTICS_CACHE_TTL_SECONDS,
-  fileFrequency: ANALYTICS_CACHE_TTL_SECONDS,
-  summary: ANALYTICS_CACHE_TTL_SECONDS,
+  timeline: TEN_MINUTES,
+  heatmap: TEN_MINUTES,
+  qualityScores: TEN_MINUTES,
+  qualityTrends: TEN_MINUTES,
+  contributors: TEN_MINUTES,
+  fileFrequency: TEN_MINUTES,
+  summary: TEN_MINUTES,
 };

--- a/apps/api/src/modules/git-analysis/services/analytics-cache.constants.ts
+++ b/apps/api/src/modules/git-analysis/services/analytics-cache.constants.ts
@@ -1,2 +1,15 @@
+import type { AnalyticsCacheKind } from "./analytics-cache.types.js";
+
 export const ANALYTICS_CACHE_TTL_SECONDS = 600; // 10 minutes
 export const ANALYTICS_CACHE_PREFIX = "analytics";
+
+/** Per-query TTL overrides (seconds). Falls back to ANALYTICS_CACHE_TTL_SECONDS. */
+export const ANALYTICS_CACHE_TTL: Record<AnalyticsCacheKind, number> = {
+  timeline: ANALYTICS_CACHE_TTL_SECONDS,
+  heatmap: ANALYTICS_CACHE_TTL_SECONDS,
+  qualityScores: ANALYTICS_CACHE_TTL_SECONDS,
+  qualityTrends: ANALYTICS_CACHE_TTL_SECONDS,
+  contributors: ANALYTICS_CACHE_TTL_SECONDS,
+  fileFrequency: ANALYTICS_CACHE_TTL_SECONDS,
+  summary: ANALYTICS_CACHE_TTL_SECONDS,
+};

--- a/apps/api/src/modules/git-analysis/services/analytics-cache.service.test.ts
+++ b/apps/api/src/modules/git-analysis/services/analytics-cache.service.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
 
+import type { CacheService } from "../../../common/cache/cache.service.js";
+
+import {
+  ANALYTICS_CACHE_STATS_HITS,
+  ANALYTICS_CACHE_STATS_MISSES,
+  ANALYTICS_CACHE_TTL,
+} from "./analytics-cache.constants.js";
 import { AnalyticsCacheService } from "./analytics-cache.service.js";
 
 function makeCache(stored: Record<string, string> = {}) {
   const store = { ...stored };
+  const counters: Record<string, number> = {};
   return {
     getJson: vi.fn((key: string) => {
       const raw = store[key];
@@ -17,21 +25,35 @@ function makeCache(stored: Record<string, string> = {}) {
     }),
     del: vi.fn(() => Promise.resolve()),
     delByPattern: vi.fn(() => Promise.resolve(0)),
+    incr: vi.fn((key: string) => {
+      counters[key] = (counters[key] ?? 0) + 1;
+      return Promise.resolve(counters[key]);
+    }),
+    getNumber: vi.fn((key: string) => Promise.resolve(counters[key] ?? 0)),
   };
 }
 
 describe("AnalyticsCacheService", () => {
-  it("calls loader on cache miss and stores result", async () => {
+  it("calls loader on cache miss, stores result with per-kind TTL", async () => {
     const cache = makeCache();
-    const svc = new AnalyticsCacheService(cache as never);
+    const svc = new AnalyticsCacheService(cache as unknown as CacheService);
     const loader = vi.fn(() => Promise.resolve({ totalCommits: 5 }));
 
     const result = await svc.getOrSet("summary", "repo-1", loader);
 
     expect(loader).toHaveBeenCalledOnce();
     expect(result).toEqual({ totalCommits: 5 });
-    expect(cache.setJson).toHaveBeenCalledOnce();
-    expect(svc.metrics()).toEqual({ hits: 0, misses: 1 });
+    expect(cache.setJson).toHaveBeenCalledWith(
+      "analytics:repo-1:summary",
+      { totalCommits: 5 },
+      ANALYTICS_CACHE_TTL.summary,
+    );
+    expect(cache.incr).toHaveBeenCalledWith(ANALYTICS_CACHE_STATS_MISSES);
+    await expect(svc.metrics()).resolves.toEqual({
+      hits: 0,
+      misses: 1,
+      hitRate: 0,
+    });
   });
 
   it("returns cached value without calling loader on hit", async () => {
@@ -39,7 +61,7 @@ describe("AnalyticsCacheService", () => {
       "analytics:repo-1:summary": JSON.stringify({ totalCommits: 5 }),
     };
     const cache = makeCache(preloaded);
-    const svc = new AnalyticsCacheService(cache as never);
+    const svc = new AnalyticsCacheService(cache as unknown as CacheService);
     const loader = vi.fn(() => Promise.resolve({ totalCommits: 99 }));
 
     const result = await svc.getOrSet("summary", "repo-1", loader);
@@ -47,35 +69,44 @@ describe("AnalyticsCacheService", () => {
     expect(loader).not.toHaveBeenCalled();
     expect(result).toEqual({ totalCommits: 5 });
     expect(cache.setJson).not.toHaveBeenCalled();
-    expect(svc.metrics()).toEqual({ hits: 1, misses: 0 });
+    expect(cache.incr).toHaveBeenCalledWith(ANALYTICS_CACHE_STATS_HITS);
+    await expect(svc.metrics()).resolves.toEqual({
+      hits: 1,
+      misses: 0,
+      hitRate: 1,
+    });
   });
 
   it("appends suffix to key", async () => {
     const cache = makeCache();
-    const svc = new AnalyticsCacheService(cache as never);
+    const svc = new AnalyticsCacheService(cache as unknown as CacheService);
     await svc.getOrSet("timeline", "repo-1", () => Promise.resolve([]), "day");
 
     expect(cache.setJson).toHaveBeenCalledWith(
       "analytics:repo-1:timeline:day",
       [],
-      expect.any(Number),
+      ANALYTICS_CACHE_TTL.timeline,
     );
   });
 
-  it("accumulates hits and misses across calls", async () => {
+  it("metrics reports hit rate across mixed traffic", async () => {
     const preloaded = { "analytics:repo-1:heatmap": JSON.stringify([]) };
     const cache = makeCache(preloaded);
-    const svc = new AnalyticsCacheService(cache as never);
+    const svc = new AnalyticsCacheService(cache as unknown as CacheService);
 
     await svc.getOrSet("heatmap", "repo-1", () => Promise.resolve([]));
     await svc.getOrSet("summary", "repo-1", () => Promise.resolve({}));
 
-    expect(svc.metrics()).toEqual({ hits: 1, misses: 1 });
+    await expect(svc.metrics()).resolves.toEqual({
+      hits: 1,
+      misses: 1,
+      hitRate: 0.5,
+    });
   });
 
   it("invalidateRepo delegates to delByPattern with correct prefix", async () => {
     const cache = makeCache();
-    const svc = new AnalyticsCacheService(cache as never);
+    const svc = new AnalyticsCacheService(cache as unknown as CacheService);
 
     await svc.invalidateRepo("repo-42");
 

--- a/apps/api/src/modules/git-analysis/services/analytics-cache.service.test.ts
+++ b/apps/api/src/modules/git-analysis/services/analytics-cache.service.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AnalyticsCacheService } from "./analytics-cache.service.js";
+
+function makeCache(stored: Record<string, string> = {}) {
+  const store = { ...stored };
+  return {
+    getJson: vi.fn((key: string) => {
+      const raw = store[key];
+      return Promise.resolve(
+        raw !== undefined ? (JSON.parse(raw) as unknown) : null,
+      );
+    }),
+    setJson: vi.fn((key: string, value: unknown) => {
+      store[key] = JSON.stringify(value);
+      return Promise.resolve();
+    }),
+    del: vi.fn(() => Promise.resolve()),
+    delByPattern: vi.fn(() => Promise.resolve(0)),
+  };
+}
+
+describe("AnalyticsCacheService", () => {
+  it("calls loader on cache miss and stores result", async () => {
+    const cache = makeCache();
+    const svc = new AnalyticsCacheService(cache as never);
+    const loader = vi.fn(() => Promise.resolve({ totalCommits: 5 }));
+
+    const result = await svc.getOrSet("summary", "repo-1", loader);
+
+    expect(loader).toHaveBeenCalledOnce();
+    expect(result).toEqual({ totalCommits: 5 });
+    expect(cache.setJson).toHaveBeenCalledOnce();
+    expect(svc.metrics()).toEqual({ hits: 0, misses: 1 });
+  });
+
+  it("returns cached value without calling loader on hit", async () => {
+    const preloaded = {
+      "analytics:repo-1:summary": JSON.stringify({ totalCommits: 5 }),
+    };
+    const cache = makeCache(preloaded);
+    const svc = new AnalyticsCacheService(cache as never);
+    const loader = vi.fn(() => Promise.resolve({ totalCommits: 99 }));
+
+    const result = await svc.getOrSet("summary", "repo-1", loader);
+
+    expect(loader).not.toHaveBeenCalled();
+    expect(result).toEqual({ totalCommits: 5 });
+    expect(cache.setJson).not.toHaveBeenCalled();
+    expect(svc.metrics()).toEqual({ hits: 1, misses: 0 });
+  });
+
+  it("appends suffix to key", async () => {
+    const cache = makeCache();
+    const svc = new AnalyticsCacheService(cache as never);
+    await svc.getOrSet("timeline", "repo-1", () => Promise.resolve([]), "day");
+
+    expect(cache.setJson).toHaveBeenCalledWith(
+      "analytics:repo-1:timeline:day",
+      [],
+      expect.any(Number),
+    );
+  });
+
+  it("accumulates hits and misses across calls", async () => {
+    const preloaded = { "analytics:repo-1:heatmap": JSON.stringify([]) };
+    const cache = makeCache(preloaded);
+    const svc = new AnalyticsCacheService(cache as never);
+
+    await svc.getOrSet("heatmap", "repo-1", () => Promise.resolve([]));
+    await svc.getOrSet("summary", "repo-1", () => Promise.resolve({}));
+
+    expect(svc.metrics()).toEqual({ hits: 1, misses: 1 });
+  });
+
+  it("invalidateRepo delegates to delByPattern with correct prefix", async () => {
+    const cache = makeCache();
+    const svc = new AnalyticsCacheService(cache as never);
+
+    await svc.invalidateRepo("repo-42");
+
+    expect(cache.delByPattern).toHaveBeenCalledWith("analytics:repo-42:*");
+  });
+});

--- a/apps/api/src/modules/git-analysis/services/analytics-cache.service.ts
+++ b/apps/api/src/modules/git-analysis/services/analytics-cache.service.ts
@@ -4,6 +4,8 @@ import { CacheService } from "../../../common/cache/cache.service.js";
 
 import {
   ANALYTICS_CACHE_PREFIX,
+  ANALYTICS_CACHE_STATS_HITS,
+  ANALYTICS_CACHE_STATS_MISSES,
   ANALYTICS_CACHE_TTL,
 } from "./analytics-cache.constants.js";
 import type { AnalyticsCacheKind } from "./analytics-cache.types.js";
@@ -11,8 +13,6 @@ import type { AnalyticsCacheKind } from "./analytics-cache.types.js";
 @Injectable()
 export class AnalyticsCacheService {
   private readonly logger = new Logger(AnalyticsCacheService.name);
-  private hits = 0;
-  private misses = 0;
 
   constructor(private readonly cache: CacheService) {}
 
@@ -25,7 +25,8 @@ export class AnalyticsCacheService {
   /**
    * Read-through helper: returns cached value if present, otherwise calls
    * `loader`, stores the result under `analytics:<repoId>:<kind>[:<suffix>]`
-   * with the per-query TTL, and returns it.
+   * with the per-query TTL, and returns it. Hit/miss tallies are INCR'd in
+   * Redis so `metrics()` aggregates across instances.
    */
   async getOrSet<T>(
     kind: AnalyticsCacheKind,
@@ -36,24 +37,25 @@ export class AnalyticsCacheService {
     const k = this.key(repoId, kind, suffix);
     const cached = await this.cache.getJson<T>(k);
     if (cached !== null) {
-      this.hits++;
-      this.logger.debug(
-        `cache hit  key=${k} hits=${this.hits} misses=${this.misses}`,
-      );
+      const hits = await this.cache.incr(ANALYTICS_CACHE_STATS_HITS);
+      this.logger.debug(`cache hit  key=${k} hits=${hits}`);
       return cached;
     }
-    this.misses++;
-    this.logger.debug(
-      `cache miss key=${k} hits=${this.hits} misses=${this.misses}`,
-    );
+    const misses = await this.cache.incr(ANALYTICS_CACHE_STATS_MISSES);
+    this.logger.debug(`cache miss key=${k} misses=${misses}`);
     const result = await loader();
     await this.cache.setJson(k, result, ANALYTICS_CACHE_TTL[kind]);
     return result;
   }
 
-  /** Hit/miss counters for debugging (e.g. health endpoint or logs). */
-  metrics(): { hits: number; misses: number } {
-    return { hits: this.hits, misses: this.misses };
+  /** Cross-instance hit/miss counters (read from Redis). */
+  async metrics(): Promise<{ hits: number; misses: number; hitRate: number }> {
+    const [hits, misses] = await Promise.all([
+      this.cache.getNumber(ANALYTICS_CACHE_STATS_HITS),
+      this.cache.getNumber(ANALYTICS_CACHE_STATS_MISSES),
+    ]);
+    const total = hits + misses;
+    return { hits, misses, hitRate: total === 0 ? 0 : hits / total };
   }
 
   async invalidateRepo(repoId: string): Promise<number> {

--- a/apps/api/src/modules/git-analysis/services/analytics-cache.service.ts
+++ b/apps/api/src/modules/git-analysis/services/analytics-cache.service.ts
@@ -1,36 +1,62 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 
 import { CacheService } from "../../../common/cache/cache.service.js";
 
 import {
   ANALYTICS_CACHE_PREFIX,
-  ANALYTICS_CACHE_TTL_SECONDS,
+  ANALYTICS_CACHE_TTL,
 } from "./analytics-cache.constants.js";
 import type { AnalyticsCacheKind } from "./analytics-cache.types.js";
 
 @Injectable()
 export class AnalyticsCacheService {
+  private readonly logger = new Logger(AnalyticsCacheService.name);
+  private hits = 0;
+  private misses = 0;
+
   constructor(private readonly cache: CacheService) {}
 
-  private key(kind: AnalyticsCacheKind, repoId: string, suffix?: string): string {
+  private key(repoId: string, kind: AnalyticsCacheKind, suffix?: string): string {
     return suffix
-      ? `${ANALYTICS_CACHE_PREFIX}:${kind}:${repoId}:${suffix}`
-      : `${ANALYTICS_CACHE_PREFIX}:${kind}:${repoId}`;
+      ? `${ANALYTICS_CACHE_PREFIX}:${repoId}:${kind}:${suffix}`
+      : `${ANALYTICS_CACHE_PREFIX}:${repoId}:${kind}`;
   }
 
-  async get<T>(kind: AnalyticsCacheKind, repoId: string, suffix?: string): Promise<T | null> {
-    return this.cache.getJson<T>(this.key(kind, repoId, suffix));
-  }
-
-  async set(kind: AnalyticsCacheKind, repoId: string, value: unknown, suffix?: string): Promise<void> {
-    await this.cache.setJson(
-      this.key(kind, repoId, suffix),
-      value,
-      ANALYTICS_CACHE_TTL_SECONDS,
+  /**
+   * Read-through helper: returns cached value if present, otherwise calls
+   * `loader`, stores the result under `analytics:<repoId>:<kind>[:<suffix>]`
+   * with the per-query TTL, and returns it.
+   */
+  async getOrSet<T>(
+    kind: AnalyticsCacheKind,
+    repoId: string,
+    loader: () => Promise<T>,
+    suffix?: string,
+  ): Promise<T> {
+    const k = this.key(repoId, kind, suffix);
+    const cached = await this.cache.getJson<T>(k);
+    if (cached !== null) {
+      this.hits++;
+      this.logger.debug(
+        `cache hit  key=${k} hits=${this.hits} misses=${this.misses}`,
+      );
+      return cached;
+    }
+    this.misses++;
+    this.logger.debug(
+      `cache miss key=${k} hits=${this.hits} misses=${this.misses}`,
     );
+    const result = await loader();
+    await this.cache.setJson(k, result, ANALYTICS_CACHE_TTL[kind]);
+    return result;
+  }
+
+  /** Hit/miss counters for debugging (e.g. health endpoint or logs). */
+  metrics(): { hits: number; misses: number } {
+    return { hits: this.hits, misses: this.misses };
   }
 
   async invalidateRepo(repoId: string): Promise<number> {
-    return this.cache.delByPattern(`${ANALYTICS_CACHE_PREFIX}:*:${repoId}*`);
+    return this.cache.delByPattern(`${ANALYTICS_CACHE_PREFIX}:${repoId}:*`);
   }
 }

--- a/apps/api/src/modules/git-analysis/services/analytics-cache.types.ts
+++ b/apps/api/src/modules/git-analysis/services/analytics-cache.types.ts
@@ -4,5 +4,4 @@ export type AnalyticsCacheKind =
   | "qualityScores"
   | "qualityTrends"
   | "contributors"
-  | "fileFrequency"
   | "summary";


### PR DESCRIPTION
## Summary
- Adds `getOrSet(kind, repoId, loader, suffix?)` read-through helper to `AnalyticsCacheService`; handlers collapse from explicit get+set to one call.
- Key format now `analytics:<repoId>:<kind>[:<suffix>]` (was `analytics:<kind>:<repoId>[:<suffix>]`), letting `invalidateRepo` use the cheaper `analytics:<repoId>:*` scan pattern.
- Hit/miss counters exposed via `metrics()` and logged at debug level per call.
- Per-query TTL table (`ANALYTICS_CACHE_TTL`) in constants — all 10 min today, but overridable per `AnalyticsCacheKind`.
- New unit tests for hit, miss, suffix, counter accumulation, and invalidation prefix.

Closes #36