### PR TITLE
feat(T-2.14): e2e specs + perf gate for sync

### DIFF
--- a/apps/web/e2e/analytics.spec.ts
+++ b/apps/web/e2e/analytics.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "./fixtures";
+import { MOCK_SEEDED_REPO_ID } from "./mock-server";
+
+const CHART_HEADINGS = [
+  "Overview",
+  "Commit timeline",
+  "Quality trend",
+  "Activity heatmap",
+  "Quality distribution",
+  "Top contributors",
+  "Top files by churn",
+] as const;
+
+const SUMMARY_TILES = [
+  "Total commits",
+  "Contributors",
+  "Avg quality",
+  "CC compliance",
+] as const;
+
+test.describe("analytics dashboard", () => {
+  test("renders all 7 charts with non-zero summary numbers", async ({
+    authedPage: page,
+  }) => {
+    await page.goto(`/repositories/${MOCK_SEEDED_REPO_ID}`);
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: "acme/seeded-repo" }),
+    ).toBeVisible();
+
+    for (const name of CHART_HEADINGS) {
+      await expect(
+        page.getByRole("heading", { level: 3, name }),
+      ).toBeVisible();
+    }
+
+    // Each summary tile renders <p class="text-3xl">value</p><p>label</p>.
+    // Walk from the label up to its sibling value, then assert it's non-zero
+    // so an empty repo never silently passes this gate.
+    for (const label of SUMMARY_TILES) {
+      const valueText = await page
+        .locator("p", { hasText: new RegExp(`^${label}$`) })
+        .locator("xpath=preceding-sibling::p[contains(@class,'text-3xl')][1]")
+        .first()
+        .innerText();
+      const numeric = Number(valueText.replace(/[^\d.-]/g, ""));
+      expect(numeric, `${label} should be non-zero (got "${valueText}")`)
+        .toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/web/e2e/mock-server.ts
+++ b/apps/web/e2e/mock-server.ts
@@ -182,8 +182,30 @@ const drivePendingSync = (
 
 // ─── HTTP helpers ───────────────────────────────────────────────────────────
 
-const sendJson = (res: ServerResponse, status: number, body: unknown): void => {
-  res.writeHead(status, { "Content-Type": "application/json" });
+// The browser makes authenticated cross-origin requests from the Next.js dev
+// server (localhost:3000) to this mock (127.0.0.1:54321). Without permissive
+// CORS headers + OPTIONS preflight support, React Query's client-side
+// refetches and the Connect POST fail silently.
+const corsHeaders = (req: IncomingMessage): Record<string, string> => ({
+  "Access-Control-Allow-Origin": req.headers.origin ?? "*",
+  "Access-Control-Allow-Credentials": "true",
+  "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers":
+    req.headers["access-control-request-headers"] ??
+    "authorization, content-type",
+  "Access-Control-Max-Age": "600",
+});
+
+const sendJson = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+): void => {
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    ...corsHeaders(req),
+  });
   res.end(JSON.stringify(body));
 };
 
@@ -213,6 +235,12 @@ const handleRequest = async (
   const url = new URL(req.url ?? "/", `http://127.0.0.1:${MOCK_PORT}`);
   const { pathname, searchParams } = url;
 
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, corsHeaders(req));
+    res.end();
+    return;
+  }
+
   // ── Auth ─────────────────────────────────────────────────────────────────
   if (
     req.method === "POST" &&
@@ -229,13 +257,13 @@ const handleRequest = async (
       user: MOCK_USER,
     };
     req.resume();
-    sendJson(res, 200, session);
+    sendJson(req, res, 200, session);
     return;
   }
 
   if (req.method === "GET" && pathname === "/auth/v1/user") {
-    if (isAuthorized(req)) sendJson(res, 200, MOCK_USER);
-    else sendJson(res, 401, { message: "not authenticated" });
+    if (isAuthorized(req)) sendJson(req, res, 200, MOCK_USER);
+    else sendJson(req, res, 401, { message: "not authenticated" });
     return;
   }
 
@@ -244,14 +272,14 @@ const handleRequest = async (
     (pathname === "/auth/sync" || pathname === "/auth/sign-in-event")
   ) {
     await drainBody(req);
-    sendJson(res, 200, { ok: true });
+    sendJson(req, res, 200, { ok: true });
     return;
   }
 
   // ── Repositories ─────────────────────────────────────────────────────────
   if (req.method === "GET" && pathname === "/repos/github") {
     if (!isAuthorized(req)) {
-      sendJson(res, 401, { message: "unauthorized" });
+      sendJson(req, res, 401, { message: "unauthorized" });
       return;
     }
     // Reflect current connection state so the UI sees freshly-connected repos.
@@ -261,37 +289,37 @@ const handleRequest = async (
         (c) => c.githubRepoId === repo.githubRepoId,
       ),
     }));
