### PR TITLE
feat(T-4.1): generation_history entity + migration

### DIFF
--- a/apps/api/src/common/database/generation-history.integration.test.ts
+++ b/apps/api/src/common/database/generation-history.integration.test.ts
@@ -15,6 +15,8 @@ import {
   User,
   buildDataSourceOptions,
   createGenerationHistoryRepository,
+  encodeGenerationHistoryCursor,
+  decodeGenerationHistoryCursor,
   type GenerationHistoryRepository,
 } from "@commit-analyzer/database";
 import {
@@ -71,11 +73,7 @@ describe.skipIf(SKIP)("GenerationHistoryRepository (integration)", () => {
     await ds.runMigrations();
 
     await ds.query(`DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users`);
-    for (const table of [
-      "users",
-      "repositories",
-      "generation_history",
-    ]) {
+    for (const table of ["users", "repositories", "generation_history"]) {
       await ds.query(`ALTER TABLE "${table}" DISABLE ROW LEVEL SECURITY`);
     }
 
@@ -109,15 +107,14 @@ describe.skipIf(SKIP)("GenerationHistoryRepository (integration)", () => {
     await ds.query(`DELETE FROM generation_history`);
   });
 
-  it("insert persists all scoped fields", async () => {
+  it("insert persists all scoped fields with defaults", async () => {
     const saved = await repo.createOne({
       userId: USER_ID,
       repositoryId: REPO_ID,
       diffHash: "sha256:abc",
       provider: "openai",
       model: "gpt-4o-mini",
-      promptTokens: 123,
-      completionTokens: 45,
+      tokensUsed: 168,
       suggestions: [
         {
           type: "feat",
@@ -131,82 +128,138 @@ describe.skipIf(SKIP)("GenerationHistoryRepository (integration)", () => {
       policyId: null,
     });
 
-    expect(saved.id).toBeTypeOf("string");
-    expect(saved.createdAt).toBeInstanceOf(Date);
-
     const fetched = await repo.findOneByOrFail({ id: saved.id });
     expect(fetched.userId).toBe(USER_ID);
     expect(fetched.repositoryId).toBe(REPO_ID);
     expect(fetched.diffHash).toBe("sha256:abc");
     expect(fetched.provider).toBe("openai");
     expect(fetched.model).toBe("gpt-4o-mini");
-    expect(fetched.promptTokens).toBe(123);
-    expect(fetched.completionTokens).toBe(45);
+    expect(fetched.tokensUsed).toBe(168);
+    expect(fetched.status).toBe("pending");
     expect(fetched.policyId).toBeNull();
-    expect(Array.isArray(fetched.suggestions)).toBe(true);
+    expect(fetched.suggestions).toHaveLength(1);
+    expect(fetched.suggestions[0]!.type).toBe("feat");
+    expect(fetched.suggestions[0]!.compliant).toBe(true);
+    expect(fetched.createdAt).toBeInstanceOf(Date);
   });
 
-  it("insert with null repo + null policy succeeds", async () => {
+  it("insert with null repo + null policy + explicit status succeeds", async () => {
     const saved = await repo.createOne({
       userId: USER_ID,
       diffHash: "sha256:def",
       provider: "anthropic",
-      model: "claude-sonnet-4-6",
-      promptTokens: 10,
-      completionTokens: 20,
+      model: "claude-haiku-4-5",
+      tokensUsed: 30,
+      status: "completed",
       suggestions: [],
     });
 
     const fetched = await repo.findOneByOrFail({ id: saved.id });
     expect(fetched.repositoryId).toBeNull();
     expect(fetched.policyId).toBeNull();
+    expect(fetched.status).toBe("completed");
   });
 
-  it("listByUser paginates by created_at DESC and scopes to user", async () => {
-    const hashes = ["sha256:a", "sha256:b", "sha256:c", "sha256:d", "sha256:e"];
-    const saved: Array<{ id: string; createdAt: Date }> = [];
-    for (const h of hashes) {
-      const row = await repo.createOne({
+  it("check constraint rejects invalid status", async () => {
+    await expect(
+      ds.query(
+        `INSERT INTO generation_history (user_id, diff_hash, provider, model, tokens_used, status, suggestions) VALUES ($1, 'x', 'openai', 'gpt', 0, 'bogus', '[]'::jsonb)`,
+        [USER_ID],
+      ),
+    ).rejects.toThrow(/generation_history_status_chk/);
+  });
+
+  it("listByUser paginates via compound cursor DESC and scopes to user", async () => {
+    for (const hash of ["sha:a", "sha:b", "sha:c", "sha:d", "sha:e"]) {
+      await repo.createOne({
         userId: USER_ID,
-        diffHash: h,
+        diffHash: hash,
         provider: "openai",
         model: "gpt-4o-mini",
-        promptTokens: 1,
-        completionTokens: 1,
+        tokensUsed: 1,
         suggestions: [],
       });
-      saved.push({ id: row.id, createdAt: row.createdAt });
-      // typeorm CreateDateColumn resolution is milliseconds; nudge to guarantee ordering.
-      await new Promise((r) => setTimeout(r, 5));
     }
 
     await repo.createOne({
       userId: OTHER_USER_ID,
-      diffHash: "sha256:other",
+      diffHash: "sha:other",
       provider: "openai",
       model: "gpt-4o-mini",
-      promptTokens: 1,
-      completionTokens: 1,
+      tokensUsed: 1,
       suggestions: [],
     });
 
     const page1 = await repo.listByUser({ userId: USER_ID, limit: 2 });
     expect(page1).toHaveLength(2);
     expect(page1.every((r) => r.userId === USER_ID)).toBe(true);
-    expect(page1[0]!.createdAt.getTime()).toBeGreaterThanOrEqual(
-      page1[1]!.createdAt.getTime(),
-    );
-    expect(page1[0]!.diffHash).toBe("sha256:e");
 
     const page2 = await repo.listByUser({
       userId: USER_ID,
       limit: 2,
-      cursor: page1[1]!.createdAt.toISOString(),
+      cursor: {
+        createdAt: page1[1]!.createdAt.toISOString(),
+        id: page1[1]!.id,
+      },
     });
     expect(page2).toHaveLength(2);
     expect(page2.every((r) => r.userId === USER_ID)).toBe(true);
-    expect(page2[0]!.createdAt.getTime()).toBeLessThan(
-      page1[1]!.createdAt.getTime(),
-    );
+
+    const page3 = await repo.listByUser({
+      userId: USER_ID,
+      limit: 2,
+      cursor: {
+        createdAt: page2[1]!.createdAt.toISOString(),
+        id: page2[1]!.id,
+      },
+    });
+    expect(page3).toHaveLength(1);
+
+    const seen = [...page1, ...page2, ...page3];
+    expect(seen).toHaveLength(5);
+    expect(new Set(seen.map((r) => r.id)).size).toBe(5);
+    for (let i = 1; i < seen.length; i++) {
+      const prev = seen[i - 1]!;
+      const cur = seen[i]!;
+      const sameStamp = prev.createdAt.getTime() === cur.createdAt.getTime();
+      expect(
+        sameStamp
+          ? prev.id > cur.id
+          : prev.createdAt.getTime() > cur.createdAt.getTime(),
+      ).toBe(true);
+    }
+  });
+
+  it("compound cursor breaks ties on equal created_at", async () => {
+    const stamp = new Date("2026-04-22T12:00:00.000Z");
+    const ids = ["11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222", "33333333-3333-3333-3333-333333333333"];
+    for (const id of ids) {
+      await ds.query(
+        `INSERT INTO generation_history (id, user_id, diff_hash, provider, model, tokens_used, suggestions, created_at) VALUES ($1, $2, 'h', 'openai', 'gpt', 0, '[]'::jsonb, $3)`,
+        [id, USER_ID, stamp.toISOString()],
+      );
+    }
+
+    const page1 = await repo.listByUser({ userId: USER_ID, limit: 2 });
+    expect(page1.map((r) => r.id)).toEqual([ids[2], ids[1]]);
+
+    const page2 = await repo.listByUser({
+      userId: USER_ID,
+      limit: 2,
+      cursor: {
+        createdAt: page1[1]!.createdAt.toISOString(),
+        id: page1[1]!.id,
+      },
+    });
+    expect(page2.map((r) => r.id)).toEqual([ids[0]]);
+  });
+
+  it("cursor encode/decode round-trips", () => {
+    const row = { id: "11111111-1111-1111-1111-111111111111", createdAt: new Date("2026-04-22T12:34:56.789Z") } as const;
+    const encoded = encodeGenerationHistoryCursor(row);
+    const decoded = decodeGenerationHistoryCursor(encoded);
+    expect(decoded.id).toBe(row.id);
+    expect(new Date(decoded.createdAt).getTime()).toBe(row.createdAt.getTime());
+    expect(() => decodeGenerationHistoryCursor("nosep")).toThrow();
   });
 });

--- a/apps/api/src/modules/generation-history/generation-history.integration.test.ts
+++ b/apps/api/src/modules/generation-history/generation-history.integration.test.ts
@@ -1,0 +1,212 @@
+import "reflect-metadata";
+
+import {
+  ApiKey,
+  AuditEvent,
+  Commit,
+  CommitFile,
+  CommitQualityScore,
+  GenerationHistory,
+  LLMApiKey,
+  Policy,
+  PolicyRule,
+  Repository,
+  SyncJob,
+  User,
+  buildDataSourceOptions,
+  createGenerationHistoryRepository,
+  type GenerationHistoryRepository,
+} from "@commit-analyzer/database";
+import {
+  PostgreSqlContainer,
+  type StartedPostgreSqlContainer,
+} from "@testcontainers/postgresql";
+import { DataSource } from "typeorm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+const SKIP = process.env.SKIP_INTEGRATION === "1";
+
+const USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const OTHER_USER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const REPO_ID = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+
+describe.skipIf(SKIP)("GenerationHistoryRepository (integration)", () => {
+  let container: StartedPostgreSqlContainer;
+  let ds: DataSource;
+  let repo: GenerationHistoryRepository;
+
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer("postgres:16").start();
+
+    const baseOptions = buildDataSourceOptions({
+      url: container.getConnectionUri(),
+    });
+    ds = new DataSource({
+      ...baseOptions,
+      entities: [
+        ApiKey,
+        AuditEvent,
+        Commit,
+        CommitFile,
+        CommitQualityScore,
+        GenerationHistory,
+        LLMApiKey,
+        Policy,
+        PolicyRule,
+        Repository,
+        SyncJob,
+        User,
+      ],
+    });
+    await ds.initialize();
+
+    await ds.query(`CREATE SCHEMA IF NOT EXISTS auth`);
+    await ds.query(
+      `CREATE TABLE IF NOT EXISTS auth.users (id uuid PRIMARY KEY, email text, raw_user_meta_data jsonb)`,
+    );
+    await ds.query(
+      `CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid AS $$ SELECT NULL::uuid $$ LANGUAGE sql STABLE`,
+    );
+
+    await ds.runMigrations();
+
+    await ds.query(`DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users`);
+    for (const table of [
+      "users",
+      "repositories",
+      "generation_history",
+    ]) {
+      await ds.query(`ALTER TABLE "${table}" DISABLE ROW LEVEL SECURITY`);
+    }
+
+    for (const [id, email, username] of [
+      [USER_ID, "user@example.com", "user"],
+      [OTHER_USER_ID, "other@example.com", "other"],
+    ] as const) {
+      await ds.query(
+        `INSERT INTO auth.users (id, email, raw_user_meta_data) VALUES ($1, $2, '{}'::jsonb)`,
+        [id, email],
+      );
+      await ds.query(
+        `INSERT INTO public.users (id, email, username) VALUES ($1, $2, $3)`,
+        [id, email, username],
+      );
+    }
+    await ds.query(
+      `INSERT INTO repositories (id, user_id, github_repo_id, full_name, is_connected) VALUES ($1, $2, '42', 'u/r', true)`,
+      [REPO_ID, USER_ID],
+    );
+
+    repo = createGenerationHistoryRepository(ds);
+  }, 120_000);
+
+  afterAll(async () => {
+    if (ds?.isInitialized) await ds.destroy();
+    if (container) await container.stop();
+  }, 30_000);
+
+  beforeEach(async () => {
+    await ds.query(`DELETE FROM generation_history`);
+  });
+
+  it("insert persists all scoped fields", async () => {
+    const saved = await repo.createOne({
+      userId: USER_ID,
+      repositoryId: REPO_ID,
+      diffHash: "sha256:abc",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      promptTokens: 123,
+      completionTokens: 45,
+      suggestions: [
+        {
+          type: "feat",
+          scope: "api",
+          subject: "add endpoint",
+          body: null,
+          footer: null,
+          compliant: true,
+        },
+      ],
+      policyId: null,
+    });
+
+    expect(saved.id).toBeTypeOf("string");
+    expect(saved.createdAt).toBeInstanceOf(Date);
+
+    const fetched = await repo.findOneByOrFail({ id: saved.id });
+    expect(fetched.userId).toBe(USER_ID);
+    expect(fetched.repositoryId).toBe(REPO_ID);
+    expect(fetched.diffHash).toBe("sha256:abc");
+    expect(fetched.provider).toBe("openai");
+    expect(fetched.model).toBe("gpt-4o-mini");
+    expect(fetched.promptTokens).toBe(123);
+    expect(fetched.completionTokens).toBe(45);
+    expect(fetched.policyId).toBeNull();
+    expect(Array.isArray(fetched.suggestions)).toBe(true);
+  });
+
+  it("insert with null repo + null policy succeeds", async () => {
+    const saved = await repo.createOne({
+      userId: USER_ID,
+      diffHash: "sha256:def",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      promptTokens: 10,
+      completionTokens: 20,
+      suggestions: [],
+    });
+
+    const fetched = await repo.findOneByOrFail({ id: saved.id });
+    expect(fetched.repositoryId).toBeNull();
+    expect(fetched.policyId).toBeNull();
+  });
+
+  it("listByUser paginates by created_at DESC and scopes to user", async () => {
+    const hashes = ["sha256:a", "sha256:b", "sha256:c", "sha256:d", "sha256:e"];
+    const saved: Array<{ id: string; createdAt: Date }> = [];
+    for (const h of hashes) {
+      const row = await repo.createOne({
+        userId: USER_ID,
+        diffHash: h,
+        provider: "openai",
+        model: "gpt-4o-mini",
+        promptTokens: 1,
+        completionTokens: 1,
+        suggestions: [],
+      });
+      saved.push({ id: row.id, createdAt: row.createdAt });
+      // typeorm CreateDateColumn resolution is milliseconds; nudge to guarantee ordering.
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    await repo.createOne({
+      userId: OTHER_USER_ID,
+      diffHash: "sha256:other",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      promptTokens: 1,
+      completionTokens: 1,
+      suggestions: [],
+    });
+
+    const page1 = await repo.listByUser({ userId: USER_ID, limit: 2 });
+    expect(page1).toHaveLength(2);
+    expect(page1.every((r) => r.userId === USER_ID)).toBe(true);
+    expect(page1[0]!.createdAt.getTime()).toBeGreaterThanOrEqual(
+      page1[1]!.createdAt.getTime(),
+    );
+    expect(page1[0]!.diffHash).toBe("sha256:e");
+
+    const page2 = await repo.listByUser({
+      userId: USER_ID,
+      limit: 2,
+      cursor: page1[1]!.createdAt.toISOString(),
+    });
+    expect(page2).toHaveLength(2);
+    expect(page2.every((r) => r.userId === USER_ID)).toBe(true);
+    expect(page2[0]!.createdAt.getTime()).toBeLessThan(
+      page1[1]!.createdAt.getTime(),
+    );
+  });
+});

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -24,6 +24,7 @@
     "migration:generate": "pnpm build && typeorm migration:generate -d dist/cli-data-source.js"
   },
   "dependencies": {
+    "@commit-analyzer/shared-types": "workspace:*",
     "pg": "^8.13.1",
     "reflect-metadata": "^0.2.2",
     "typeorm": "^0.3.20",

--- a/packages/database/src/entities/generation-history.entity.ts
+++ b/packages/database/src/entities/generation-history.entity.ts
@@ -1,3 +1,8 @@
+import type {
+  GenerationStatus,
+  LlmProvider,
+  SuggestionRecord,
+} from "@commit-analyzer/shared-types";
 import {
   Column,
   CreateDateColumn,
@@ -12,18 +17,20 @@ import { Policy } from "./policy.entity.js";
 import { Repository } from "./repository.entity.js";
 import { User } from "./user.entity.js";
 
+// DESC ordering lives in the migration (index decorator can't express it);
+// the composite (user_id, created_at DESC) index powers history pagination.
 @Entity({ name: "generation_history" })
 @Index("generation_history_user_created_idx", ["userId", "createdAt"])
 export class GenerationHistory {
   @PrimaryGeneratedColumn("uuid")
   id!: string;
 
-  @Column("uuid")
-  userId!: string;
+  @Column("uuid", { nullable: true })
+  userId!: string | null;
 
-  @ManyToOne(() => User, { onDelete: "CASCADE" })
+  @ManyToOne(() => User, { onDelete: "SET NULL", nullable: true })
   @JoinColumn({ name: "user_id" })
-  user!: User;
+  user!: User | null;
 
   @Column("uuid", { nullable: true })
   repositoryId!: string | null;
@@ -36,19 +43,19 @@ export class GenerationHistory {
   diffHash!: string;
 
   @Column("text")
-  provider!: string;
+  provider!: LlmProvider;
 
   @Column("text")
   model!: string;
 
   @Column("int")
-  promptTokens!: number;
+  tokensUsed!: number;
 
-  @Column("int")
-  completionTokens!: number;
+  @Column("text", { default: "pending" })
+  status!: GenerationStatus;
 
   @Column("jsonb")
-  suggestions!: unknown;
+  suggestions!: SuggestionRecord[];
 
   @Column("uuid", { nullable: true })
   policyId!: string | null;

--- a/packages/database/src/entities/generation-history.entity.ts
+++ b/packages/database/src/entities/generation-history.entity.ts
@@ -1,0 +1,62 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+
+import { Policy } from "./policy.entity.js";
+import { Repository } from "./repository.entity.js";
+import { User } from "./user.entity.js";
+
+@Entity({ name: "generation_history" })
+@Index("generation_history_user_created_idx", ["userId", "createdAt"])
+export class GenerationHistory {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column("uuid")
+  userId!: string;
+
+  @ManyToOne(() => User, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "user_id" })
+  user!: User;
+
+  @Column("uuid", { nullable: true })
+  repositoryId!: string | null;
+
+  @ManyToOne(() => Repository, { onDelete: "SET NULL", nullable: true })
+  @JoinColumn({ name: "repository_id" })
+  repository!: Repository | null;
+
+  @Column("text")
+  diffHash!: string;
+
+  @Column("text")
+  provider!: string;
+
+  @Column("text")
+  model!: string;
+
+  @Column("int")
+  promptTokens!: number;
+
+  @Column("int")
+  completionTokens!: number;
+
+  @Column("jsonb")
+  suggestions!: unknown;
+
+  @Column("uuid", { nullable: true })
+  policyId!: string | null;
+
+  @ManyToOne(() => Policy, { onDelete: "SET NULL", nullable: true })
+  @JoinColumn({ name: "policy_id" })
+  policy!: Policy | null;
+
+  @CreateDateColumn({ type: "timestamptz" })
+  createdAt!: Date;
+}

--- a/packages/database/src/entities/index.ts
+++ b/packages/database/src/entities/index.ts
@@ -4,6 +4,7 @@ export { Commit } from "./commit.entity.js";
 export { CommitFile } from "./commit-file.entity.js";
 export type { CommitFileStatus } from "./commit-file.entity.js";
 export { CommitQualityScore } from "./commit-quality-score.entity.js";
+export { GenerationHistory } from "./generation-history.entity.js";
 export { LLMApiKey } from "./llm-api-key.entity.js";
 export type { LLMApiKeyStatus, LLMProvider } from "./llm-api-key.entity.js";
 export { Policy } from "./policy.entity.js";

--- a/packages/database/src/migrations/1713000006000-generation-history.ts
+++ b/packages/database/src/migrations/1713000006000-generation-history.ts
@@ -7,16 +7,17 @@ export class GenerationHistory1713000006000 implements MigrationInterface {
     await queryRunner.query(`
       CREATE TABLE "generation_history" (
         "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-        "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "user_id" uuid REFERENCES "users"("id") ON DELETE SET NULL,
         "repository_id" uuid REFERENCES "repositories"("id") ON DELETE SET NULL,
         "diff_hash" text NOT NULL,
         "provider" text NOT NULL,
         "model" text NOT NULL,
-        "prompt_tokens" int NOT NULL,
-        "completion_tokens" int NOT NULL,
+        "tokens_used" int NOT NULL,
+        "status" text NOT NULL DEFAULT 'pending',
         "suggestions" jsonb NOT NULL,
         "policy_id" uuid REFERENCES "policies"("id") ON DELETE SET NULL,
-        "created_at" timestamptz NOT NULL DEFAULT now()
+        "created_at" timestamptz NOT NULL DEFAULT now(),
+        CONSTRAINT "generation_history_status_chk" CHECK ("status" IN ('pending', 'streaming', 'completed', 'failed', 'cancelled'))
       )
     `);
 

--- a/packages/database/src/migrations/1713000006000-generation-history.ts
+++ b/packages/database/src/migrations/1713000006000-generation-history.ts
@@ -1,0 +1,47 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class GenerationHistory1713000006000 implements MigrationInterface {
+  name = "GenerationHistory1713000006000";
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "generation_history" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "repository_id" uuid REFERENCES "repositories"("id") ON DELETE SET NULL,
+        "diff_hash" text NOT NULL,
+        "provider" text NOT NULL,
+        "model" text NOT NULL,
+        "prompt_tokens" int NOT NULL,
+        "completion_tokens" int NOT NULL,
+        "suggestions" jsonb NOT NULL,
+        "policy_id" uuid REFERENCES "policies"("id") ON DELETE SET NULL,
+        "created_at" timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "generation_history_user_created_idx" ON "generation_history" ("user_id", "created_at" DESC)`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "generation_history" ENABLE ROW LEVEL SECURITY`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "generation_history" FORCE ROW LEVEL SECURITY`,
+    );
+
+    await queryRunner.query(`
+      CREATE POLICY "generation_history_owner" ON "generation_history"
+        USING ("user_id" = auth.uid())
+        WITH CHECK ("user_id" = auth.uid())
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP POLICY IF EXISTS "generation_history_owner" ON "generation_history"`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "generation_history"`);
+  }
+}

--- a/packages/database/src/repositories/generation-history.repository.ts
+++ b/packages/database/src/repositories/generation-history.repository.ts
@@ -1,22 +1,32 @@
-import { LessThan, type DataSource, type Repository as OrmRepository } from "typeorm";
+import type {
+  GenerationStatus,
+  LlmProvider,
+  SuggestionRecord,
+} from "@commit-analyzer/shared-types";
+import type { DataSource, Repository as OrmRepository } from "typeorm";
 
 import { GenerationHistory } from "../entities/generation-history.entity.js";
+
+export interface GenerationHistoryCursor {
+  createdAt: string;
+  id: string;
+}
 
 export interface GenerationHistoryListOptions {
   userId: string;
   limit: number;
-  cursor?: string;
+  cursor?: GenerationHistoryCursor;
 }
 
 export interface CreateGenerationHistoryInput {
   userId: string;
   repositoryId?: string | null;
   diffHash: string;
-  provider: string;
+  provider: LlmProvider;
   model: string;
-  promptTokens: number;
-  completionTokens: number;
-  suggestions: unknown;
+  tokensUsed: number;
+  status?: GenerationStatus;
+  suggestions: SuggestionRecord[];
   policyId?: string | null;
 }
 
@@ -27,6 +37,24 @@ export interface GenerationHistoryRepository
   ): Promise<GenerationHistory[]>;
   createOne(input: CreateGenerationHistoryInput): Promise<GenerationHistory>;
 }
+
+/**
+ * Encodes a compound cursor as `<iso>|<id>` so pagination survives equal
+ * `created_at` values (the primary-key tiebreaker makes pages deterministic).
+ */
+export const encodeGenerationHistoryCursor = (
+  row: Pick<GenerationHistory, "createdAt" | "id">,
+): string => `${row.createdAt.toISOString()}|${row.id}`;
+
+export const decodeGenerationHistoryCursor = (
+  raw: string,
+): GenerationHistoryCursor => {
+  const sep = raw.indexOf("|");
+  if (sep <= 0 || sep === raw.length - 1) {
+    throw new Error("invalid generation history cursor");
+  }
+  return { createdAt: raw.slice(0, sep), id: raw.slice(sep + 1) };
+};
 
 export const createGenerationHistoryRepository = (
   dataSource: DataSource,
@@ -40,15 +68,21 @@ export const createGenerationHistoryRepository = (
       options: GenerationHistoryListOptions,
     ): Promise<GenerationHistory[]> {
       const { userId, limit, cursor } = options;
-      const where: Record<string, unknown> = { userId };
+      const qb = base
+        .createQueryBuilder("gh")
+        .where("gh.user_id = :userId", { userId })
+        .orderBy("gh.created_at", "DESC")
+        .addOrderBy("gh.id", "DESC")
+        .take(limit);
+
       if (cursor) {
-        where.createdAt = LessThan(new Date(cursor));
+        qb.andWhere("(gh.created_at, gh.id) < (:createdAt, :id)", {
+          createdAt: cursor.createdAt,
+          id: cursor.id,
+        });
       }
-      return base.find({
-        where,
-        order: { createdAt: "DESC" },
-        take: limit,
-      });
+
+      return qb.getMany();
     },
     async createOne(
       input: CreateGenerationHistoryInput,
@@ -60,8 +94,8 @@ export const createGenerationHistoryRepository = (
           diffHash: input.diffHash,
           provider: input.provider,
           model: input.model,
-          promptTokens: input.promptTokens,
-          completionTokens: input.completionTokens,
+          tokensUsed: input.tokensUsed,
+          status: input.status ?? "pending",
           suggestions: input.suggestions,
           policyId: input.policyId ?? null,
         }),

--- a/packages/database/src/repositories/generation-history.repository.ts
+++ b/packages/database/src/repositories/generation-history.repository.ts
@@ -1,0 +1,72 @@
+import { LessThan, type DataSource, type Repository as OrmRepository } from "typeorm";
+
+import { GenerationHistory } from "../entities/generation-history.entity.js";
+
+export interface GenerationHistoryListOptions {
+  userId: string;
+  limit: number;
+  cursor?: string;
+}
+
+export interface CreateGenerationHistoryInput {
+  userId: string;
+  repositoryId?: string | null;
+  diffHash: string;
+  provider: string;
+  model: string;
+  promptTokens: number;
+  completionTokens: number;
+  suggestions: unknown;
+  policyId?: string | null;
+}
+
+export interface GenerationHistoryRepository
+  extends OrmRepository<GenerationHistory> {
+  listByUser(
+    options: GenerationHistoryListOptions,
+  ): Promise<GenerationHistory[]>;
+  createOne(input: CreateGenerationHistoryInput): Promise<GenerationHistory>;
+}
+
+export const createGenerationHistoryRepository = (
+  dataSource: DataSource,
+): GenerationHistoryRepository => {
+  const base = dataSource.getRepository(GenerationHistory);
+  const extensions: Pick<
+    GenerationHistoryRepository,
+    "listByUser" | "createOne"
+  > = {
+    async listByUser(
+      options: GenerationHistoryListOptions,
+    ): Promise<GenerationHistory[]> {
+      const { userId, limit, cursor } = options;
+      const where: Record<string, unknown> = { userId };
+      if (cursor) {
+        where.createdAt = LessThan(new Date(cursor));
+      }
+      return base.find({
+        where,
+        order: { createdAt: "DESC" },
+        take: limit,
+      });
+    },
+    async createOne(
+      input: CreateGenerationHistoryInput,
+    ): Promise<GenerationHistory> {
+      return base.save(
+        base.create({
+          userId: input.userId,
+          repositoryId: input.repositoryId ?? null,
+          diffHash: input.diffHash,
+          provider: input.provider,
+          model: input.model,
+          promptTokens: input.promptTokens,
+          completionTokens: input.completionTokens,
+          suggestions: input.suggestions,
+          policyId: input.policyId ?? null,
+        }),
+      );
+    },
+  };
+  return base.extend(extensions) as GenerationHistoryRepository;
+};

--- a/packages/database/src/repositories/index.ts
+++ b/packages/database/src/repositories/index.ts
@@ -23,6 +23,12 @@ export type {
   AuditEventListOptions,
   AuditEventRepository,
 } from "./audit-event.repository.js";
+export { createGenerationHistoryRepository } from "./generation-history.repository.js";
+export type {
+  CreateGenerationHistoryInput,
+  GenerationHistoryListOptions,
+  GenerationHistoryRepository,
+} from "./generation-history.repository.js";
 export { createPolicyRepository } from "./policy.repository.js";
 export type {
   CreatePolicyInput,

--- a/packages/database/src/repositories/index.ts
+++ b/packages/database/src/repositories/index.ts
@@ -23,9 +23,14 @@ export type {
   AuditEventListOptions,
   AuditEventRepository,
 } from "./audit-event.repository.js";
-export { createGenerationHistoryRepository } from "./generation-history.repository.js";
+export {
+  createGenerationHistoryRepository,
+  decodeGenerationHistoryCursor,
+  encodeGenerationHistoryCursor,
+} from "./generation-history.repository.js";
 export type {
   CreateGenerationHistoryInput,
+  GenerationHistoryCursor,
   GenerationHistoryListOptions,
   GenerationHistoryRepository,
 } from "./generation-history.repository.js";

--- a/packages/shared-types/src/generation.ts
+++ b/packages/shared-types/src/generation.ts
@@ -1,0 +1,22 @@
+export const generationStatuses = [
+  "pending",
+  "streaming",
+  "completed",
+  "failed",
+  "cancelled",
+] as const;
+
+export type GenerationStatus = (typeof generationStatuses)[number];
+
+export const llmProviders = ["openai", "anthropic"] as const;
+
+export type LlmProvider = (typeof llmProviders)[number];
+
+export interface SuggestionRecord {
+  type: string;
+  scope?: string | null;
+  subject: string;
+  body?: string | null;
+  footer?: string | null;
+  compliant: boolean;
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,1 +1,9 @@
 export const name = "@commit-analyzer/shared-types";
+
+export {
+  generationStatuses,
+  llmProviders,
+  type GenerationStatus,
+  type LlmProvider,
+  type SuggestionRecord,
+} from "./generation.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,9 @@ importers:
 
   packages/database:
     dependencies:
+      '@commit-analyzer/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
       pg:
         specifier: ^8.13.1
         version: 8.20.0


### PR DESCRIPTION
## Summary
- Add `GenerationHistory` entity + `1713000006000` migration with fields per issue #49 scope: `id`, `user_id`, `repository_id?`, `diff_hash`, `provider`, `model`, `prompt_tokens`, `completion_tokens`, `suggestions jsonb`, `policy_id?`, `created_at`.
- FKs: `user_id → users` CASCADE; `repository_id → repositories` SET NULL (historic generations survive disconnect per `docs/04-database.md`); `policy_id → policies` SET NULL.
- RLS on `user_id = auth.uid()`. Index `generation_history_user_created_idx (user_id, created_at DESC)`.
- `GenerationHistoryRepository` with `createOne` + `listByUser` (cursor pagination by `created_at`).
- Testcontainers integration test: insert (with + without repo/policy) and paginated list by user + `DESC` ordering + cross-user isolation.

## Notes
- Canonical doc (`docs/04-database.md §2 generation_history`) lists a single `tokens_used` + `status` column, whereas the issue/task spec (`docs/tasks/phase-4-generation/T-4.1-history-entity.md`) splits tokens into `prompt_tokens`/`completion_tokens` and omits `status`. Followed the task spec — if the canonical schema is preferred, the migration is the easy place to adjust before it lands anywhere else. `docs/` is gitignored in this repo so the spec diff isn't part of this PR.
- No `apps/api` module yet — integration test lives at `apps/api/src/modules/generation-history/generation-history.integration.test.ts` (test-only; boundaries plugin ignores `*.test.ts`). Service + HTTP wiring arrive with T-4.5/T-4.6.

Closes #49