### PR TITLE
feat(T-3.3): policy validator + 5 v1 rules

### DIFF
--- a/apps/api/src/modules/policy/services/rules/allowed-scopes.rule.ts
+++ b/apps/api/src/modules/policy/services/rules/allowed-scopes.rule.ts
@@ -1,0 +1,23 @@
+import type { RuleFn } from "./types.js";
+
+export type AllowedScopesValue =
+  | { kind: "list"; values: string[] }
+  | { kind: "regex"; pattern: string };
+
+export const allowedScopes: RuleFn<AllowedScopesValue> = (parsed, value) => {
+  const scope = parsed.scope ?? "";
+
+  if (value.kind === "list") {
+    if (value.values.includes(scope)) return { passed: true };
+    return {
+      passed: false,
+      message: `scope "${scope}" is not allowed. Allowed: ${value.values.join(", ")}`,
+    };
+  }
+
+  if (new RegExp(value.pattern).test(scope)) return { passed: true };
+  return {
+    passed: false,
+    message: `scope "${scope}" does not match pattern /${value.pattern}/`,
+  };
+};

--- a/apps/api/src/modules/policy/services/rules/allowed-scopes.rule.ts
+++ b/apps/api/src/modules/policy/services/rules/allowed-scopes.rule.ts
@@ -1,6 +1,6 @@
 import type { RuleFn } from "./types.js";
 
-export type AllowedScopesValue =
+type AllowedScopesValue =
   | { kind: "list"; values: string[] }
   | { kind: "regex"; pattern: string };
 
@@ -15,6 +15,8 @@ export const allowedScopes: RuleFn<AllowedScopesValue> = (parsed, value) => {
     };
   }
 
