### PR TITLE
fix(T-2.8): auth via socket.io middleware

### DIFF
--- a/apps/api/src/modules/ws/sync.gateway.test.ts
+++ b/apps/api/src/modules/ws/sync.gateway.test.ts
@@ -1,0 +1,181 @@
+import "reflect-metadata";
+
+import type { Repository as RepoEntity, RepositoryRepository } from "@commit-analyzer/database";
+import { UnauthorizedException } from "@nestjs/common";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Server, Socket } from "socket.io";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SyncGateway } from "./sync.gateway.js";
+
+vi.mock("../../common/config.js", () => ({
+  getServerEnv: () => ({ WEB_ORIGIN: "http://localhost:3000" }),
+}));
+
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+const REPO_ID = "22222222-2222-2222-2222-222222222222";
+
+type NextFn = (err?: Error) => void;
+
+interface TestSocket {
+  socket: Socket;
+  join: ReturnType<typeof vi.fn>;
+}
+
+const makeSocket = (
+  overrides: Partial<{
+    auth: Record<string, unknown>;
+    headers: Record<string, string>;
+    data: Record<string, unknown>;
+  }> = {},
+): TestSocket => {
+  const join = vi.fn();
+  const socket = {
+    id: "sock-1",
+    handshake: {
+      auth: overrides.auth ?? {},
+      headers: overrides.headers ?? {},
+    },
+    data: overrides.data ?? {},
+    join,
+  } as unknown as Socket;
+  return { socket, join };
+};
+
+describe("SyncGateway", () => {
+  let supabase: { auth: { getUser: ReturnType<typeof vi.fn> } };
+  let repos: { findByIdForUser: ReturnType<typeof vi.fn> };
+  let gateway: SyncGateway;
+
+  beforeEach(() => {
+    supabase = { auth: { getUser: vi.fn() } };
+    repos = { findByIdForUser: vi.fn() };
+    gateway = new SyncGateway(
+      supabase as unknown as SupabaseClient,
+      repos as unknown as RepositoryRepository,
+    );
+  });
+
+  describe("afterInit middleware", () => {
+    it("registers a handshake middleware on the namespace server", () => {
+      const use = vi.fn();
+      gateway.afterInit({ use } as unknown as Server);
+      expect(use).toHaveBeenCalledOnce();
+    });
+
+    it("rejects sockets without a token before any message can fire", async () => {
+      const use = vi.fn();
+      gateway.afterInit({ use } as unknown as Server);
+      const middleware = use.mock.calls[0]![0] as (
+        socket: Socket,
+        next: NextFn,
+      ) => void;
+
+      const { socket } = makeSocket();
+      const next = vi.fn();
+      middleware(socket, next);
+      await vi.waitFor(() => expect(next).toHaveBeenCalled());
+
+      const err = next.mock.calls[0]![0] as Error;
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe("missing token");
+      expect(supabase.auth.getUser).not.toHaveBeenCalled();
+    });
+
+    it("rejects sockets whose token Supabase can't validate", async () => {
+      supabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+        error: { message: "jwt expired" },
+      });
+      const use = vi.fn();
+      gateway.afterInit({ use } as unknown as Server);
+      const middleware = use.mock.calls[0]![0] as (
+        socket: Socket,
+        next: NextFn,
+      ) => void;
+
+      const { socket } = makeSocket({ auth: { token: "bad.jwt" } });
+      const next = vi.fn();
+      middleware(socket, next);
+      await vi.waitFor(() => expect(next).toHaveBeenCalled());
+
+      const err = next.mock.calls[0]![0] as Error;
+      expect(err.message).toBe("invalid token");
+    });
+
+    it("sets userId on the socket BEFORE next() is called", async () => {
+      supabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      });
+      const use = vi.fn();
+      gateway.afterInit({ use } as unknown as Server);
+      const middleware = use.mock.calls[0]![0] as (
+        socket: Socket,
+        next: NextFn,
+      ) => void;
+
+      const { socket } = makeSocket({ auth: { token: "good.jwt" } });
+      const next = vi.fn(() => {
+        // Guarantees Nest's @SubscribeMessage handlers — bound right after
+        // middleware resolves — will see a populated socket.data.
+        expect((socket.data as { userId?: string }).userId).toBe(USER_ID);
+      });
+      middleware(socket, next);
+      await vi.waitFor(() => expect(next).toHaveBeenCalledWith());
+    });
+
+    it("accepts `authorization: Bearer <token>` header in addition to auth.token", async () => {
+      supabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: USER_ID } },
+        error: null,
+      });
+      const use = vi.fn();
+      gateway.afterInit({ use } as unknown as Server);
+      const middleware = use.mock.calls[0]![0] as (
+        socket: Socket,
+        next: NextFn,
+      ) => void;
+
+      const { socket } = makeSocket({
+        headers: { authorization: "Bearer hdr.jwt" },
+      });
+      const next = vi.fn();
+      middleware(socket, next);
+      await vi.waitFor(() => expect(next).toHaveBeenCalledWith());
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("hdr.jwt");
+    });
+  });
+
+  describe("handleJoin", () => {
+    it("joins repo:<id> when userId is set and repo is owned", async () => {
+      repos.findByIdForUser.mockResolvedValue({ id: REPO_ID } as RepoEntity);
+      const { socket, join } = makeSocket({ data: { userId: USER_ID } });
+
+      const result = await gateway.handleJoin(socket, { repositoryId: REPO_ID });
+
+      expect(result).toEqual({ ok: true });
+      expect(repos.findByIdForUser).toHaveBeenCalledWith(REPO_ID, USER_ID);
+      expect(join).toHaveBeenCalledWith(`repo:${REPO_ID}`);
+    });
+
+    it("throws when socket.data.userId is missing (pre-fix regression guard)", async () => {
+      const { socket, join } = makeSocket({ data: {} });
+      await expect(
+        gateway.handleJoin(socket, { repositoryId: REPO_ID }),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+      expect(repos.findByIdForUser).not.toHaveBeenCalled();
+      expect(join).not.toHaveBeenCalled();
+    });
+
+    it("throws when repo is not owned by user", async () => {
+      repos.findByIdForUser.mockResolvedValue(null);
+      const { socket, join } = makeSocket({ data: { userId: USER_ID } });
+
+      await expect(
+        gateway.handleJoin(socket, { repositoryId: REPO_ID }),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+      expect(join).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/modules/ws/sync.gateway.ts
+++ b/apps/api/src/modules/ws/sync.gateway.ts
@@ -6,7 +6,6 @@ import {
   UnauthorizedException,
 } from "@nestjs/common";
 import {
-  OnGatewayConnection,
   OnGatewayInit,
   SubscribeMessage,
   WebSocketGateway,
@@ -29,7 +28,7 @@ import { SUPABASE_CLIENT } from "../auth/supabase-auth.guard.js";
     credentials: true,
   },
 })
-export class SyncGateway implements OnGatewayInit, OnGatewayConnection, OnModuleDestroy {
+export class SyncGateway implements OnGatewayInit, OnModuleDestroy {
   private readonly logger = new Logger(SyncGateway.name);
 
   @WebSocketServer()
@@ -40,7 +39,16 @@ export class SyncGateway implements OnGatewayInit, OnGatewayConnection, OnModule
     @Inject(REPOSITORY_REPOSITORY) private readonly repos: RepositoryRepository,
   ) {}
 
-  afterInit(): void {
+  afterInit(server: Server): void {
+    // Auth runs as Socket.IO middleware during handshake — if we put it in
+    // handleConnection (async), Nest binds @SubscribeMessage handlers
+    // synchronously right after firing the connection subject, so the
+    // client's `join` emit can race past `supabase.auth.getUser` and find
+    // `socket.data.userId` still unset. That throws in handleJoin, the
+    // socket never joins the repo room, and progress events are dropped.
+    server.use((socket, next) => {
+      void this.authenticate(socket, next);
+    });
     this.logger.log("ws.gateway initialized");
   }
 
@@ -48,31 +56,38 @@ export class SyncGateway implements OnGatewayInit, OnGatewayConnection, OnModule
     // Redis pub/sub clients are owned by RedisIoAdapter; its close() handles cleanup.
   }
 
-  async handleConnection(client: Socket): Promise<void> {
+  private async authenticate(
+    socket: Socket,
+    next: (err?: Error) => void,
+  ): Promise<void> {
     try {
       const token =
-        (client.handshake.auth as Record<string, unknown>)["token"] as string | undefined ??
-        client.handshake.headers["authorization"]?.toString().replace(/^Bearer /i, "");
+        ((socket.handshake.auth as Record<string, unknown>)["token"] as
+          | string
+          | undefined) ??
+        socket.handshake.headers["authorization"]
+          ?.toString()
+          .replace(/^Bearer /i, "");
 
       if (!token) {
-        this.logger.debug(`ws.connect rejected reason=missing_token id=${client.id}`);
-        client.disconnect(true);
+        this.logger.debug(`ws.connect rejected reason=missing_token id=${socket.id}`);
+        next(new Error("missing token"));
         return;
       }
 
       const { data, error } = await this.supabase.auth.getUser(token);
       if (error || !data?.user) {
-        this.logger.debug(`ws.connect rejected reason=token_rejected id=${client.id}`);
-        client.disconnect(true);
+        this.logger.debug(`ws.connect rejected reason=token_rejected id=${socket.id}`);
+        next(new Error("invalid token"));
         return;
       }
 
-      const userId = data.user.id;
-      client.data = { userId } as { userId: string };
-      this.logger.debug(`ws.connect accepted id=${client.id} userId=${userId}`);
+      socket.data = { userId: data.user.id } as { userId: string };
+      this.logger.debug(`ws.connect accepted id=${socket.id} userId=${data.user.id}`);
+      next();
     } catch (err) {
-      this.logger.error(`ws.connect error id=${client.id}: ${String(err)}`);
-      client.disconnect(true);
+      this.logger.error(`ws.connect error id=${socket.id}: ${String(err)}`);
+      next(new Error("auth error"));
     }
   }
 


### PR DESCRIPTION
## Summary
- Move WS auth from async `handleConnection` to Socket.IO handshake middleware (`server.use` in `afterInit`), closing a race where `@SubscribeMessage("join")` handlers are bound synchronously right after `connection.next()` fires and can run before `supabase.auth.getUser` resolves — leaving `socket.data.userId` unset, `handleJoin` throwing, and the socket never joining the `repo:{id}` room.
- Symptom: sync job completes server-side (`commits=491`) but no `sync.progress` / `sync.completed` reaches the browser; banner stuck at "Starting sync… 0%", and on fresh repo connect the banner never appears.
- Add `sync.gateway.test.ts` covering the middleware (missing/invalid/valid token, Bearer header) and `handleJoin` (success, missing-userId regression guard, foreign repo).

## Test plan
- [x] `pnpm --filter @commit-analyzer/api test -- --run src/modules/ws/sync.gateway.test.ts` (8 pass)
- [x] `pnpm --filter @commit-analyzer/api typecheck`
- [x] `pnpm --filter @commit-analyzer/api lint`
- [ ] Click "Sync now" on an existing repo in prod — banner progresses past 0% and shows "Completed"
- [ ] Connect a new repo — progress banner appears during sync