### PR TITLE
feat(T-3.4): policies ts-rest contract + ctrl

### DIFF
--- a/apps/api/src/modules/policy/policies.controller.ts
+++ b/apps/api/src/modules/policy/policies.controller.ts
@@ -1,0 +1,112 @@
+import { policiesContract } from "@commit-analyzer/contracts";
+import { Controller, UseGuards } from "@nestjs/common";
+import { TsRestHandler, tsRestHandler } from "@ts-rest/nest";
+
+import { ThrottleTierDecorator } from "../../common/throttler/throttle-tier.decorator.js";
+import { CurrentUser } from "../auth/current-user.decorator.js";
+import { SupabaseAuthGuard } from "../auth/supabase-auth.guard.js";
+
+import { toPolicyDto } from "./policy.mappers.js";
+import { PolicyService } from "./policy.service.js";
+import { ValidatorService } from "./services/validator.service.js";
+
+@Controller()
+@UseGuards(SupabaseAuthGuard)
+@ThrottleTierDecorator("default")
+export class PoliciesController {
+  constructor(
+    private readonly policies: PolicyService,
+    private readonly validator: ValidatorService,
+  ) {}
+
+  @TsRestHandler(policiesContract.list)
+  list(@CurrentUser() userId: string): unknown {
+    return tsRestHandler(policiesContract.list, async ({ params }) => {
+      const items = await this.policies.list(userId, params.repoId);
+      return { status: 200, body: { items: items.map(toPolicyDto) } };
+    });
+  }
+
+  @TsRestHandler(policiesContract.get)
+  get(@CurrentUser() userId: string): unknown {
+    return tsRestHandler(policiesContract.get, async ({ params }) => {
+      const policy = await this.policies.get(userId, params.repoId, params.id);
+      return { status: 200, body: toPolicyDto(policy) };
+    });
+  }
+
+  @TsRestHandler(policiesContract.create)
+  create(@CurrentUser() userId: string): unknown {
+    return tsRestHandler(
+      policiesContract.create,
+      async ({ params, body }) => {
+        const policy = await this.policies.create(
+          userId,
+          params.repoId,
+          body,
+        );
+        return { status: 201, body: toPolicyDto(policy) };
+      },
+    );
+  }
+
+  @TsRestHandler(policiesContract.update)
+  update(@CurrentUser() userId: string): unknown {
+    return tsRestHandler(
+      policiesContract.update,
+      async ({ params, body }) => {
+        const policy = await this.policies.update(
+          userId,
+          params.repoId,
+          params.id,
+          body,
+        );
+        return { status: 200, body: toPolicyDto(policy) };
+      },
+    );
+  }
+
+  @TsRestHandler(policiesContract.delete as never)
+  delete(@CurrentUser() userId: string): unknown {
+    return tsRestHandler(
+      policiesContract.delete as never,
+      (async ({ params }: { params: { repoId: string; id: string } }) => {
+        await this.policies.delete(userId, params.repoId, params.id);
+        return { status: 204, body: undefined };
+      }) as never,
+    );
+  }
+
+  @TsRestHandler(policiesContract.activate)
+  activate(@CurrentUser() userId: string): unknown {
+    return tsRestHandler(policiesContract.activate, async ({ params }) => {
+      const policy = await this.policies.activate(
+        userId,
+        params.repoId,
+        params.id,
+      );
+      return { status: 200, body: toPolicyDto(policy) };
+    });
+  }
+
+  @TsRestHandler(policiesContract.validate)
+  validate(@CurrentUser() userId: string): unknown {
+    return tsRestHandler(
+      policiesContract.validate,
+      async ({ params, body }) => {
+        const policy = await this.policies.get(
+          userId,
+          params.repoId,
+          params.id,
+        );
+        const result = this.validator.validate(body.message, {
+          rules: policy.rules.map((r) => ({
+            ruleType: r.ruleType,
+            ruleValue: r.ruleValue,
+          })),
+        });
+        return { status: 200, body: result };
+      },
+    );
+  }
+}