-    sendJson(res, 200, { items });
+    sendJson(req, res, 200, { items });
     return;
   }
 
   if (req.method === "GET" && pathname === "/repos") {
     if (!isAuthorized(req)) {
-      sendJson(res, 401, { message: "unauthorized" });
+      sendJson(req, res, 401, { message: "unauthorized" });
       return;
     }
-    sendJson(res, 200, { items: Array.from(connectedRepos.values()) });
+    sendJson(req, res, 200, { items: Array.from(connectedRepos.values()) });
     return;
   }
 
   const connectMatch = /^\/repos\/(\d+)\/connect$/.exec(pathname);
   if (req.method === "POST" && connectMatch) {
     if (!isAuthorized(req)) {
-      sendJson(res, 401, { message: "unauthorized" });
+      sendJson(req, res, 401, { message: "unauthorized" });
       return;
     }
     await drainBody(req);
     const githubRepoId = Number(connectMatch[1]);
     const source = GITHUB_REPOS.find((r) => r.githubRepoId === githubRepoId);
     if (!source) {
-      sendJson(res, 404, { message: "not found" });
+      sendJson(req, res, 404, { message: "not found" });
       return;
     }
     const existing = Array.from(connectedRepos.values()).find(
       (r) => r.githubRepoId === githubRepoId,
     );
     if (existing) {
-      sendJson(res, 409, { message: "already connected" });
+      sendJson(req, res, 409, { message: "already connected" });
       return;
     }
     const connected: ConnectedRepoFixture = {
@@ -309,39 +337,39 @@ const handleRequest = async (
     // always observes the full progress → completed sequence regardless of
     // navigation timing between list and analytics pages.
     pendingSyncs.set(connected.id, { syncJobId: `mock-sync-${connected.id}` });
-    sendJson(res, 201, connected);
+    sendJson(req, res, 201, connected);
     return;
   }
 
   const resyncMatch = /^\/repos\/([0-9a-fA-F-]+)\/resync$/.exec(pathname);
   if (req.method === "POST" && resyncMatch) {
     if (!isAuthorized(req)) {
-      sendJson(res, 401, { message: "unauthorized" });
+      sendJson(req, res, 401, { message: "unauthorized" });
       return;
     }
     await drainBody(req);
     const repoId = resyncMatch[1] as string;
     if (!connectedRepos.has(repoId)) {
-      sendJson(res, 404, { message: "not found" });
+      sendJson(req, res, 404, { message: "not found" });
       return;
     }
     pendingSyncs.set(repoId, { syncJobId: `mock-sync-${repoId}-${Date.now()}` });
-    sendJson(res, 202, {});
+    sendJson(req, res, 202, {});
     return;
   }
 
   const disconnectMatch = /^\/repos\/([0-9a-fA-F-]+)$/.exec(pathname);
   if (req.method === "DELETE" && disconnectMatch) {
     if (!isAuthorized(req)) {
-      sendJson(res, 401, { message: "unauthorized" });
+      sendJson(req, res, 401, { message: "unauthorized" });
       return;
     }
     const repoId = disconnectMatch[1] as string;
     if (!connectedRepos.delete(repoId)) {
-      sendJson(res, 404, { message: "not found" });
+      sendJson(req, res, 404, { message: "not found" });
       return;
     }
-    res.writeHead(204);
+    res.writeHead(204, corsHeaders(req));
     res.end();
     return;
   }
@@ -352,43 +380,43 @@ const handleRequest = async (
   );
   if (req.method === "GET" && analyticsMatch) {
     if (!isAuthorized(req)) {
-      sendJson(res, 401, { message: "unauthorized" });
+      sendJson(req, res, 401, { message: "unauthorized" });
       return;
     }
     const repoId = analyticsMatch[1] as string;
     const sub = analyticsMatch[2] as string;
     if (!connectedRepos.has(repoId)) {
-      sendJson(res, 404, { message: "not found" });
+      sendJson(req, res, 404, { message: "not found" });
       return;
     }
     switch (sub) {
       case "summary":
-        sendJson(res, 200, ANALYTICS_SUMMARY);
+        sendJson(req, res, 200, ANALYTICS_SUMMARY);
         return;
       case "timeline":
-        sendJson(res, 200, { items: ANALYTICS_TIMELINE });
+        sendJson(req, res, 200, { items: ANALYTICS_TIMELINE });
         return;
       case "heatmap":
-        sendJson(res, 200, { items: ANALYTICS_HEATMAP });
+        sendJson(req, res, 200, { items: ANALYTICS_HEATMAP });
         return;
       case "quality":
-        sendJson(res, 200, { items: ANALYTICS_QUALITY_DIST });
+        sendJson(req, res, 200, { items: ANALYTICS_QUALITY_DIST });
         return;
       case "quality/trends":
-        sendJson(res, 200, { items: ANALYTICS_QUALITY_TREND });
+        sendJson(req, res, 200, { items: ANALYTICS_QUALITY_TREND });
         return;
       case "contributors":
-        sendJson(res, 200, { items: ANALYTICS_CONTRIBUTORS });
+        sendJson(req, res, 200, { items: ANALYTICS_CONTRIBUTORS });
         return;
       case "files":
-        sendJson(res, 200, { items: ANALYTICS_FILES });
+        sendJson(req, res, 200, { items: ANALYTICS_FILES });
         return;
     }
-    sendJson(res, 404, { message: "not found" });
+    sendJson(req, res, 404, { message: "not found" });
     return;
   }
 
-  res.writeHead(404);
+  res.writeHead(404, corsHeaders(req));
   res.end();
 };
 
@@ -414,7 +442,7 @@ export const startMockServer = (): Promise<void> =>
     resetState();
     server = createServer((req, res) => {
       void handleRequest(req, res).catch(() => {
-        if (!res.headersSent) sendJson(res, 500, { message: "mock error" });
+        if (!res.headersSent) sendJson(req, res, 500, { message: "mock error" });
       });
     });
 

--- a/apps/web/e2e/mock-server.ts
+++ b/apps/web/e2e/mock-server.ts
@@ -1,4 +1,7 @@
+import { randomUUID } from "node:crypto";
 import { createServer, IncomingMessage, Server, ServerResponse } from "node:http";
+
+import { Server as SocketIOServer, type Namespace } from "socket.io";
 
 export const MOCK_PORT = 54321;
 export const MOCK_ACCESS_TOKEN = "mock-access-token";
@@ -18,13 +21,199 @@ const MOCK_USER = {
 // Pre-populated so the bypass path (page.route interception) works without
 // going through the real token-exchange endpoint.
 const validTokens = new Set<string>([MOCK_ACCESS_TOKEN]);
-let server: Server | null = null;
 
-function handleRequest(req: IncomingMessage, res: ServerResponse) {
+// ─── Repositories & analytics fixtures ──────────────────────────────────────
+
+type GithubRepoFixture = {
+  githubRepoId: number;
+  owner: string;
+  name: string;
+  fullName: string;
+  private: boolean;
+  defaultBranch: string;
+  description: string | null;
+  htmlUrl: string;
+  connected: boolean;
+  pushedAt: string | null;
+  stargazersCount: number;
+  archived: boolean;
+};
+
+type ConnectedRepoFixture = {
+  id: string;
+  githubRepoId: number;
+  owner: string;
+  name: string;
+  fullName: string;
+  defaultBranch: string;
+  lastSyncedAt: string | null;
+  createdAt: string;
+};
+
+// Stable UUIDs for tests to navigate to deterministic analytics URLs.
+export const MOCK_SEEDED_REPO_ID = "11111111-1111-4111-8111-111111111111";
+export const MOCK_FRESH_GITHUB_REPO_ID = 1001;
+export const MOCK_SEEDED_GITHUB_REPO_ID = 1002;
+
+const GITHUB_REPOS: GithubRepoFixture[] = [
+  {
+    githubRepoId: MOCK_FRESH_GITHUB_REPO_ID,
+    owner: "acme",
+    name: "fresh-repo",
+    fullName: "acme/fresh-repo",
+    private: false,
+    defaultBranch: "main",
+    description: "A fresh repository ready to be connected.",
+    htmlUrl: "https://github.com/acme/fresh-repo",
+    connected: false,
+    pushedAt: "2024-03-01T00:00:00.000Z",
+    stargazersCount: 5,
+    archived: false,
+  },
+  {
+    githubRepoId: MOCK_SEEDED_GITHUB_REPO_ID,
+    owner: "acme",
+    name: "seeded-repo",
+    fullName: "acme/seeded-repo",
+    private: false,
+    defaultBranch: "main",
+    description: "Already connected; pre-loaded with analytics fixtures.",
+    htmlUrl: "https://github.com/acme/seeded-repo",
+    connected: true,
+    pushedAt: "2024-02-01T00:00:00.000Z",
+    stargazersCount: 12,
+    archived: false,
+  },
+];
+
+const connectedRepos = new Map<string, ConnectedRepoFixture>();
+
+const ANALYTICS_SUMMARY = {
+  totalCommits: 1234,
+  totalContributors: 7,
+  avgQuality: 82.5,
+  ccCompliancePercent: 91,
+};
+
+const ANALYTICS_TIMELINE = [
+  { date: "2024-01-29", count: 12 },
+  { date: "2024-01-30", count: 18 },
+  { date: "2024-01-31", count: 9 },
+  { date: "2024-02-01", count: 22 },
+  { date: "2024-02-02", count: 15 },
+];
+
+const ANALYTICS_HEATMAP = [
+  { day: 1, hour: 9, count: 5 },
+  { day: 2, hour: 10, count: 8 },
+  { day: 3, hour: 14, count: 3 },
+  { day: 4, hour: 16, count: 11 },
+  { day: 5, hour: 11, count: 7 },
+];
+
+const ANALYTICS_QUALITY_DIST = [
+  { bucket: "good", count: 80 },
+  { bucket: "average", count: 40 },
+  { bucket: "poor", count: 10 },
+];
+
+const ANALYTICS_QUALITY_TREND = [
+  { date: "2024-01-29", avgScore: 78.2 },
+  { date: "2024-01-30", avgScore: 80.1 },
+  { date: "2024-01-31", avgScore: 79.5 },
+  { date: "2024-02-01", avgScore: 83.4 },
+  { date: "2024-02-02", avgScore: 82.5 },
+];
+
+const ANALYTICS_CONTRIBUTORS = [
+  {
+    authorName: "Jane Doe",
+    authorEmail: "jane@example.com",
+    commitCount: 128,
+    avgQuality: 85.4,
+  },
+  {
+    authorName: "John Smith",
+    authorEmail: "john@example.com",
+    commitCount: 94,
+    avgQuality: 79.1,
+  },
+];
+
+const ANALYTICS_FILES = [
+  { filePath: "src/index.ts", changeCount: 120 },
+  { filePath: "apps/api/src/app.module.ts", changeCount: 88 },
+  { filePath: "packages/contracts/src/analytics.contract.ts", changeCount: 54 },
+];
+
+// ─── Sync simulation state ──────────────────────────────────────────────────
+
+type PendingSync = { syncJobId: string };
+
+const pendingSyncs = new Map<string, PendingSync>();
+
+const drivePendingSync = (
+  ns: Namespace,
+  repositoryId: string,
+  pending: PendingSync,
+): void => {
+  const total = 10;
+  let processed = 0;
+  const tick = () => {
+    processed += 2;
+    if (processed >= total) {
+      ns.to(repositoryId).emit("sync.completed", {
+        repositoryId,
+        syncJobId: pending.syncJobId,
+        commitsProcessed: total,
+      });
+      return;
+    }
+    ns.to(repositoryId).emit("sync.progress", {
+      repositoryId,
+      syncJobId: pending.syncJobId,
+      commitsProcessed: processed,
+      totalCommits: total,
+    });
+    setTimeout(tick, 250);
+  };
+  setTimeout(tick, 150);
+};
+
+// ─── HTTP helpers ───────────────────────────────────────────────────────────
+
+const sendJson = (res: ServerResponse, status: number, body: unknown): void => {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+};
+
+const isAuthorized = (req: IncomingMessage): boolean => {
+  const auth = req.headers.authorization ?? "";
+  const token = auth.replace(/^Bearer\s+/i, "");
+  return token.length > 0 && validTokens.has(token);
+};
+
+const drainBody = (req: IncomingMessage): Promise<void> =>
+  new Promise((resolve) => {
+    req.on("data", () => {});
+    req.on("end", () => resolve());
+    req.on("error", () => resolve());
+  });
+
+// ─── Server & socket state ──────────────────────────────────────────────────
+
+let server: Server | null = null;
+let io: SocketIOServer | null = null;
+let syncNamespace: Namespace | null = null;
+
+const handleRequest = async (
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> => {
   const url = new URL(req.url ?? "/", `http://127.0.0.1:${MOCK_PORT}`);
   const { pathname, searchParams } = url;
 
-  // POST /auth/v1/token?grant_type=pkce — exchange code for session
+  // ── Auth ─────────────────────────────────────────────────────────────────
   if (
     req.method === "POST" &&
     pathname === "/auth/v1/token" &&
@@ -39,64 +228,238 @@ function handleRequest(req: IncomingMessage, res: ServerResponse) {
       token_type: "bearer",
       user: MOCK_USER,
     };
-    req.resume(); // drain body
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(session));
+    req.resume();
+    sendJson(res, 200, session);
     return;
   }
 
-  // GET /auth/v1/user — return mock user when token is valid
   if (req.method === "GET" && pathname === "/auth/v1/user") {
-    const auth = req.headers.authorization ?? "";
-    const token = auth.replace(/^Bearer\s+/i, "");
-    if (token && validTokens.has(token)) {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(MOCK_USER));
-    } else {
-      res.writeHead(401, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ message: "not authenticated" }));
+    if (isAuthorized(req)) sendJson(res, 200, MOCK_USER);
+    else sendJson(res, 401, { message: "not authenticated" });
+    return;
+  }
+
+  if (
+    req.method === "POST" &&
+    (pathname === "/auth/sync" || pathname === "/auth/sign-in-event")
+  ) {
+    await drainBody(req);
+    sendJson(res, 200, { ok: true });
+    return;
+  }
+
+  // ── Repositories ─────────────────────────────────────────────────────────
+  if (req.method === "GET" && pathname === "/repos/github") {
+    if (!isAuthorized(req)) {
+      sendJson(res, 401, { message: "unauthorized" });
+      return;
     }
+    // Reflect current connection state so the UI sees freshly-connected repos.
+    const items = GITHUB_REPOS.map((repo) => ({
+      ...repo,
+      connected: Array.from(connectedRepos.values()).some(
+        (c) => c.githubRepoId === repo.githubRepoId,
+      ),
+    }));
+    sendJson(res, 200, { items });
     return;
   }
 
-  // POST /auth/sync — API auth sync (always 200)
-  if (req.method === "POST" && pathname === "/auth/sync") {
-    req.resume();
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ ok: true }));
+  if (req.method === "GET" && pathname === "/repos") {
+    if (!isAuthorized(req)) {
+      sendJson(res, 401, { message: "unauthorized" });
+      return;
+    }
+    sendJson(res, 200, { items: Array.from(connectedRepos.values()) });
     return;
   }
 
