### PR TITLE
feat(T-2.11): cache invalidation on repo events

### DIFF
--- a/apps/api/src/modules/git-analysis/events/on-repository-synced.handler.test.ts
+++ b/apps/api/src/modules/git-analysis/events/on-repository-synced.handler.test.ts
@@ -1,0 +1,126 @@
+import type { Redis } from "ioredis";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { CacheService } from "../../../common/cache/cache.service.js";
+import { RepoRescoredEvent } from "../../../shared/events/repo-rescored.event.js";
+import { RepoSyncedEvent } from "../../../shared/events/repo-synced.event.js";
+import { AnalyticsCacheService } from "../services/analytics-cache.service.js";
+
+import { OnRepositorySyncedHandler } from "./on-repository-synced.handler.js";
+
+/**
+ * Minimal in-memory ioredis stand-in. Implements only the commands the
+ * invalidation path exercises (`set`, `get`, `scan`, `del`) with real glob
+ * semantics (`*`) so SCAN/MATCH behaves like production.
+ */
+function createFakeRedis(initial: Record<string, string> = {}): Redis {
+  const store = new Map<string, string>(Object.entries(initial));
+
+  const globToRegex = (pattern: string): RegExp => {
+    const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`^${escaped.replace(/\*/g, ".*")}$`);
+  };
+
+  const redis = {
+    get(key: string) {
+      return Promise.resolve(store.get(key) ?? null);
+    },
+    set(key: string, value: string) {
+      store.set(key, value);
+      return Promise.resolve("OK" as const);
+    },
+    del(...keys: string[]) {
+      let removed = 0;
+      for (const k of keys) {
+        if (store.delete(k)) removed += 1;
+      }
+      return Promise.resolve(removed);
+    },
+    scan(
+      cursor: string,
+      _match: "MATCH",
+      pattern: string,
+      _count: "COUNT",
+      _n: number,
+    ) {
+      const re = globToRegex(pattern);
+      const all = [...store.keys()].filter((k) => re.test(k));
+      return Promise.resolve([
+        "0",
+        cursor === "0" ? all : [],
+      ] as [string, string[]]);
+    },
+    keys() {
+      return [...store.keys()];
+    },
+  };
+
+  return redis as unknown as Redis;
+}
+
+describe("OnRepositorySyncedHandler", () => {
+  let redis: Redis;
+  let handler: OnRepositorySyncedHandler;
+
+  beforeEach(() => {
+    redis = createFakeRedis({
+      "analytics:repo-1:summary": "{}",
+      "analytics:repo-1:timeline": "[]",
+      "analytics:repo-1:heatmap:day": "[]",
+      "analytics:repo-2:summary": "{}",
+      "analytics:repo-2:timeline": "[]",
+      "analytics:stats:hits": "5",
+      "analytics:stats:misses": "3",
+      "unrelated:repo-1": "keep",
+    });
+    const cache = new CacheService(redis);
+    const analyticsCache = new AnalyticsCacheService(cache);
+    handler = new OnRepositorySyncedHandler(analyticsCache);
+  });
+
+  it("wipes only target repo keys on RepoSyncedEvent", async () => {
+    await handler.handle(
+      new RepoSyncedEvent("repo-1", "user-1", "sync-job-1", 42),
+    );
+
+    const remaining = (redis as unknown as { keys(): string[] }).keys();
+    expect(remaining).not.toContain("analytics:repo-1:summary");
+    expect(remaining).not.toContain("analytics:repo-1:timeline");
+    expect(remaining).not.toContain("analytics:repo-1:heatmap:day");
+
+    expect(remaining).toContain("analytics:repo-2:summary");
+    expect(remaining).toContain("analytics:repo-2:timeline");
+    expect(remaining).toContain("unrelated:repo-1");
+  });
+
+  it("preserves cross-repo stats counters (no leaks beyond target)", async () => {
+    await handler.handle(
+      new RepoSyncedEvent("repo-1", "user-1", "sync-job-1", 42),
+    );
+
+    const remaining = (redis as unknown as { keys(): string[] }).keys();
+    // stats counters live under `analytics:stats:*` — invalidation for
+    // `analytics:repo-1:*` must not touch them.
+    expect(remaining).toContain("analytics:stats:hits");
+    expect(remaining).toContain("analytics:stats:misses");
+  });
+
+  it("wipes keys on RepoRescoredEvent just like sync", async () => {
+    await handler.handle(new RepoRescoredEvent("repo-1", "rescore-9", 10));
+
+    const remaining = (redis as unknown as { keys(): string[] }).keys();
+    expect(remaining.filter((k) => k.startsWith("analytics:repo-1:"))).toEqual(
+      [],
+    );
+    expect(remaining).toContain("analytics:repo-2:summary");
+  });
+
+  it("is a no-op when no keys match (no throw, no unrelated deletions)", async () => {
+    await handler.handle(
+      new RepoSyncedEvent("repo-999", "user-1", "sync-job-x", 0),
+    );
+
+    const remaining = (redis as unknown as { keys(): string[] }).keys();
+    expect(remaining).toHaveLength(8);
+  });
+});