--- a/apps/api/src/modules/policy/policy.mappers.ts
+++ b/apps/api/src/modules/policy/policy.mappers.ts
@@ -1,0 +1,18 @@
+import type { PolicyDto, PolicyRuleDto } from "@commit-analyzer/contracts";
+import type { Policy, PolicyRule } from "@commit-analyzer/database";
+
+const toRuleDto = (rule: PolicyRule): PolicyRuleDto => ({
+  id: rule.id,
+  ruleType: rule.ruleType,
+  ruleValue: rule.ruleValue,
+});
+
+export const toPolicyDto = (policy: Policy): PolicyDto => ({
+  id: policy.id,
+  repositoryId: policy.repositoryId,
+  name: policy.name,
+  isActive: policy.isActive,
+  rules: (policy.rules ?? []).map(toRuleDto),
+  createdAt: policy.createdAt.toISOString(),
+  updatedAt: policy.updatedAt.toISOString(),
+});

--- a/apps/api/src/modules/policy/policy.mappers.ts
+++ b/apps/api/src/modules/policy/policy.mappers.ts
@@ -1,11 +1,14 @@
 import type { PolicyDto, PolicyRuleDto } from "@commit-analyzer/contracts";
 import type { Policy, PolicyRule } from "@commit-analyzer/database";
 