+  // Pattern validity is enforced on policy create/update (D-policy-engine §7);
+  // validator trusts input and will surface SyntaxError on malformed regex.
   if (new RegExp(value.pattern).test(scope)) return { passed: true };
   return {
     passed: false,

--- a/apps/api/src/modules/policy/services/rules/allowed-types.rule.ts
+++ b/apps/api/src/modules/policy/services/rules/allowed-types.rule.ts
@@ -1,0 +1,9 @@
+import type { RuleFn } from "./types.js";
+
+export const allowedTypes: RuleFn<string[]> = (parsed, value) => {
+  if (value.includes(parsed.type)) return { passed: true };
+  return {
+    passed: false,
+    message: `type "${parsed.type}" is not allowed. Allowed: ${value.join(", ")}`,
+  };
+};

--- a/apps/api/src/modules/policy/services/rules/body-required.rule.ts
+++ b/apps/api/src/modules/policy/services/rules/body-required.rule.ts
@@ -1,0 +1,7 @@
+import type { RuleFn } from "./types.js";
+
+export const bodyRequired: RuleFn<boolean> = (parsed, value) => {
+  if (!value) return { passed: true };
+  if ((parsed.body?.length ?? 0) > 0) return { passed: true };
+  return { passed: false, message: "body is required" };
+};

--- a/apps/api/src/modules/policy/services/rules/footer-required.rule.ts
+++ b/apps/api/src/modules/policy/services/rules/footer-required.rule.ts
@@ -1,0 +1,7 @@
+import type { RuleFn } from "./types.js";
+
+export const footerRequired: RuleFn<boolean> = (parsed, value) => {
+  if (!value) return { passed: true };
+  if ((parsed.footer?.length ?? 0) > 0) return { passed: true };
+  return { passed: false, message: "footer is required" };
+};

--- a/apps/api/src/modules/policy/services/rules/max-subject-length.rule.ts
+++ b/apps/api/src/modules/policy/services/rules/max-subject-length.rule.ts
@@ -1,0 +1,9 @@
+import type { RuleFn } from "./types.js";
+
+export const maxSubjectLength: RuleFn<number> = (parsed, value) => {
+  if (parsed.subject.length <= value) return { passed: true };
+  return {
+    passed: false,
+    message: `subject is ${parsed.subject.length} chars; max allowed is ${value}`,
+  };
+};

--- a/apps/api/src/modules/policy/services/rules/registry.ts
+++ b/apps/api/src/modules/policy/services/rules/registry.ts
@@ -15,10 +15,4 @@ export const RULE_REGISTRY: Record<PolicyRuleType, RuleFn> = {
   footerRequired: footerRequired as RuleFn,
 };
 
-export { allowedScopes } from "./allowed-scopes.rule.js";
-export type { AllowedScopesValue } from "./allowed-scopes.rule.js";
-export { allowedTypes } from "./allowed-types.rule.js";
-export { bodyRequired } from "./body-required.rule.js";
-export { footerRequired } from "./footer-required.rule.js";
-export { maxSubjectLength } from "./max-subject-length.rule.js";
-export * from "./types.js";
+export { UnknownPolicyRuleError } from "./types.js";

--- a/apps/api/src/modules/policy/services/rules/registry.ts
+++ b/apps/api/src/modules/policy/services/rules/registry.ts
@@ -1,0 +1,24 @@
+import type { PolicyRuleType } from "@commit-analyzer/database";
+
+import { allowedScopes } from "./allowed-scopes.rule.js";
+import { allowedTypes } from "./allowed-types.rule.js";
+import { bodyRequired } from "./body-required.rule.js";
+import { footerRequired } from "./footer-required.rule.js";
+import { maxSubjectLength } from "./max-subject-length.rule.js";
+import type { RuleFn } from "./types.js";
+
+export const RULE_REGISTRY: Record<PolicyRuleType, RuleFn> = {
+  allowedTypes: allowedTypes as RuleFn,
+  allowedScopes: allowedScopes as RuleFn,
+  maxSubjectLength: maxSubjectLength as RuleFn,
+  bodyRequired: bodyRequired as RuleFn,
+  footerRequired: footerRequired as RuleFn,
+};
+
+export { allowedScopes } from "./allowed-scopes.rule.js";
+export type { AllowedScopesValue } from "./allowed-scopes.rule.js";
+export { allowedTypes } from "./allowed-types.rule.js";
+export { bodyRequired } from "./body-required.rule.js";
+export { footerRequired } from "./footer-required.rule.js";
+export { maxSubjectLength } from "./max-subject-length.rule.js";
+export * from "./types.js";

--- a/apps/api/src/modules/policy/services/rules/rules.test.ts
+++ b/apps/api/src/modules/policy/services/rules/rules.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import { allowedScopes } from "./allowed-scopes.rule.js";
+import { allowedTypes } from "./allowed-types.rule.js";
+import { bodyRequired } from "./body-required.rule.js";
+import { footerRequired } from "./footer-required.rule.js";
+import { maxSubjectLength } from "./max-subject-length.rule.js";
+import type { ParsedOk } from "./types.js";
+
+const baseParsed: ParsedOk = {
+  ok: true,
+  type: "feat",
+  subject: "add thing",
+  isBreaking: false,
+};
+
+const withOverrides = (o: Partial<ParsedOk>): ParsedOk => ({
+  ...baseParsed,
+  ...o,
+});
+
+describe("allowedTypes", () => {
+  it("passes when type is in the list", () => {
+    expect(
+      allowedTypes(withOverrides({ type: "feat" }), ["feat", "fix"]),
+    ).toEqual({ passed: true });
+  });
+
+  it("fails with message when type is not in the list", () => {
+    const out = allowedTypes(withOverrides({ type: "wip" }), ["feat", "fix"]);
+    expect(out.passed).toBe(false);
+    expect(out.message).toContain("wip");
+    expect(out.message).toContain("feat, fix");
+  });
+
+  it("edge: empty list fails every type", () => {
+    const out = allowedTypes(withOverrides({ type: "feat" }), []);
+    expect(out.passed).toBe(false);
+  });
+});
+
+describe("allowedScopes", () => {
+  describe("list variant", () => {
+    it("passes when scope is in values", () => {
+      expect(
+        allowedScopes(withOverrides({ scope: "api" }), {
+          kind: "list",
+          values: ["api", "web"],
+        }),
+      ).toEqual({ passed: true });
+    });
+
+    it("fails when scope is not in values", () => {
+      const out = allowedScopes(withOverrides({ scope: "cli" }), {
+        kind: "list",
+        values: ["api", "web"],
+      });
+      expect(out.passed).toBe(false);
+      expect(out.message).toContain("cli");
+    });
+
+    it("edge: missing scope treated as empty string", () => {
+      const out = allowedScopes(withOverrides({ scope: undefined }), {
+        kind: "list",
+        values: ["api"],
+      });
+      expect(out.passed).toBe(false);
+      expect(out.message).toContain('""');
+    });
+
+    it("edge: empty string scope matches when list contains empty string", () => {
+      expect(
+        allowedScopes(withOverrides({ scope: undefined }), {
+          kind: "list",
+          values: [""],
+        }),
+      ).toEqual({ passed: true });
+    });
+  });
+
+  describe("regex variant", () => {
+    it("passes when scope matches pattern", () => {
+      expect(
+        allowedScopes(withOverrides({ scope: "api-v2" }), {
+          kind: "regex",
+          pattern: "^api(-v\\d+)?$",
+        }),
+      ).toEqual({ passed: true });
+    });
+
+    it("fails when scope does not match pattern", () => {
+      const out = allowedScopes(withOverrides({ scope: "frontend" }), {
+        kind: "regex",
+        pattern: "^api(-v\\d+)?$",
+      });
+      expect(out.passed).toBe(false);
+      expect(out.message).toContain("frontend");
+    });
+
+    it("edge: missing scope tested as empty string against regex", () => {
+      expect(
+        allowedScopes(withOverrides({ scope: undefined }), {
+          kind: "regex",
+          pattern: "^$",
+        }),
+      ).toEqual({ passed: true });
+    });
+  });
+});
+
+describe("maxSubjectLength", () => {
+  it("passes when subject length is under the limit", () => {
+    expect(
+      maxSubjectLength(withOverrides({ subject: "short" }), 50),
+    ).toEqual({ passed: true });
+  });
+
+  it("passes at exactly the boundary (<=)", () => {
+    expect(
+      maxSubjectLength(withOverrides({ subject: "x".repeat(50) }), 50),
+    ).toEqual({ passed: true });
+  });
+
+  it("fails when subject length exceeds the limit", () => {
+    const out = maxSubjectLength(
+      withOverrides({ subject: "x".repeat(51) }),
+      50,
+    );
+    expect(out.passed).toBe(false);
+    expect(out.message).toContain("51");
+    expect(out.message).toContain("50");
+  });
+
+  it("edge: limit 0 rejects every non-empty subject", () => {
+    const out = maxSubjectLength(withOverrides({ subject: "x" }), 0);
+    expect(out.passed).toBe(false);
+  });
+});
+
+describe("bodyRequired", () => {
+  it("passes when value=false regardless of body", () => {
+    expect(bodyRequired(withOverrides({ body: undefined }), false)).toEqual({
+      passed: true,
+    });
+  });
+
+  it("passes when value=true and body present", () => {
+    expect(
+      bodyRequired(withOverrides({ body: "why this change" }), true),
+    ).toEqual({ passed: true });
+  });
+
+  it("fails when value=true and body missing", () => {
+    expect(bodyRequired(withOverrides({ body: undefined }), true)).toEqual({
+      passed: false,
+      message: "body is required",
+    });
+  });
+
+  it("edge: empty-string body counts as missing", () => {
+    expect(bodyRequired(withOverrides({ body: "" }), true)).toEqual({
+      passed: false,
+      message: "body is required",
+    });
+  });
+});
+
+describe("footerRequired", () => {
+  it("passes when value=false regardless of footer", () => {
+    expect(footerRequired(withOverrides({ footer: undefined }), false)).toEqual(
+      { passed: true },
+    );
+  });
+
+  it("passes when value=true and footer present", () => {
+    expect(
+      footerRequired(withOverrides({ footer: "Closes #7" }), true),
+    ).toEqual({ passed: true });
+  });
+
+  it("fails when value=true and footer missing", () => {
+    expect(footerRequired(withOverrides({ footer: undefined }), true)).toEqual({
+      passed: false,
+      message: "footer is required",
+    });
+  });
+
+  it("edge: empty-string footer counts as missing", () => {
+    expect(footerRequired(withOverrides({ footer: "" }), true)).toEqual({
+      passed: false,
+      message: "footer is required",
+    });
+  });
+});

--- a/apps/api/src/modules/policy/services/rules/types.ts
+++ b/apps/api/src/modules/policy/services/rules/types.ts
@@ -1,0 +1,17 @@
+import type { ParsedCC } from "../../../../shared/cc-parser.js";
+
+export type ParsedOk = Extract<ParsedCC, { ok: true }>;
+
+export type RuleOutcome = { passed: boolean; message?: string };
+
+export type RuleFn<TValue = unknown> = (
+  parsed: ParsedOk,
+  value: TValue,
+) => RuleOutcome;
+
+export class UnknownPolicyRuleError extends Error {
+  constructor(public readonly ruleType: string) {
+    super(`Unknown policy rule type: ${ruleType}`);
+    this.name = "UnknownPolicyRuleError";
+  }
+}

--- a/apps/api/src/modules/policy/services/validator.service.test.ts
+++ b/apps/api/src/modules/policy/services/validator.service.test.ts
@@ -1,0 +1,156 @@
+import "reflect-metadata";
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { UnknownPolicyRuleError } from "./rules/registry.js";
+import { ValidatorService } from "./validator.service.js";
+import type { ValidatorPolicy } from "./validator.service.types.js";
+
+const makePolicy = (
+  rules: ValidatorPolicy["rules"] = [],
+): ValidatorPolicy => ({ rules });
+
+describe("ValidatorService", () => {
+  let service: ValidatorService;
+
+  beforeEach(() => {
+    service = new ValidatorService();
+  });
+
+  describe("format short-circuit", () => {
+    it("returns format failure when message is empty", () => {
+      const r = service.validate(
+        "",
+        makePolicy([{ ruleType: "allowedTypes", ruleValue: ["feat"] }]),
+      );
+      expect(r).toEqual({
+        passed: false,
+        results: [{ ruleType: "format", passed: false, message: "empty" }],
+      });
+    });
+
+    it("returns format failure with reason=no-type", () => {
+      const r = service.validate("not a conventional commit", makePolicy());
+      expect(r.passed).toBe(false);
+      expect(r.results).toHaveLength(1);
+      expect(r.results[0]).toEqual({
+        ruleType: "format",
+        passed: false,
+        message: "no-type",
+      });
+    });
+
+    it("returns format failure with reason=malformed-header", () => {
+      const r = service.validate("Feat: upper case", makePolicy());
+      expect(r.results[0]?.message).toBe("malformed-header");
+    });
+
+    it("skips all rules on format failure", () => {
+      const r = service.validate(
+        "bad",
+        makePolicy([{ ruleType: "allowedTypes", ruleValue: ["feat"] }]),
+      );
+      expect(r.results).toHaveLength(1);
+    });
+  });
+
+  describe("rule orchestration", () => {
+    it("passes when all rules pass", () => {
+      const r = service.validate(
+        "feat(api): add endpoint\n\nbody text\n\nCloses #1",
+        makePolicy([
+          { ruleType: "allowedTypes", ruleValue: ["feat", "fix"] },
+          {
+            ruleType: "allowedScopes",
+            ruleValue: { kind: "list", values: ["api", "web"] },
+          },
+          { ruleType: "maxSubjectLength", ruleValue: 50 },
+          { ruleType: "bodyRequired", ruleValue: true },
+          { ruleType: "footerRequired", ruleValue: true },
+        ]),
+      );
+      expect(r.passed).toBe(true);
+      expect(r.results).toHaveLength(5);
+      expect(r.results.every((x) => x.passed)).toBe(true);
+    });
+
+    it("fails when any rule fails and runs every rule", () => {
+      const r = service.validate(
+        "feat: huge subject that goes way past the configured limit for sure",
+        makePolicy([
+          { ruleType: "allowedTypes", ruleValue: ["feat"] },
+          { ruleType: "maxSubjectLength", ruleValue: 10 },
+        ]),
+      );
+      expect(r.passed).toBe(false);
+      expect(r.results).toHaveLength(2);
+      expect(r.results[0]?.passed).toBe(true);
+      expect(r.results[1]?.passed).toBe(false);
+    });
+
+    it("returns passed=true with empty results when policy has no rules", () => {
+      const r = service.validate("feat: noop", makePolicy([]));
+      expect(r).toEqual({ passed: true, results: [] });
+    });
+
+    it("preserves rule order in results", () => {
+      const r = service.validate(
+        "feat: ok",
+        makePolicy([
+          { ruleType: "maxSubjectLength", ruleValue: 50 },
+          { ruleType: "allowedTypes", ruleValue: ["feat"] },
+        ]),
+      );
+      expect(r.results.map((x) => x.ruleType)).toEqual([
+        "maxSubjectLength",
+        "allowedTypes",
+      ]);
+    });
+
+    it("omits message when rule passes", () => {
+      const r = service.validate(
+        "feat: ok",
+        makePolicy([{ ruleType: "allowedTypes", ruleValue: ["feat"] }]),
+      );
+      expect(r.results[0]).toEqual({ ruleType: "allowedTypes", passed: true });
+      expect("message" in r.results[0]!).toBe(false);
+    });
+
+    it("includes message when rule fails", () => {
+      const r = service.validate(
+        "feat: ok",
+        makePolicy([{ ruleType: "allowedTypes", ruleValue: ["fix"] }]),
+      );
+      expect(r.results[0]?.passed).toBe(false);
+      expect(r.results[0]?.message).toBeDefined();
+    });
+  });
+
+  describe("unknown rule type", () => {
+    it("throws UnknownPolicyRuleError for an unregistered ruleType", () => {
+      const bogus = {
+        ruleType: "subject_imperative",
+        ruleValue: true,
+      } as never;
+      expect(() => service.validate("feat: ok", makePolicy([bogus]))).toThrow(
+        UnknownPolicyRuleError,
+      );
+    });
+
+    it("error carries the offending ruleType", () => {
+      const bogus = {
+        ruleType: "ticket_reference",
+        ruleValue: "X",
+      } as never;
+      try {
+        service.validate("feat: ok", makePolicy([bogus]));
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(UnknownPolicyRuleError);
+        expect((err as UnknownPolicyRuleError).ruleType).toBe(
+          "ticket_reference",
+        );
+      }
+    });
+  });
+});

--- a/apps/api/src/modules/policy/services/validator.service.ts
+++ b/apps/api/src/modules/policy/services/validator.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from "@nestjs/common";
+
+import { parseConventionalCommit } from "../../../shared/cc-parser.js";
+
+import { RULE_REGISTRY, UnknownPolicyRuleError } from "./rules/registry.js";
+import type {
+  RuleResult,
+  ValidationResult,
+  ValidatorPolicy,
+} from "./validator.service.types.js";
+
+@Injectable()
+export class ValidatorService {
+  validate(message: string, policy: ValidatorPolicy): ValidationResult {
+    const parsed = parseConventionalCommit(message);
+
+    if (!parsed.ok) {
+      return {
+        passed: false,
+        results: [
+          { ruleType: "format", passed: false, message: parsed.reason },
+        ],
+      };
+    }
+
+    const results: RuleResult[] = [];
+
+    for (const rule of policy.rules) {
+      const fn = RULE_REGISTRY[rule.ruleType];
+      if (!fn) throw new UnknownPolicyRuleError(rule.ruleType);
+
+      const outcome = fn(parsed, rule.ruleValue);
+      results.push({
+        ruleType: rule.ruleType,
+        passed: outcome.passed,
+        ...(outcome.message !== undefined ? { message: outcome.message } : {}),
+      });
+    }
+
+    return { passed: results.every((r) => r.passed), results };
+  }
+}

--- a/apps/api/src/modules/policy/services/validator.service.types.ts
+++ b/apps/api/src/modules/policy/services/validator.service.types.ts
@@ -1,0 +1,21 @@
+import type { PolicyRuleType } from "@commit-analyzer/database";
+
+export type RuleResult = {
+  ruleType: PolicyRuleType | "format";
+  passed: boolean;
+  message?: string;
+};
+
+export type ValidationResult = {
+  passed: boolean;
+  results: RuleResult[];
+};
+
+export type ValidatorPolicyRule = {
+  ruleType: PolicyRuleType;
+  ruleValue: unknown;
+};
+
+export type ValidatorPolicy = {
+  rules: ValidatorPolicyRule[];
+};


### PR DESCRIPTION
## Summary
- Pure `ValidatorService` (NestJS-injectable, stateless) that checks a commit message against an ordered list of policy rules.
- Exactly the five v1 rule kinds from `docs/08-algorithms.md` §5 / `docs/04-database.md` `policy_rules.rule_type` enum:
  - `allowedTypes`, `allowedScopes` (list | regex), `maxSubjectLength`, `bodyRequired`, `footerRequired`.
- Each rule is a pure `(parsed, value) => { passed, message? }` in its own file under `services/rules/`, wired through a `RULE_REGISTRY` keyed by `PolicyRuleType`.
- Short-circuits on `parseCC` failure with a single `{ ruleType: 'format', passed: false, message: parsed.reason }` result.
- Unknown `rule_type` throws typed `UnknownPolicyRuleError` (carries the offending `ruleType`), so adding a future rule kind to the DB enum without a registry entry fails loudly instead of silently passing.
- No I/O, no DB access, no Nest DI dependencies — safe to call from any consumer.

## Scope notes
- Does not register the service in `policy.module.ts` — that's T-3.2's surface (PR #197 in-flight). Wiring can land there or in a later task.
- v2 rule kinds (`subject_imperative`, `body_required_when`, `forbidden_pattern`, `ticket_reference`) intentionally not added; the DB enum does not accept them.

## Test plan
- [x] `pnpm -F @commit-analyzer/api typecheck` — clean
- [x] `pnpm -F @commit-analyzer/api lint` — clean
- [x] Policy tests: 34 passing (22 rule matrix × {pass, fail, edge} + 12 orchestrator)
- [x] Full api non-integration suite: 310 passing, 0 regressions
- [x] Branch coverage (local `vitest --coverage` run, scoped to `src/modules/policy/**`): 100% stmts / branches / funcs / lines across all 8 source files

Closes #43