-  // POST /auth/sign-in-event — always 200
-  if (req.method === "POST" && pathname === "/auth/sign-in-event") {
-    req.resume();
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ ok: true }));
+  const connectMatch = /^\/repos\/(\d+)\/connect$/.exec(pathname);
+  if (req.method === "POST" && connectMatch) {
+    if (!isAuthorized(req)) {
+      sendJson(res, 401, { message: "unauthorized" });
+      return;
+    }
+    await drainBody(req);
+    const githubRepoId = Number(connectMatch[1]);
+    const source = GITHUB_REPOS.find((r) => r.githubRepoId === githubRepoId);
+    if (!source) {
+      sendJson(res, 404, { message: "not found" });
+      return;
+    }
+    const existing = Array.from(connectedRepos.values()).find(
+      (r) => r.githubRepoId === githubRepoId,
+    );
+    if (existing) {
+      sendJson(res, 409, { message: "already connected" });
+      return;
+    }
+    const connected: ConnectedRepoFixture = {
+      id: randomUUID(),
+      githubRepoId: source.githubRepoId,
+      owner: source.owner,
+      name: source.name,
+      fullName: source.fullName,
+      defaultBranch: source.defaultBranch,
+      lastSyncedAt: null,
+      createdAt: new Date().toISOString(),
+    };
+    connectedRepos.set(connected.id, connected);
+    // Queue a sync — driven once a WS subscriber joins the room, so the banner
+    // always observes the full progress → completed sequence regardless of
+    // navigation timing between list and analytics pages.
+    pendingSyncs.set(connected.id, { syncJobId: `mock-sync-${connected.id}` });
+    sendJson(res, 201, connected);
+    return;
+  }
+
+  const resyncMatch = /^\/repos\/([0-9a-fA-F-]+)\/resync$/.exec(pathname);
+  if (req.method === "POST" && resyncMatch) {
+    if (!isAuthorized(req)) {
+      sendJson(res, 401, { message: "unauthorized" });
+      return;
+    }
+    await drainBody(req);
+    const repoId = resyncMatch[1] as string;
+    if (!connectedRepos.has(repoId)) {
+      sendJson(res, 404, { message: "not found" });
+      return;
+    }
+    pendingSyncs.set(repoId, { syncJobId: `mock-sync-${repoId}-${Date.now()}` });
+    sendJson(res, 202, {});
+    return;
+  }
+
+  const disconnectMatch = /^\/repos\/([0-9a-fA-F-]+)$/.exec(pathname);
+  if (req.method === "DELETE" && disconnectMatch) {
+    if (!isAuthorized(req)) {
+      sendJson(res, 401, { message: "unauthorized" });
+      return;
+    }
+    const repoId = disconnectMatch[1] as string;
+    if (!connectedRepos.delete(repoId)) {
+      sendJson(res, 404, { message: "not found" });
+      return;
+    }
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  // ── Analytics ────────────────────────────────────────────────────────────
+  const analyticsMatch = /^\/repos\/([0-9a-fA-F-]+)\/analytics\/(.+)$/.exec(
+    pathname,
+  );
+  if (req.method === "GET" && analyticsMatch) {
+    if (!isAuthorized(req)) {
+      sendJson(res, 401, { message: "unauthorized" });
+      return;
+    }
+    const repoId = analyticsMatch[1] as string;
+    const sub = analyticsMatch[2] as string;
+    if (!connectedRepos.has(repoId)) {
+      sendJson(res, 404, { message: "not found" });
+      return;
+    }
+    switch (sub) {
+      case "summary":
+        sendJson(res, 200, ANALYTICS_SUMMARY);
+        return;
+      case "timeline":
+        sendJson(res, 200, { items: ANALYTICS_TIMELINE });
+        return;
+      case "heatmap":
+        sendJson(res, 200, { items: ANALYTICS_HEATMAP });
+        return;
+      case "quality":
+        sendJson(res, 200, { items: ANALYTICS_QUALITY_DIST });
+        return;
+      case "quality/trends":
+        sendJson(res, 200, { items: ANALYTICS_QUALITY_TREND });
+        return;
+      case "contributors":
+        sendJson(res, 200, { items: ANALYTICS_CONTRIBUTORS });
+        return;
+      case "files":
+        sendJson(res, 200, { items: ANALYTICS_FILES });
+        return;
+    }
+    sendJson(res, 404, { message: "not found" });
     return;
   }
 
   res.writeHead(404);
   res.end();
-}
+};
 
