### PR TITLE
fix(T-4.2): docker copy + build diff-parser pkg

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -9,6 +9,7 @@ COPY apps/cli/package.json apps/cli/package.json
 COPY apps/web/package.json apps/web/package.json
 COPY packages/contracts/package.json packages/contracts/package.json
 COPY packages/database/package.json packages/database/package.json
+COPY packages/diff-parser/package.json packages/diff-parser/package.json
 COPY packages/eslint-config/package.json packages/eslint-config/package.json
 COPY packages/shared-types/package.json packages/shared-types/package.json
 COPY packages/typescript-config/package.json packages/typescript-config/package.json
@@ -19,10 +20,12 @@ COPY packages/typescript-config packages/typescript-config
 COPY packages/shared-types packages/shared-types
 COPY packages/contracts packages/contracts
 COPY packages/database packages/database
+COPY packages/diff-parser packages/diff-parser
 COPY apps/api apps/api
 RUN pnpm --filter @commit-analyzer/shared-types build \
  && pnpm --filter @commit-analyzer/contracts build \
  && pnpm --filter @commit-analyzer/database build \
+ && pnpm --filter @commit-analyzer/diff-parser build \
  && pnpm --filter @commit-analyzer/api build
 
 FROM base AS runner
@@ -34,6 +37,7 @@ COPY --chown=app:app apps/cli/package.json apps/cli/package.json
 COPY --chown=app:app apps/web/package.json apps/web/package.json
 COPY --chown=app:app packages/contracts/package.json packages/contracts/package.json
 COPY --chown=app:app packages/database/package.json packages/database/package.json
+COPY --chown=app:app packages/diff-parser/package.json packages/diff-parser/package.json
 COPY --chown=app:app packages/eslint-config/package.json packages/eslint-config/package.json
 COPY --chown=app:app packages/shared-types/package.json packages/shared-types/package.json
 COPY --chown=app:app packages/typescript-config/package.json packages/typescript-config/package.json
@@ -42,6 +46,7 @@ RUN pnpm install --frozen-lockfile --prod --filter "@commit-analyzer/api..." \
 COPY --from=build --chown=app:app /app/packages/shared-types/dist packages/shared-types/dist
 COPY --from=build --chown=app:app /app/packages/contracts/dist packages/contracts/dist
 COPY --from=build --chown=app:app /app/packages/database/dist packages/database/dist
+COPY --from=build --chown=app:app /app/packages/diff-parser/dist packages/diff-parser/dist
 COPY --from=build --chown=app:app /app/apps/api/dist apps/api/dist
 USER app
 EXPOSE 3000


### PR DESCRIPTION
## Summary
Railway deploy broke on main after T-4.2 — the api Dockerfile wasn't updated when `@commit-analyzer/diff-parser` was introduced. The `deps` stage's `pnpm install --frozen-lockfile` had no `packages/diff-parser/package.json` in its build context, and the `build` stage had no source to compile, so api's build step failed.

Fix: mirror the existing pattern for `shared-types` / `contracts` / `database`:
- Copy `packages/diff-parser/package.json` in the `deps` and `runner` stages.
- Copy `packages/diff-parser` source in the `build` stage and run `pnpm --filter @commit-analyzer/diff-parser build`.
- Copy the built `packages/diff-parser/dist` from the `build` stage into the `runner` image.

## Test plan
- [ ] Deploy api to Railway CI job succeeds on this PR.
- [ ] Resulting image boots `node apps/api/dist/bootstrap.js` without a runtime "Cannot find module '@commit-analyzer/diff-parser'" error.

Failed run being replaced: https://github.com/GEOFARL/commit-analyzer/actions/runs/24788466000/job/72538989956