--- a/apps/api/src/modules/git-analysis/events/on-repository-synced.handler.ts
+++ b/apps/api/src/modules/git-analysis/events/on-repository-synced.handler.ts
@@ -1,24 +1,28 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { EventsHandler, type IEventHandler } from "@nestjs/cqrs";
 
+import { RepoRescoredEvent } from "../../../shared/events/repo-rescored.event.js";
 import { RepoSyncedEvent } from "../../../shared/events/repo-synced.event.js";
 import { AnalyticsCacheService } from "../services/analytics-cache.service.js";
 
+type InvalidationEvent = RepoSyncedEvent | RepoRescoredEvent;
+
 @Injectable()
-@EventsHandler(RepoSyncedEvent)
+@EventsHandler(RepoSyncedEvent, RepoRescoredEvent)
 export class OnRepositorySyncedHandler
-  implements IEventHandler<RepoSyncedEvent>
+  implements IEventHandler<InvalidationEvent>
 {
   private readonly logger = new Logger(OnRepositorySyncedHandler.name);
 
   constructor(private readonly analyticsCache: AnalyticsCacheService) {}
 
-  async handle(event: RepoSyncedEvent): Promise<void> {
+  async handle(event: InvalidationEvent): Promise<void> {
+    const kind = event instanceof RepoRescoredEvent ? "rescored" : "synced";
     const deleted = await this.analyticsCache.invalidateRepo(
       event.repositoryId,
     );
     this.logger.debug(
-      `invalidated ${deleted} analytics cache keys for repo=${event.repositoryId}`,
+      `invalidated ${deleted} analytics cache keys for repo=${event.repositoryId} trigger=${kind}`,
     );
   }
 }

--- a/apps/api/src/modules/jobs/processors/rescore.processor.test.ts
+++ b/apps/api/src/modules/jobs/processors/rescore.processor.test.ts
@@ -1,8 +1,9 @@
 import type { CommitQualityScoreRepository } from "@commit-analyzer/database";
+import type { EventBus } from "@nestjs/cqrs";
 import type { Job } from "bullmq";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { CacheService } from "../../../common/cache/cache.service.js";
+import { RepoRescoredEvent } from "../../../shared/events/repo-rescored.event.js";
 import type { RescoreJobData } from "../queues/rescore.queue.js";
 
 import { RescoreProcessor } from "./rescore.processor.js";
@@ -29,13 +30,13 @@ describe("RescoreProcessor", () => {
   let processor: RescoreProcessor;
   let queryMock: ReturnType<typeof vi.fn>;
   let upsertBatchMock: ReturnType<typeof vi.fn>;
-  let delByPatternMock: ReturnType<typeof vi.fn>;
+  let publishMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     updateProgressMock.mockReset();
     queryMock = vi.fn().mockResolvedValue([]);
     upsertBatchMock = vi.fn().mockResolvedValue(undefined);
-    delByPatternMock = vi.fn().mockResolvedValue(0);
+    publishMock = vi.fn();
 
     const dataSource = { query: queryMock } as unknown as InstanceType<
       typeof import("typeorm").DataSource
@@ -43,11 +44,9 @@ describe("RescoreProcessor", () => {
     const qualityScoreRepo = {
       upsertBatch: upsertBatchMock,
     } as unknown as CommitQualityScoreRepository;
-    const cacheService = {
-      delByPattern: delByPatternMock,
-    } as unknown as CacheService;
+    const eventBus = { publish: publishMock } as unknown as EventBus;
 
-    processor = new RescoreProcessor(dataSource, qualityScoreRepo, cacheService);
+    processor = new RescoreProcessor(dataSource, qualityScoreRepo, eventBus);
   });
 
   it("processes empty repo without errors", async () => {
@@ -55,7 +54,7 @@ describe("RescoreProcessor", () => {
     await processor.process(job);
     expect(queryMock).toHaveBeenCalledOnce();
     expect(upsertBatchMock).not.toHaveBeenCalled();
-    expect(delByPatternMock).not.toHaveBeenCalled();
+    expect(publishMock).not.toHaveBeenCalled();
   });
 
   it("scores commits in batches and upserts results", async () => {
@@ -123,7 +122,7 @@ describe("RescoreProcessor", () => {
     expect(query[1]).toEqual(["repo-1", 500, 0]);
   });
 
-  it("invalidates analytics cache after scoring", async () => {
+  it("publishes RepoRescoredEvent after scoring", async () => {
     queryMock
       .mockResolvedValueOnce([makeCommit("c1", "fix: patch")])
       .mockResolvedValueOnce([]);
@@ -131,8 +130,12 @@ describe("RescoreProcessor", () => {
     const job = makeJob();
     await processor.process(job);
 
-    expect(delByPatternMock).toHaveBeenCalledOnce();
-    expect(delByPatternMock).toHaveBeenCalledWith("analytics:*:repo-1*");
+    expect(publishMock).toHaveBeenCalledOnce();
+    const event = publishMock.mock.calls[0]![0] as RepoRescoredEvent;
+    expect(event).toBeInstanceOf(RepoRescoredEvent);
+    expect(event.repositoryId).toBe("repo-1");
+    expect(event.rescoreJobId).toBe("rescore-job-1");
+    expect(event.commitsProcessed).toBe(1);
   });
 
   it("logs error on failure event", () => {

--- a/apps/api/src/modules/jobs/processors/rescore.processor.ts
+++ b/apps/api/src/modules/jobs/processors/rescore.processor.ts
@@ -4,22 +4,19 @@ import type {
 } from "@commit-analyzer/database";
 import { OnWorkerEvent, Processor, WorkerHost } from "@nestjs/bullmq";
 import { Inject, Logger } from "@nestjs/common";
+import { EventBus } from "@nestjs/cqrs";
 import type { Job } from "bullmq";
 import type { DataSource } from "typeorm";
 
-import { CacheService } from "../../../common/cache/cache.service.js";
 import {
   COMMIT_QUALITY_SCORE_REPOSITORY,
   DATA_SOURCE,
 } from "../../../common/database/tokens.js";
 import { parseConventionalCommit } from "../../../shared/cc-parser.js";
+import { RepoRescoredEvent } from "../../../shared/events/repo-rescored.event.js";
 import { scoreCommit } from "../../../shared/quality-scorer.js";
 import { RESCORE_QUEUE, type RescoreJobData } from "../queues/rescore.queue.js";
 import { DEFAULT_RESCORE_BATCH_SIZE } from "../services/queue.constants.js";
-
-/** Glob matching all analytics keys for a repo (spec: `analytics:{type}:{repoId}…`). */
-const ANALYTICS_CACHE_PATTERN = (repoId: string) =>
-  `analytics:*:${repoId}*`;
 
 @Processor(RESCORE_QUEUE)
 export class RescoreProcessor extends WorkerHost {
@@ -29,7 +26,7 @@ export class RescoreProcessor extends WorkerHost {
     @Inject(DATA_SOURCE) private readonly dataSource: DataSource,
     @Inject(COMMIT_QUALITY_SCORE_REPOSITORY)
     private readonly qualityScoreRepo: CommitQualityScoreRepository,
-    private readonly cacheService: CacheService,
+    private readonly eventBus: EventBus,
   ) {
     super();
   }
@@ -82,10 +79,8 @@ export class RescoreProcessor extends WorkerHost {
     }
 
     if (processed > 0) {
-      const pattern = ANALYTICS_CACHE_PATTERN(repositoryId);
-      const deleted = await this.cacheService.delByPattern(pattern);
-      this.logger.log(
-        `rescore cache invalidated repositoryId=${repositoryId} keys=${deleted}`,
+      this.eventBus.publish(
+        new RepoRescoredEvent(repositoryId, String(job.id), processed),
       );
     }
 

--- a/apps/api/src/shared/events/repo-rescored.event.ts
+++ b/apps/api/src/shared/events/repo-rescored.event.ts
@@ -1,0 +1,7 @@
+export class RepoRescoredEvent {
+  constructor(
+    public readonly repositoryId: string,
+    public readonly rescoreJobId: string,
+    public readonly commitsProcessed: number,
+  ) {}
+}


### PR DESCRIPTION
## Summary
- New `RepoRescoredEvent` (`apps/api/src/shared/events/repo-rescored.event.ts`) alongside the existing `RepoSyncedEvent`.
- `OnRepositorySyncedHandler` now subscribes to **both** `RepoSyncedEvent` and `RepoRescoredEvent`, wiping `analytics:<repoId>:*` via `AnalyticsCacheService.invalidateRepo()` (which delegates to `CacheService.delByPattern()` → Redis `SCAN`/`DEL`).
- `RescoreProcessor` no longer calls `cacheService.delByPattern` directly; it publishes `RepoRescoredEvent` on success. This also fixes a latent bug: the previous inline pattern `analytics:*:${repoId}*` never matched the real key shape `analytics:<repoId>:<kind>`, so rescore-driven invalidation was a no-op in practice.
- Unit test `on-repository-synced.handler.test.ts` with an in-memory fake Redis implementing real glob semantics for `SCAN`/`MATCH` — asserts only target-repo keys are wiped, cross-repo and unrelated keys survive, stats counters are preserved, and rescore events behave identically to sync.
- `rescore.processor.test.ts` updated: asserts `EventBus.publish(new RepoRescoredEvent(...))` instead of the old direct cache call.

## Acceptance
- [x] After sync completes, next dashboard request is a cache miss → fresh data (`invalidateRepo()` wipes all `analytics:<repoId>:*` entries).
- [x] No leaked keys (verified at SCAN layer in the new handler unit test: unrelated keys — `analytics:repo-2:*`, `analytics:stats:*`, `unrelated:*` — remain after invalidation).

## Verification
- `pnpm -r typecheck` — clean
- `pnpm -r lint` — clean (2 pre-existing web warnings, unrelated)
- `pnpm -F api test` — 277/277 pass

Closes #37