-export function startMockServer(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    server = createServer(handleRequest);
+// ─── Lifecycle ──────────────────────────────────────────────────────────────
+
+const resetState = (): void => {
+  connectedRepos.clear();
+  connectedRepos.set(MOCK_SEEDED_REPO_ID, {
+    id: MOCK_SEEDED_REPO_ID,
+    githubRepoId: MOCK_SEEDED_GITHUB_REPO_ID,
+    owner: "acme",
+    name: "seeded-repo",
+    fullName: "acme/seeded-repo",
+    defaultBranch: "main",
+    lastSyncedAt: "2024-02-02T00:00:00.000Z",
+    createdAt: "2024-02-01T00:00:00.000Z",
+  });
+  pendingSyncs.clear();
+};
+
+export const startMockServer = (): Promise<void> =>
+  new Promise((resolve, reject) => {
+    resetState();
+    server = createServer((req, res) => {
+      void handleRequest(req, res).catch(() => {
+        if (!res.headersSent) sendJson(res, 500, { message: "mock error" });
+      });
+    });
+
+    io = new SocketIOServer(server, {
+      cors: { origin: true, credentials: true },
+    });
+    syncNamespace = io.of("/sync");
+    syncNamespace.use((socket, next) => {
+      const auth = socket.handshake.auth as { token?: unknown } | undefined;
+      const token = auth?.token;
+      if (typeof token === "string" && token.length > 0) return next();
+      next(new Error("unauthorized"));
+    });
+    syncNamespace.on("connection", (socket) => {
+      socket.on("join", async (payload: { repositoryId?: string }) => {
+        const repositoryId = payload?.repositoryId;
+        if (!repositoryId) return;
+        await socket.join(repositoryId);
+        const pending = pendingSyncs.get(repositoryId);
+        if (!pending || !syncNamespace) return;
+        pendingSyncs.delete(repositoryId);
+        drivePendingSync(syncNamespace, repositoryId, pending);
+      });
+    });
+
     server.listen(MOCK_PORT, "127.0.0.1", () => resolve());
     server.on("error", reject);
   });
-}
 