-const toRuleDto = (rule: PolicyRule): PolicyRuleDto => ({
-  id: rule.id,
-  ruleType: rule.ruleType,
-  ruleValue: rule.ruleValue,
-});
+// The { ruleType, ruleValue } pair is validated by the Zod `policyRuleSchema`
+// on every create/update path, so the discriminant is already correct in the DB.
+const toRuleDto = (rule: PolicyRule): PolicyRuleDto =>
+  ({
+    id: rule.id,
+    ruleType: rule.ruleType,
+    ruleValue: rule.ruleValue,
+  }) as PolicyRuleDto;
 
 export const toPolicyDto = (policy: Policy): PolicyDto => ({
   id: policy.id,

--- a/apps/api/src/modules/policy/policy.module.ts
+++ b/apps/api/src/modules/policy/policy.module.ts
@@ -1,17 +1,23 @@
 import { Module } from "@nestjs/common";
 import { CqrsModule } from "@nestjs/cqrs";
 
+import { AuthModule } from "../auth/auth.module.js";
+
 import { ApplyDefaultPolicyOnRepoConnected } from "./apply-default-policy.handler.js";
 import { DefaultPolicyService } from "./default-policy.service.js";
+import { PoliciesController } from "./policies.controller.js";
 import { PolicyService } from "./policy.service.js";
+import { ValidatorService } from "./services/validator.service.js";
 
 @Module({
-  imports: [CqrsModule],
+  imports: [CqrsModule, AuthModule],
+  controllers: [PoliciesController],
   providers: [
     PolicyService,
     DefaultPolicyService,
     ApplyDefaultPolicyOnRepoConnected,
+    ValidatorService,
   ],
-  exports: [PolicyService, DefaultPolicyService],
+  exports: [PolicyService, DefaultPolicyService, ValidatorService],
 })
 export class PolicyModule {}

--- a/apps/api/src/modules/policy/policy.schemas.ts
+++ b/apps/api/src/modules/policy/policy.schemas.ts
@@ -7,7 +7,6 @@ import { z } from "zod";
 
 export {
   createPolicySchema,
-  policyRuleSchema,
   updatePolicySchema,
 } from "@commit-analyzer/contracts";
 

--- a/apps/api/src/modules/policy/policy.schemas.ts
+++ b/apps/api/src/modules/policy/policy.schemas.ts
@@ -1,65 +1,15 @@
+import {
+  createPolicySchema,
+  policyRuleSchema,
+  updatePolicySchema,
+} from "@commit-analyzer/contracts";
 import { z } from "zod";
 
-const isValidRegex = (pattern: string): boolean => {
-  try {
-    new RegExp(pattern);
-    return true;
-  } catch {
-    return false;
-  }
-};
-
-const allowedTypesRule = z.object({
-  ruleType: z.literal("allowedTypes"),
-  ruleValue: z.array(z.string().min(1)).min(1),
-});
-
-const allowedScopesRule = z.object({
-  ruleType: z.literal("allowedScopes"),
-  ruleValue: z.discriminatedUnion("kind", [
-    z.object({
-      kind: z.literal("list"),
-      values: z.array(z.string().min(1)).min(1),
-    }),
-    z.object({
-      kind: z.literal("regex"),
-      pattern: z.string().refine(isValidRegex, "invalid regex"),
-    }),
-  ]),
-});
-
-const maxSubjectLengthRule = z.object({
-  ruleType: z.literal("maxSubjectLength"),
-  ruleValue: z.number().int().positive().max(500),
-});
-
-const bodyRequiredRule = z.object({
-  ruleType: z.literal("bodyRequired"),
-  ruleValue: z.boolean(),
-});
-
-const footerRequiredRule = z.object({
-  ruleType: z.literal("footerRequired"),
-  ruleValue: z.boolean(),
-});
-
-const policyRuleSchema = z.discriminatedUnion("ruleType", [
-  allowedTypesRule,
-  allowedScopesRule,
-  maxSubjectLengthRule,
-  bodyRequiredRule,
-  footerRequiredRule,
-]);
-
-export const createPolicySchema = z.object({
-  name: z.string().min(1).max(100),
-  rules: z.array(policyRuleSchema).default([]),
-});
-
-export const updatePolicySchema = z.object({
-  name: z.string().min(1).max(100).optional(),
-  rules: z.array(policyRuleSchema).optional(),
-});
+export {
+  createPolicySchema,
+  policyRuleSchema,
+  updatePolicySchema,
+} from "@commit-analyzer/contracts";
 
 export type CreatePolicyInputParsed = z.infer<typeof createPolicySchema>;
 export type UpdatePolicyInputParsed = z.infer<typeof updatePolicySchema>;

--- a/apps/api/src/modules/policy/policy.service.test.ts
+++ b/apps/api/src/modules/policy/policy.service.test.ts
@@ -46,6 +46,7 @@ const policyEntity = (overrides: Partial<Policy> = {}): Policy =>
 describe("PolicyService", () => {
   const policies = {
     listByRepository: vi.fn(),
+    listByRepositoryWithRules: vi.fn(),
     findWithRules: vi.fn(),
     getActiveForRepo: vi.fn(),
     createWithRules: vi.fn(),
@@ -74,7 +75,7 @@ describe("PolicyService", () => {
       await expect(service.list(USER_ID, REPO_ID)).rejects.toBeInstanceOf(
         PolicyRepoNotFoundError,
       );
-      expect(policies.listByRepository).not.toHaveBeenCalled();
+      expect(policies.listByRepositoryWithRules).not.toHaveBeenCalled();
     });
 
     it("get: 404 when repo not owned", async () => {
@@ -93,14 +94,14 @@ describe("PolicyService", () => {
   });
 
   describe("list", () => {
-    it("returns policies for repo when owned", async () => {
+    it("returns policies with rules for repo when owned", async () => {
       repos.findByIdForUser.mockResolvedValue(repoEntity());
-      policies.listByRepository.mockResolvedValue([policyEntity()]);
+      policies.listByRepositoryWithRules.mockResolvedValue([policyEntity()]);
 
       const result = await service.list(USER_ID, REPO_ID);
 
       expect(repos.findByIdForUser).toHaveBeenCalledWith(REPO_ID, USER_ID);
-      expect(policies.listByRepository).toHaveBeenCalledWith(REPO_ID);
+      expect(policies.listByRepositoryWithRules).toHaveBeenCalledWith(REPO_ID);
       expect(result).toHaveLength(1);
     });
   });

--- a/apps/api/src/modules/policy/policy.service.ts
+++ b/apps/api/src/modules/policy/policy.service.ts
@@ -42,7 +42,7 @@ export class PolicyService {
 
   async list(userId: string, repositoryId: string): Promise<Policy[]> {
     await this.ensureRepoOwned(userId, repositoryId);
-    return this.policies.listByRepository(repositoryId);
+    return this.policies.listByRepositoryWithRules(repositoryId);
   }
 
   async get(

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3,6 +3,7 @@ import { initContract } from "@ts-rest/core";
 import { analyticsContract } from "./analytics.contract.js";
 import { auditContract } from "./audit.contract.js";
 import { authContract } from "./auth.contract.js";
+import { policiesContract } from "./policies.contract.js";
 import { reposContract } from "./repos.contract.js";
 
 const c = initContract();
@@ -12,6 +13,7 @@ export const contracts = c.router({
   audit: auditContract,
   analytics: analyticsContract,
   repos: reposContract,
+  policies: policiesContract,
 });
 
 export type Contracts = typeof contracts;
@@ -63,6 +65,36 @@ export {
   summarySchema,
   timelinePointSchema,
 } from "./analytics.contract.js";
+
+export { policiesContract } from "./policies.contract.js";
+export type {
+  CreatePolicyInput,
+  PolicyDto,
+  PolicyRuleDto,
+  PolicyRuleInput,
+  PolicyRuleTypeName,
+  RuleResultDto,
+  UpdatePolicyInput,
+  ValidatePolicyInput,
+  ValidationResultDto,
+} from "./policies.contract.js";
+export {
+  allowedScopesRuleSchema,
+  allowedTypesRuleSchema,
+  bodyRequiredRuleSchema,
+  createPolicySchema,
+  footerRequiredRuleSchema,
+  maxSubjectLengthRuleSchema,
+  policyDtoSchema,
+  policyRuleDtoSchema,
+  policyRuleSchema,
+  policyRuleTypes,
+  policyRuleTypeSchema,
+  ruleResultSchema,
+  updatePolicySchema,
+  validatePolicyInputSchema,
+  validationResultSchema,
+} from "./policies.contract.js";
 
 export { errorEnvelopeSchema } from "./shared/error.js";
 export type { ErrorEnvelope } from "./shared/error.js";

--- a/packages/contracts/src/policies.contract.test.ts
+++ b/packages/contracts/src/policies.contract.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createPolicySchema,
+  policiesContract,
+  policyDtoSchema,
+  policyRuleSchema,
+  ruleResultSchema,
+  updatePolicySchema,
+  validatePolicyInputSchema,
+  validationResultSchema,
+} from "./policies.contract.js";
+
+const uuid = "2f5c1e3a-9d4b-4a7e-8f2c-1b3d4e5f6a7b";
+
+const validPolicyDto = {
+  id: uuid,
+  repositoryId: "a1111111-2222-4333-8444-555555555555",
+  name: "conventional-commits",
+  isActive: true,
+  rules: [
+    {
+      id: "b1111111-2222-4333-8444-555555555555",
+      ruleType: "maxSubjectLength" as const,
+      ruleValue: 72,
+    },
+  ],
+  createdAt: "2026-04-20T10:00:00.000Z",
+  updatedAt: "2026-04-22T10:00:00.000Z",
+};
+
+describe("policyRuleSchema", () => {
+  it("accepts allowedTypes with a non-empty list", () => {
+    expect(
+      policyRuleSchema.parse({
+        ruleType: "allowedTypes",
+        ruleValue: ["feat", "fix"],
+      }),
+    ).toEqual({ ruleType: "allowedTypes", ruleValue: ["feat", "fix"] });
+  });
+
+  it("accepts allowedScopes with a regex kind", () => {
+    const parsed = policyRuleSchema.parse({
+      ruleType: "allowedScopes",
+      ruleValue: { kind: "regex", pattern: "^[a-z-]+$" },
+    });
+    expect(parsed.ruleType).toBe("allowedScopes");
+  });
+
+  it("rejects allowedScopes with invalid regex", () => {
+    expect(() =>
+      policyRuleSchema.parse({
+        ruleType: "allowedScopes",
+        ruleValue: { kind: "regex", pattern: "[unclosed" },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects maxSubjectLength above 500", () => {
+    expect(() =>
+      policyRuleSchema.parse({ ruleType: "maxSubjectLength", ruleValue: 501 }),
+    ).toThrow();
+  });
+
+  it("rejects unknown rule type", () => {
+    expect(() =>
+      policyRuleSchema.parse({ ruleType: "unknown", ruleValue: true }),
+    ).toThrow();
+  });
+});
+
+describe("createPolicySchema", () => {
+  it("defaults rules to an empty array", () => {
+    const parsed = createPolicySchema.parse({ name: "strict" });
+    expect(parsed.rules).toEqual([]);
+  });
+
+  it("rejects empty name", () => {
+    expect(() => createPolicySchema.parse({ name: "" })).toThrow();
+  });
+});
+
+describe("updatePolicySchema", () => {
+  it("allows name only", () => {
+    expect(updatePolicySchema.parse({ name: "renamed" })).toEqual({
+      name: "renamed",
+    });
+  });
+
+  it("allows rules only", () => {
+    const parsed = updatePolicySchema.parse({
+      rules: [{ ruleType: "bodyRequired", ruleValue: true }],
+    });
+    expect(parsed.rules).toHaveLength(1);
+  });
+});
+
+describe("policyDtoSchema", () => {
+  it("parses a valid policy dto", () => {
+    expect(policyDtoSchema.parse(validPolicyDto)).toEqual(validPolicyDto);
+  });
+
+  it("rejects non-iso createdAt", () => {
+    expect(() =>
+      policyDtoSchema.parse({ ...validPolicyDto, createdAt: "today" }),
+    ).toThrow();
+  });
+});
+
+describe("validatePolicyInputSchema", () => {
+  it("accepts a non-empty message", () => {
+    expect(
+      validatePolicyInputSchema.parse({ message: "feat: add widget" }),
+    ).toEqual({ message: "feat: add widget" });
+  });
+
+  it("rejects an empty message", () => {
+    expect(() => validatePolicyInputSchema.parse({ message: "" })).toThrow();
+  });
+});
+
+describe("ruleResultSchema", () => {
+  it("accepts format result without message", () => {
+    expect(
+      ruleResultSchema.parse({ ruleType: "format", passed: false }),
+    ).toEqual({ ruleType: "format", passed: false });
+  });
+
+  it("accepts a rule-type result with a message", () => {
+    expect(
+      ruleResultSchema.parse({
+        ruleType: "bodyRequired",
+        passed: false,
+        message: "body is required",
+      }),
+    ).toMatchObject({ ruleType: "bodyRequired", passed: false });
+  });
+});
+
+describe("validationResultSchema", () => {
+  it("parses a passed validation", () => {
+    expect(
+      validationResultSchema.parse({
+        passed: true,
+        results: [{ ruleType: "maxSubjectLength", passed: true }],
+      }),
+    ).toMatchObject({ passed: true });
+  });
+});
+
+describe("policiesContract", () => {
+  it("declares every endpoint in scope", () => {
+    expect(policiesContract.list.method).toBe("GET");
+    expect(policiesContract.list.path).toBe("/repos/:repoId/policies");
+    expect(policiesContract.get.method).toBe("GET");
+    expect(policiesContract.get.path).toBe("/repos/:repoId/policies/:id");
+    expect(policiesContract.create.method).toBe("POST");
+    expect(policiesContract.create.path).toBe("/repos/:repoId/policies");
+    expect(policiesContract.update.method).toBe("PATCH");
+    expect(policiesContract.update.path).toBe("/repos/:repoId/policies/:id");
+    expect(policiesContract.delete.method).toBe("DELETE");
+    expect(policiesContract.delete.path).toBe("/repos/:repoId/policies/:id");
+    expect(policiesContract.activate.method).toBe("POST");
+    expect(policiesContract.activate.path).toBe(
+      "/repos/:repoId/policies/:id/activate",
+    );
+    expect(policiesContract.validate.method).toBe("POST");
+    expect(policiesContract.validate.path).toBe(
+      "/repos/:repoId/policies/:id/validate",
+    );
+  });
+
+  it("tags every policy endpoint with jwt + default rate limit", () => {
+    const expected = { auth: "jwt", rateLimit: "default" };
+    expect(policiesContract.list.metadata).toEqual(expected);
+    expect(policiesContract.get.metadata).toEqual(expected);
+    expect(policiesContract.create.metadata).toEqual(expected);
+    expect(policiesContract.update.metadata).toEqual(expected);
+    expect(policiesContract.delete.metadata).toEqual(expected);
+    expect(policiesContract.activate.metadata).toEqual(expected);
+    expect(policiesContract.validate.metadata).toEqual(expected);
+  });
+});

--- a/packages/contracts/src/policies.contract.ts
+++ b/packages/contracts/src/policies.contract.ts
@@ -2,6 +2,7 @@ import { initContract } from "@ts-rest/core";
 import { z } from "zod";
 
 import { errorEnvelopeSchema } from "./shared/error.js";
+import type { RouteMetadata } from "./shared/metadata.js";
 
 const c = initContract();
 
@@ -80,11 +81,15 @@ export const updatePolicySchema = z.object({
 });
 export type UpdatePolicyInput = z.infer<typeof updatePolicySchema>;
 
-export const policyRuleDtoSchema = z.object({
-  id: z.string().uuid(),
-  ruleType: policyRuleTypeSchema,
-  ruleValue: z.unknown(),
-});
+const ruleIdShape = { id: z.string().uuid() };
+
+export const policyRuleDtoSchema = z.discriminatedUnion("ruleType", [
+  allowedTypesRuleSchema.extend(ruleIdShape),
+  allowedScopesRuleSchema.extend(ruleIdShape),
+  maxSubjectLengthRuleSchema.extend(ruleIdShape),
+  bodyRequiredRuleSchema.extend(ruleIdShape),
+  footerRequiredRuleSchema.extend(ruleIdShape),
+]);
 export type PolicyRuleDto = z.infer<typeof policyRuleDtoSchema>;
 
 export const policyDtoSchema = z.object({
@@ -134,7 +139,7 @@ export const policiesContract = c.router(
         404: errorEnvelopeSchema,
       },
       summary: "List policies for a repository",
-      metadata: { auth: "jwt", rateLimit: "default" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } satisfies RouteMetadata,
     },
     get: {
       method: "GET",
@@ -146,7 +151,7 @@ export const policiesContract = c.router(
         404: errorEnvelopeSchema,
       },
       summary: "Get a policy by id",
-      metadata: { auth: "jwt", rateLimit: "default" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } satisfies RouteMetadata,
     },
     create: {
       method: "POST",
@@ -160,7 +165,7 @@ export const policiesContract = c.router(
         404: errorEnvelopeSchema,
       },
       summary: "Create a policy for a repository",
-      metadata: { auth: "jwt", rateLimit: "default" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } satisfies RouteMetadata,
     },
     update: {
       method: "PATCH",
@@ -174,7 +179,7 @@ export const policiesContract = c.router(
         404: errorEnvelopeSchema,
       },
       summary: "Update a policy",
-      metadata: { auth: "jwt", rateLimit: "default" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } satisfies RouteMetadata,
     },
     delete: {
       method: "DELETE",
@@ -188,7 +193,7 @@ export const policiesContract = c.router(
         404: errorEnvelopeSchema,
       },
       summary: "Delete a policy (inactive only)",
-      metadata: { auth: "jwt", rateLimit: "default" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } satisfies RouteMetadata,
     },
     activate: {
       method: "POST",
@@ -202,7 +207,7 @@ export const policiesContract = c.router(
         409: errorEnvelopeSchema,
       },
       summary: "Activate a policy for its repository (atomic swap)",
-      metadata: { auth: "jwt", rateLimit: "default" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } satisfies RouteMetadata,
     },
     validate: {
       method: "POST",
@@ -216,7 +221,7 @@ export const policiesContract = c.router(
         404: errorEnvelopeSchema,
       },
       summary: "Validate a commit message against a policy",
-      metadata: { auth: "jwt", rateLimit: "default" } as const,
+      metadata: { auth: "jwt", rateLimit: "default" } satisfies RouteMetadata,
     },
   },
   { strictStatusCodes: true },

--- a/packages/contracts/src/policies.contract.ts
+++ b/packages/contracts/src/policies.contract.ts
@@ -1,0 +1,223 @@
+import { initContract } from "@ts-rest/core";
+import { z } from "zod";
+
+import { errorEnvelopeSchema } from "./shared/error.js";
+
+const c = initContract();
+
+const isValidRegex = (pattern: string): boolean => {
+  try {
+    new RegExp(pattern);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const policyRuleTypes = [
+  "allowedTypes",
+  "allowedScopes",
+  "maxSubjectLength",
+  "bodyRequired",
+  "footerRequired",
+] as const;
+
+export const policyRuleTypeSchema = z.enum(policyRuleTypes);
+export type PolicyRuleTypeName = z.infer<typeof policyRuleTypeSchema>;
+
+export const allowedTypesRuleSchema = z.object({
+  ruleType: z.literal("allowedTypes"),
+  ruleValue: z.array(z.string().min(1)).min(1),
+});
+
+export const allowedScopesRuleSchema = z.object({
+  ruleType: z.literal("allowedScopes"),
+  ruleValue: z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("list"),
+      values: z.array(z.string().min(1)).min(1),
+    }),
+    z.object({
+      kind: z.literal("regex"),
+      pattern: z.string().refine(isValidRegex, "invalid regex"),
+    }),
+  ]),
+});
+
+export const maxSubjectLengthRuleSchema = z.object({
+  ruleType: z.literal("maxSubjectLength"),
+  ruleValue: z.number().int().positive().max(500),
+});
+
+export const bodyRequiredRuleSchema = z.object({
+  ruleType: z.literal("bodyRequired"),
+  ruleValue: z.boolean(),
+});
+
+export const footerRequiredRuleSchema = z.object({
+  ruleType: z.literal("footerRequired"),
+  ruleValue: z.boolean(),
+});
+
+export const policyRuleSchema = z.discriminatedUnion("ruleType", [
+  allowedTypesRuleSchema,
+  allowedScopesRuleSchema,
+  maxSubjectLengthRuleSchema,
+  bodyRequiredRuleSchema,
+  footerRequiredRuleSchema,
+]);
+export type PolicyRuleInput = z.infer<typeof policyRuleSchema>;
+
+export const createPolicySchema = z.object({
+  name: z.string().min(1).max(100),
+  rules: z.array(policyRuleSchema).default([]),
+});
+export type CreatePolicyInput = z.infer<typeof createPolicySchema>;
+
+export const updatePolicySchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  rules: z.array(policyRuleSchema).optional(),
+});
+export type UpdatePolicyInput = z.infer<typeof updatePolicySchema>;
+
+export const policyRuleDtoSchema = z.object({
+  id: z.string().uuid(),
+  ruleType: policyRuleTypeSchema,
+  ruleValue: z.unknown(),
+});
+export type PolicyRuleDto = z.infer<typeof policyRuleDtoSchema>;
+
+export const policyDtoSchema = z.object({
+  id: z.string().uuid(),
+  repositoryId: z.string().uuid(),
+  name: z.string(),
+  isActive: z.boolean(),
+  rules: z.array(policyRuleDtoSchema),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+export type PolicyDto = z.infer<typeof policyDtoSchema>;
+
+export const ruleResultSchema = z.object({
+  ruleType: z.union([policyRuleTypeSchema, z.literal("format")]),
+  passed: z.boolean(),
+  message: z.string().optional(),
+});
+export type RuleResultDto = z.infer<typeof ruleResultSchema>;
+
+export const validationResultSchema = z.object({
+  passed: z.boolean(),
+  results: z.array(ruleResultSchema),
+});
+export type ValidationResultDto = z.infer<typeof validationResultSchema>;
+
+export const validatePolicyInputSchema = z.object({
+  message: z.string().min(1),
+});
+export type ValidatePolicyInput = z.infer<typeof validatePolicyInputSchema>;
+
+const repoPathParams = z.object({ repoId: z.string().uuid() });
+const repoAndPolicyPathParams = z.object({
+  repoId: z.string().uuid(),
+  id: z.string().uuid(),
+});
+
+export const policiesContract = c.router(
+  {
+    list: {
+      method: "GET",
+      path: "/repos/:repoId/policies",
+      pathParams: repoPathParams,
+      responses: {
+        200: z.object({ items: z.array(policyDtoSchema) }),
+        401: errorEnvelopeSchema,
+        404: errorEnvelopeSchema,
+      },
+      summary: "List policies for a repository",
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
+    },
+    get: {
+      method: "GET",
+      path: "/repos/:repoId/policies/:id",
+      pathParams: repoAndPolicyPathParams,
+      responses: {
+        200: policyDtoSchema,
+        401: errorEnvelopeSchema,
+        404: errorEnvelopeSchema,
+      },
+      summary: "Get a policy by id",
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
+    },
+    create: {
+      method: "POST",
+      path: "/repos/:repoId/policies",
+      pathParams: repoPathParams,
+      body: createPolicySchema,
+      responses: {
+        201: policyDtoSchema,
+        400: errorEnvelopeSchema,
+        401: errorEnvelopeSchema,
+        404: errorEnvelopeSchema,
+      },
+      summary: "Create a policy for a repository",
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
+    },
+    update: {
+      method: "PATCH",
+      path: "/repos/:repoId/policies/:id",
+      pathParams: repoAndPolicyPathParams,
+      body: updatePolicySchema,
+      responses: {
+        200: policyDtoSchema,
+        400: errorEnvelopeSchema,
+        401: errorEnvelopeSchema,
+        404: errorEnvelopeSchema,
+      },
+      summary: "Update a policy",
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
+    },
+    delete: {
+      method: "DELETE",
+      path: "/repos/:repoId/policies/:id",
+      pathParams: repoAndPolicyPathParams,
+      body: c.noBody(),
+      responses: {
+        204: c.noBody(),
+        400: errorEnvelopeSchema,
+        401: errorEnvelopeSchema,
+        404: errorEnvelopeSchema,
+      },
+      summary: "Delete a policy (inactive only)",
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
+    },
+    activate: {
+      method: "POST",
+      path: "/repos/:repoId/policies/:id/activate",
+      pathParams: repoAndPolicyPathParams,
+      body: z.object({}).strict(),
+      responses: {
+        200: policyDtoSchema,
+        401: errorEnvelopeSchema,
+        404: errorEnvelopeSchema,
+        409: errorEnvelopeSchema,
+      },
+      summary: "Activate a policy for its repository (atomic swap)",
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
+    },
+    validate: {
+      method: "POST",
+      path: "/repos/:repoId/policies/:id/validate",
+      pathParams: repoAndPolicyPathParams,
+      body: validatePolicyInputSchema,
+      responses: {
+        200: validationResultSchema,
+        400: errorEnvelopeSchema,
+        401: errorEnvelopeSchema,
+        404: errorEnvelopeSchema,
+      },
+      summary: "Validate a commit message against a policy",
+      metadata: { auth: "jwt", rateLimit: "default" } as const,
+    },
+  },
+  { strictStatusCodes: true },
+);

--- a/packages/database/src/repositories/policy.repository.ts
+++ b/packages/database/src/repositories/policy.repository.ts
@@ -23,6 +23,7 @@ export interface UpdatePolicyInput {
 
 export interface PolicyRepository extends OrmRepository<Policy> {
   listByRepository(repositoryId: string): Promise<Policy[]>;
+  listByRepositoryWithRules(repositoryId: string): Promise<Policy[]>;
   findWithRules(id: string): Promise<Policy | null>;
   getActiveForRepo(repositoryId: string): Promise<Policy | null>;
   createWithRules(input: CreatePolicyInput): Promise<Policy>;
@@ -45,6 +46,7 @@ export const createPolicyRepository = (
   const extensions: Pick<
     PolicyRepository,
     | "listByRepository"
+    | "listByRepositoryWithRules"
     | "findWithRules"
     | "getActiveForRepo"
     | "createWithRules"
@@ -55,6 +57,13 @@ export const createPolicyRepository = (
     listByRepository(repositoryId: string): Promise<Policy[]> {
       return base.find({
         where: { repositoryId },
+        order: { createdAt: "DESC" },
+      });
+    },
+    listByRepositoryWithRules(repositoryId: string): Promise<Policy[]> {
+      return base.find({
+        where: { repositoryId },
+        relations: { rules: true },
         order: { createdAt: "DESC" },
       });
     },


### PR DESCRIPTION
## Summary
- New `policies.contract.ts` in `@commit-analyzer/contracts` — list, get, create, update, delete, activate, `POST /repos/:repoId/policies/:id/validate`; Zod schemas shared FE↔BE.
- `PoliciesController` wires each endpoint to `PolicyService` + `ValidatorService` through `@TsRestHandler` under `SupabaseAuthGuard` with the `default` throttle tier.
- `validate` returns full `RuleResult[]`, handling `format` failures for non-conventional messages.
- Server `policy.schemas.ts` now re-exports the shared schemas (single source of truth).

## Test plan
- [x] `pnpm -F @commit-analyzer/contracts test` — 18 new contract tests green (44 total)
- [x] `pnpm -F api test` non-integration — 352 tests green; integration tests fail only because Docker is not running locally
- [x] `pnpm -r typecheck` and `pnpm -r lint` clean

Closes #44