### PR TITLE
fix(T-2.6): drop terminal jobs before re-enqueue

### DIFF
--- a/apps/api/src/modules/jobs/services/queue.service.test.ts
+++ b/apps/api/src/modules/jobs/services/queue.service.test.ts
@@ -95,14 +95,31 @@ describe("QueueService", () => {
     expect(addMock).not.toHaveBeenCalled();
   });
 
-  it("re-enqueues when a prior job completed", async () => {
+  it("removes and re-enqueues when a prior job completed", async () => {
+    const removeMock = vi.fn().mockResolvedValue(undefined);
     getJobMock.mockResolvedValue({
       id: "sync-repo-1",
       getState: vi.fn().mockResolvedValue("completed"),
+      remove: removeMock,
     });
 
     await service.enqueueSync("repo-1", "user-1");
 
+    expect(removeMock).toHaveBeenCalledOnce();
+    expect(addMock).toHaveBeenCalledOnce();
+  });
+
+  it("removes and re-enqueues when a prior job failed", async () => {
+    const removeMock = vi.fn().mockResolvedValue(undefined);
+    getJobMock.mockResolvedValue({
+      id: "sync-repo-1",
+      getState: vi.fn().mockResolvedValue("failed"),
+      remove: removeMock,
+    });
+
+    await service.enqueueSync("repo-1", "user-1");
+
+    expect(removeMock).toHaveBeenCalledOnce();
     expect(addMock).toHaveBeenCalledOnce();
   });
 
@@ -147,14 +164,31 @@ describe("QueueService", () => {
       },
     );
 
-    it("re-enqueues when prior rescore job completed", async () => {
+    it("removes and re-enqueues when prior rescore job completed", async () => {
+      const removeMock = vi.fn().mockResolvedValue(undefined);
       rescoreGetJobMock.mockResolvedValue({
         id: "rescore-repo-1",
         getState: vi.fn().mockResolvedValue("completed"),
+        remove: removeMock,
       });
 
       await service.enqueueRescore("repo-1");
 
+      expect(removeMock).toHaveBeenCalledOnce();
+      expect(rescoreAddMock).toHaveBeenCalledOnce();
+    });
+
+    it("removes and re-enqueues when prior rescore job failed", async () => {
+      const removeMock = vi.fn().mockResolvedValue(undefined);
+      rescoreGetJobMock.mockResolvedValue({
+        id: "rescore-repo-1",
+        getState: vi.fn().mockResolvedValue("failed"),
+        remove: removeMock,
+      });
+
+      await service.enqueueRescore("repo-1");
+
+      expect(removeMock).toHaveBeenCalledOnce();
       expect(rescoreAddMock).toHaveBeenCalledOnce();
     });
   });

--- a/apps/api/src/modules/jobs/services/queue.service.ts
+++ b/apps/api/src/modules/jobs/services/queue.service.ts
@@ -43,6 +43,9 @@ export class QueueService {
         );
         return jobId;
       }
+      // Terminal state (completed/failed/unknown): BullMQ.add() with an existing
+      // jobId returns the old job without re-running. Remove it first.
+      await existing.remove();
     }
 
     await this.syncQueue.add(SYNC_JOB_NAME, { repositoryId, userId }, {
@@ -74,6 +77,7 @@ export class QueueService {
         );
         return jobId;
       }
+      await existing.remove();
     }
 
     const data: RescoreJobData = { repositoryId };


### PR DESCRIPTION
## Summary

- `QueueService.enqueueSync` / `enqueueRescore` now `remove()` any prior job in a terminal state (`completed`/`failed`/`unknown`) before calling `queue.add(..., { jobId })`.
- Fixes the silent no-op where BullMQ returned the existing terminal job and the processor never re-ran.
- In-flight jobs (`active`/`waiting`/`delayed`/`waiting-children`/`prioritized`) still short-circuit and return the existing jobId.
- Unit tests cover all three branches for both methods (skip, remove+add on completed, remove+add on failed).

Closes #187