-export function stopMockServer(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (!server) {
-      resolve();
-      return;
-    }
-    server.close((err) => {
+export const stopMockServer = (): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const closeHttp = (cb: (err?: Error) => void) => {
+      if (!server) return cb();
+      server.close((err) => cb(err ?? undefined));
+    };
+    const done = () => {
       server = null;
-      if (err) reject(err);
-      else resolve();
-    });
+      io = null;
+      syncNamespace = null;
+      resetState();
+      resolve();
+    };
+    if (io) {
+      void io.close(() => closeHttp((err) => (err ? reject(err) : done())));
+    } else {
+      closeHttp((err) => (err ? reject(err) : done()));
+    }
   });
-}

--- a/apps/web/e2e/mock-server.ts
+++ b/apps/web/e2e/mock-server.ts
@@ -474,10 +474,6 @@ export const startMockServer = (): Promise<void> =>
 
 export const stopMockServer = (): Promise<void> =>
   new Promise((resolve, reject) => {
-    const closeHttp = (cb: (err?: Error) => void) => {
-      if (!server) return cb();
-      server.close((err) => cb(err ?? undefined));
-    };
     const done = () => {
       server = null;
       io = null;
@@ -485,9 +481,14 @@ export const stopMockServer = (): Promise<void> =>
       resetState();
       resolve();
     };
+    // Socket.io's `close()` closes the attached HTTP server too — calling
+    // `server.close()` afterwards throws "Server is not running" and trips
+    // Playwright's teardown even when every test passed.
     if (io) {
-      void io.close(() => closeHttp((err) => (err ? reject(err) : done())));
+      void io.close((err) => (err ? reject(err) : done()));
+    } else if (server) {
+      server.close((err) => (err ? reject(err) : done()));
     } else {
-      closeHttp((err) => (err ? reject(err) : done()));
+      done();
     }
   });

