### PR TITLE
fix(T-2.17): persist lastSyncedAt on sync complete

### DIFF
--- a/apps/api/src/modules/jobs/processors/sync.processor.ts
+++ b/apps/api/src/modules/jobs/processors/sync.processor.ts
@@ -264,8 +264,10 @@ export class SyncProcessor extends WorkerHost {
         });
       }
 
+      const finishedAt = new Date();
       await this.syncJobs.updateProgress(syncJob.id, total, total);
-      await this.syncJobs.markCompleted(syncJob.id, new Date());
+      await this.syncJobs.markCompleted(syncJob.id, finishedAt);
+      await this.repos.touchLastSyncedAt(repositoryId, finishedAt);
 
       this.eventBus.publish(
         new RepoSyncedEvent(repositoryId, userId, syncJob.id, total),

--- a/apps/api/src/modules/jobs/sync.processor.test.ts
+++ b/apps/api/src/modules/jobs/sync.processor.test.ts
@@ -77,7 +77,10 @@ function makeIterator(pages: typeof FIXTURE_COMMITS[]) {
 
 describe("SyncProcessor", () => {
   let processor: SyncProcessor;
-  let reposMock: { findOne: ReturnType<typeof vi.fn> };
+  let reposMock: {
+    findOne: ReturnType<typeof vi.fn>;
+    touchLastSyncedAt: ReturnType<typeof vi.fn>;
+  };
   let syncJobsMock: {
     createJob: ReturnType<typeof vi.fn>;
     markRunning: ReturnType<typeof vi.fn>;
@@ -129,6 +132,7 @@ describe("SyncProcessor", () => {
         fullName: "octocat/hello-world",
         userId: USER_ID,
       }),
+      touchLastSyncedAt: vi.fn().mockResolvedValue(undefined),
     };
 
     syncJobsMock = {
@@ -341,6 +345,19 @@ describe("SyncProcessor", () => {
       expect(event.commitsProcessed).toBe(5);
     });
 
+    it("stamps repository.lastSyncedAt with the same timestamp as the job finishedAt", async () => {
+      const job = makeJob();
+      await processor.process(job);
+
+      expect(reposMock.touchLastSyncedAt).toHaveBeenCalledWith(
+        REPO_ID,
+        expect.any(Date),
+      );
+      const completedAt = syncJobsMock.markCompleted.mock.calls[0]![1] as Date;
+      const touchedAt = reposMock.touchLastSyncedAt.mock.calls[0]![1] as Date;
+      expect(touchedAt.getTime()).toBe(completedAt.getTime());
+    });
+
     it("emits sync.progress after each page", async () => {
       const job = makeJob();
       await processor.process(job);
@@ -503,6 +520,7 @@ describe("SyncProcessor", () => {
         expect.any(Date),
       );
       expect(syncJobsMock.markCompleted).not.toHaveBeenCalled();
+      expect(reposMock.touchLastSyncedAt).not.toHaveBeenCalled();
     });
 
     it("does not upsert when commit fetch fails", async () => {

--- a/packages/database/src/repositories/repository.repository.ts
+++ b/packages/database/src/repositories/repository.repository.ts
@@ -15,6 +15,7 @@ export interface RepositoryRepository extends OrmRepository<Repository> {
   ): Promise<Repository | null>;
   findByIdForUser(id: string, userId: string): Promise<Repository | null>;
   setConnected(id: string, isConnected: boolean): Promise<void>;
+  touchLastSyncedAt(id: string, at: Date): Promise<void>;
   /**
    * Delete all commits for `id` (cascade drops commit_files + quality_scores)
    * and soft-reset the repo row (isConnected=false, lastSyncedAt=null) in one
@@ -33,6 +34,7 @@ export const createRepositoryRepository = (
     | "findByUserAndGithubId"
     | "findByIdForUser"
     | "setConnected"
+    | "touchLastSyncedAt"
     | "purge"
   > = {
     listConnectedByUser(userId: string): Promise<Repository[]> {
@@ -52,6 +54,9 @@ export const createRepositoryRepository = (
     },
     async setConnected(id: string, isConnected: boolean): Promise<void> {
       await base.update({ id }, { isConnected });
+    },
+    async touchLastSyncedAt(id: string, at: Date): Promise<void> {
+      await base.update({ id }, { lastSyncedAt: at });
     },
     async purge(id: string): Promise<PurgeResult> {
       return dataSource.transaction(async (m) => {


### PR DESCRIPTION
## Summary
- Stamp `repositories.lastSyncedAt` with the job's `finishedAt` right after `syncJobs.markCompleted` in `SyncProcessor.process`. Previously the column was only written by `purge()` (to `null`) — so after a successful sync the repo row still reported "Not synced yet" even though `router.refresh()` fired (T-2.17's client-side fix re-fetched the still-null value).
- Add `RepositoryRepository.touchLastSyncedAt(id, at)`.
- Extend `sync.processor.test.ts`: new assertion that the column is stamped with the same timestamp as `markCompleted`, and a regression guard that it is NOT called when the job fails.

## Test plan
- [x] `pnpm --filter @commit-analyzer/api test -- --run src/modules/jobs/sync.processor.test.ts` (24 pass)
- [x] `pnpm --filter @commit-analyzer/api typecheck` / `lint`
- [ ] In prod: click "Sync now" → after banner shows "Completed", `Last synced Xm ago` replaces `Not synced yet`