--- a/apps/web/e2e/repos.spec.ts
+++ b/apps/web/e2e/repos.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "./fixtures";
+
+test.describe("repositories — connect & sync", () => {
+  test("connect a GitHub repo, then watch the sync banner reach completed", async ({
+    authedPage: page,
+  }) => {
+    await page.goto("/repositories");
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Repositories" }),
+    ).toBeVisible();
+
+    // The fresh GitHub repo card initially has a "Connect" button.
+    const freshGithubCard = page
+      .locator("div.group")
+      .filter({ hasText: "acme/fresh-repo" })
+      .filter({ has: page.getByRole("button", { name: "Connect" }) })
+      .first();
+    await freshGithubCard.getByRole("button", { name: "Connect" }).click();
+
+    await expect(page.getByText("Repository connected")).toBeVisible();
+
+    // The newly connected repo appears in the connected section with a
+    // "View analytics" link — open it so the sync banner mounts and joins
+    // the WebSocket room for this repo.
+    const connectedCard = page
+      .locator("div.group")
+      .filter({ hasText: "acme/fresh-repo" })
+      .filter({ has: page.getByRole("link", { name: "View analytics" }) })
+      .first();
+    await connectedCard.getByRole("link", { name: "View analytics" }).click();
+
+    await expect(page).toHaveURL(/\/repositories\/[0-9a-f-]{36}$/);
+
+    // Sync banner appears (progress bar visible) then completes (banner
+    // unmounts on the "completed" event and a success toast surfaces).
+    const progress = page.getByRole("progressbar", { name: "Sync progress" });
+    await expect(progress).toBeVisible({ timeout: 10_000 });
+
+    await expect(page.getByText("Sync completed")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(progress).toHaveCount(0, { timeout: 5_000 });
+  });
+});

--- a/apps/web/e2e/repos.spec.ts
+++ b/apps/web/e2e/repos.spec.ts
@@ -18,16 +18,18 @@ test.describe("repositories — connect & sync", () => {
       .first();
     await freshGithubCard.getByRole("button", { name: "Connect" }).click();
 
-    await expect(page.getByText("Repository connected")).toBeVisible();
-
     // The newly connected repo appears in the connected section with a
     // "View analytics" link — open it so the sync banner mounts and joins
-    // the WebSocket room for this repo.
+    // the WebSocket room for this repo. The "Repository connected" toast
+    // auto-dismisses, so asserting on the durable UI change instead.
     const connectedCard = page
       .locator("div.group")
       .filter({ hasText: "acme/fresh-repo" })
       .filter({ has: page.getByRole("link", { name: "View analytics" }) })
       .first();
+    await expect(
+      connectedCard.getByRole("link", { name: "View analytics" }),
+    ).toBeVisible();
     await connectedCard.getByRole("link", { name: "View analytics" }).click();
 
     await expect(page).toHaveURL(/\/repositories\/[0-9a-f-]{36}$/);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@types/react-dom": "^19.2.3",
     "eslint": "^9.14.0",
     "eslint-plugin-i18next": "^6.1.3",
+    "socket.io": "^4.8.3",
     "typescript": "^5.6.3"
   },
   "dependencies": {

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,8 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     ".": {
-      "entry": ["commitlint.config.cjs"]
+      "entry": ["commitlint.config.cjs", "tests/load/*.k6.ts"],
+      "ignoreDependencies": ["^k6(/.+)?$"]
     },
     "apps/api": {
       "entry": ["src/main.ts", "src/index.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       eslint-plugin-i18next:
         specifier: ^6.1.3
         version: 6.1.3
+      socket.io:
+        specifier: ^4.8.3
+        version: 4.8.3
       typescript:
         specifier: ^5.6.3
         version: 5.9.3

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,51 @@
+# Load & performance scripts
+
+[k6](https://k6.io) scripts that exercise live API instances. They are not run
+automatically in `pnpm test` — they expect a real, reachable backend (local
+docker stack or staging) and are gated behind the `load` GitHub Actions job
+(manual dispatch, see `docs/10-testing.md` §9).
+
+## Phase 2 exit criterion
+
+`sync.k6.ts` enforces the **Phase 2 exit criterion** from
+`docs/12-roadmap.md`: connecting a real ~1000-commit repository must finish
+within 60 seconds end-to-end. The script's `sync_duration_ms` threshold fails
+the run if any single sync exceeds the budget.
+
+### Seeding a fixture repo
+
+Any GitHub repository with ≥ 1000 commits the authenticated user can list will
+work. Two reproducible options:
+
+1. **Use a public repo your test account has access to** — fork
+   `git/git` (>50k commits) into the test org and set
+   `K6_GITHUB_REPO_ID` to its numeric id.
+2. **Generate one programmatically** with a script that loops `git commit
+   --allow-empty` 1000+ times and pushes to a fresh repo, then OAuth-grants
+   the test user.
+
+### Running
+
+```bash
+# 1. Boot the API + workers locally (or point at staging).
+pnpm dev   # in another terminal
+
+# 2. Mint a fresh JWT for the test user (Supabase admin API or browser cookie).
+export K6_AUTH_TOKEN=<jwt>
+export K6_GITHUB_REPO_ID=<numeric-id-of-seeded-repo>
+export K6_API_BASE_URL=http://localhost:3001
+
+# 3. Run.
+k6 run tests/load/sync.k6.ts
+```
+
+A passing run prints `sync_duration_ms ........: max=…ms (max<60000 ✓)`.
+
+### Other scripts (planned)
+
+`docs/10-testing.md` §8 lists two more scripts that are not yet implemented:
+
+| Script | Target |
+|--------|--------|
+| `analytics.k6.ts` | 50 RPS on `/analytics/timeline` for 60 s; p95 < 500 ms uncached, < 100 ms cached |
+| `generate.k6.ts` | 10 concurrent generations; TTFT < 2 s p95 |

--- a/tests/load/sync.k6.ts
+++ b/tests/load/sync.k6.ts
@@ -1,0 +1,100 @@
+// Phase 2 exit criterion (docs/12-roadmap.md): connecting a real ~1000-commit
+// repository finishes in ≤ 60 s. This script automates that gate.
+//
+// Usage:
+//   K6_API_BASE_URL=https://api.staging.example.com \
+//   K6_AUTH_TOKEN=<supabase-jwt> \
+//   K6_GITHUB_REPO_ID=<numeric-github-id-of-seeded-repo> \
+//   k6 run tests/load/sync.k6.ts
+//
+// Requirements:
+// - k6 v0.52+ (native TypeScript support).
+// - The authenticated user's GitHub OAuth grant must include the seeded repo.
+// - The seeded repo must hold ≥ 1000 commits (see tests/load/README.md).
+
+import http from "k6/http";
+import { check, fail, sleep } from "k6";
+import { Trend } from "k6/metrics";
+
+const BASE_URL = (__ENV.K6_API_BASE_URL ?? "http://localhost:3001").replace(
+  /\/+$/,
+  "",
+);
+const AUTH_TOKEN = __ENV.K6_AUTH_TOKEN;
+const GITHUB_REPO_ID = __ENV.K6_GITHUB_REPO_ID;
+const POLL_INTERVAL_MS = Number(__ENV.K6_POLL_INTERVAL_MS ?? 2000);
+const TIMEOUT_MS = Number(__ENV.K6_SYNC_TIMEOUT_MS ?? 60_000);
+
+const syncDuration = new Trend("sync_duration_ms", true);
+
+export const options = {
+  scenarios: {
+    one_user_one_sync: {
+      executor: "shared-iterations",
+      vus: 1,
+      iterations: 1,
+      maxDuration: "2m",
+    },
+  },
+  thresholds: {
+    // Phase 2 exit criterion: a single 1000-commit sync must complete in
+    // ≤ 60 s end-to-end.
+    sync_duration_ms: ["max<60000"],
+    checks: ["rate==1.0"],
+  },
+};
+
+type ConnectedRepo = {
+  id: string;
+  githubRepoId: number;
+  fullName: string;
+  lastSyncedAt: string | null;
+};
+
+const headers = () => ({
+  Authorization: `Bearer ${AUTH_TOKEN}`,
+  "Content-Type": "application/json",
+});
+
+const connect = (githubRepoId: number): ConnectedRepo => {
+  const res = http.post(
+    `${BASE_URL}/repos/${githubRepoId}/connect`,
+    null,
+    { headers: headers() },
+  );
+  if (!check(res, { "connect → 201": (r) => r.status === 201 })) {
+    fail(`connect failed: ${res.status} ${res.body}`);
+  }
+  return res.json() as ConnectedRepo;
+};
+
+const lastSyncedAt = (repoId: string): string | null => {
+  const res = http.get(`${BASE_URL}/repos`, { headers: headers() });
+  if (res.status !== 200) return null;
+  const body = res.json() as { items: ConnectedRepo[] };
+  const repo = body.items.find((r) => r.id === repoId);
+  return repo?.lastSyncedAt ?? null;
+};
+
+export default function syncPerf(): void {
+  if (!AUTH_TOKEN) fail("K6_AUTH_TOKEN env var is required");
+  if (!GITHUB_REPO_ID) fail("K6_GITHUB_REPO_ID env var is required");
+
+  const start = Date.now();
+  const repo = connect(Number(GITHUB_REPO_ID));
+
+  const deadline = start + TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const at = lastSyncedAt(repo.id);
+    if (at !== null) {
+      const elapsed = Date.now() - start;
+      syncDuration.add(elapsed);
+      check(elapsed, { "sync ≤ 60s": (ms) => ms <= TIMEOUT_MS });
+      return;
+    }
+    sleep(POLL_INTERVAL_MS / 1000);
+  }
+
+  syncDuration.add(Date.now() - start);
+  fail(`sync did not complete within ${TIMEOUT_MS}ms`);
+}


### PR DESCRIPTION
## Summary
- **`e2e/repos.spec.ts`** — connects a mocked GitHub repo from `/repositories`, navigates to analytics, asserts the sync progress banner appears and then reaches the completed state (banner unmounts + `Sync completed` toast).
- **`e2e/analytics.spec.ts`** — navigates to a seeded analytics page, asserts all 7 chart headings (`Overview`, `Commit timeline`, `Quality trend`, `Activity heatmap`, `Quality distribution`, `Top contributors`, `Top files by churn`) and that every summary tile renders a non-zero value.
- **`e2e/mock-server.ts`** — extended with repos, analytics, disconnect, resync HTTP routes and a Socket.io `/sync` namespace. Sync progress is driven lazily on `join`, so the banner always observes the full progress → completed sequence regardless of navigation timing.
- **`tests/load/sync.k6.ts`** — k6 perf script wired as the Phase 2 exit criterion from `docs/12-roadmap.md`: connects a ≥1000-commit fixture repo against a live API and fails the run if `lastSyncedAt` doesn't update within 60s. `tests/load/README.md` documents the seed workflow and wires it to the existing `load` CI job described in `docs/10-testing.md` §8-9.
- `docs/12-roadmap.md` updated locally to point the Phase 2 exit criterion at the new perf script. `docs/` is gitignored in this repo, so the change lives in the working copy only.

## Test plan
- [x] `pnpm -r typecheck`
- [x] `pnpm -r lint` — only pre-existing warnings remain
- [ ] `pnpm -F @commit-analyzer/web exec playwright test` — could not run locally: port 3000 was already bound by another dev server. CI runs the full suite.
- [ ] `k6 run tests/load/sync.k6.ts` — requires live API + seeded repo; documented in `tests/load/README.md`, not executed in this PR.

Closes #40