### PR TITLE
feat(T-4.3): prompt builder + policy injection

### DIFF
--- a/apps/api/src/modules/commit-generation/commit-generation.module.ts
+++ b/apps/api/src/modules/commit-generation/commit-generation.module.ts
@@ -1,9 +1,10 @@
 import { Module } from "@nestjs/common";
 
 import { DiffParserService } from "./services/diff-parser.service.js";
+import { PromptBuilderService } from "./services/prompt-builder.service.js";
 
 @Module({
-  providers: [DiffParserService],
-  exports: [DiffParserService],
+  providers: [DiffParserService, PromptBuilderService],
+  exports: [DiffParserService, PromptBuilderService],
 })
 export class CommitGenerationModule {}

--- a/apps/api/src/modules/commit-generation/services/prompt-builder.constants.ts
+++ b/apps/api/src/modules/commit-generation/services/prompt-builder.constants.ts
@@ -1,0 +1,26 @@
+export const DEFAULT_COUNT = 3;
+export const MIN_COUNT = 1;
+export const MAX_COUNT = 5;
+
+export const DEFAULT_MAX_SUBJECT_LENGTH = 72;
+
+export const DEFAULT_ALLOWED_TYPES: ReadonlyArray<string> = [
+  "feat",
+  "fix",
+  "docs",
+  "style",
+  "refactor",
+  "test",
+  "chore",
+  "build",
+  "ci",
+  "perf",
+  "revert",
+];
+
+export const DEFAULT_ALLOWED_SCOPES = "<any>";
+
+// Conservative ceiling — safely under the smallest supported provider context
+// window (gpt-4o-mini / claude-haiku, ~128k tokens ≈ ~512k chars). Leaves
+// headroom for model output and JSON overhead.
+export const PROMPT_CHAR_BUDGET = 480_000;

--- a/apps/api/src/modules/commit-generation/services/prompt-builder.mappers.ts
+++ b/apps/api/src/modules/commit-generation/services/prompt-builder.mappers.ts
@@ -1,0 +1,108 @@
+import {
+  renderParsedDiff,
+  type ParsedDiff,
+} from "@commit-analyzer/diff-parser";
+
+import {
+  DEFAULT_ALLOWED_SCOPES,
+  DEFAULT_ALLOWED_TYPES,
+  DEFAULT_MAX_SUBJECT_LENGTH,
+  MAX_COUNT,
+  MIN_COUNT,
+} from "./prompt-builder.constants.js";
+import type { PromptPolicy, ResolvedPolicy } from "./prompt-builder.types.js";
+
+export function clampCount(count: number): number {
+  if (!Number.isInteger(count) || count < MIN_COUNT) return MIN_COUNT;
+  if (count > MAX_COUNT) return MAX_COUNT;
+  return count;
+}
+
+export function resolvePolicy(
+  policy: PromptPolicy | undefined,
+): ResolvedPolicy {
+  let allowedTypes = DEFAULT_ALLOWED_TYPES.join(",");
+  let allowedScopes = DEFAULT_ALLOWED_SCOPES;
+  let maxSubjectLength = DEFAULT_MAX_SUBJECT_LENGTH;
+  const extraInstructions: string[] = [];
+
+  if (!policy) {
+    return { allowedTypes, allowedScopes, maxSubjectLength, extraInstructions };
+  }
+
+  for (const rule of policy.rules) {
+    switch (rule.ruleType) {
+      case "allowedTypes":
+        allowedTypes = rule.ruleValue.join(",");
+        break;
+      case "allowedScopes":
+        allowedScopes =
+          rule.ruleValue.kind === "list"
+            ? rule.ruleValue.values.join(",")
+            : `matching /${rule.ruleValue.pattern}/`;
+        break;
+      case "maxSubjectLength":
+        maxSubjectLength = rule.ruleValue;
+        break;
+      case "bodyRequired":
+        if (rule.ruleValue) {
+          extraInstructions.push(
+            "A non-empty body is required for every suggestion.",
+          );
+        }
+        break;
+      case "footerRequired":
+        if (rule.ruleValue) {
+          extraInstructions.push(
+            "A footer with a BREAKING CHANGE note or issue reference is required.",
+          );
+        }
+        break;
+    }
+  }
+
+  return { allowedTypes, allowedScopes, maxSubjectLength, extraInstructions };
+}
+
+export function renderSystemPrompt(
+  count: number,
+  policy: ResolvedPolicy,
+): string {
+  const extras =
+    policy.extraInstructions.length > 0
+      ? `\nAdditional policy constraints:\n${policy.extraInstructions
+          .map((line) => `- ${line}`)
+          .join("\n")}\n`
+      : "";
+
+  return [
+    `You are an expert Git commit author. Produce ${count} distinct commit`,
+    "messages for the diff below. Use the Conventional Commits format.",
+    "Each message must:",
+    `- match the header format \`<type>(<scope>)?: <subject>\` where subject ≤ ${policy.maxSubjectLength} chars, imperative mood, no trailing period`,
+    "- include a body wrapped at 100 cols preceded by a blank line (optional unless required below)",
+    "- include a footer with BREAKING CHANGE or issue references only when applicable",
+    `- pick type from [${policy.allowedTypes}]`,
+    `- pick scope from [${policy.allowedScopes}] (omit if N/A)`,
+    extras,
+    "Return suggestions as a JSON array of objects shaped like",
+    '{ "type": string, "scope"?: string, "subject": string, "body"?: string, "footer"?: string }',
+    "with no surrounding prose.",
+  ].join("\n");
+}
+
+export function renderUserPrompt(parsed: ParsedDiff): string {
+  const rendered = renderParsedDiff(parsed);
+  const truncatedNote = parsed.truncated
+    ? "\n\n(Diff was truncated to fit the token budget; summaries above remain authoritative.)"
+    : "";
+  return [
+    `Files touched:\n${parsed.summary || "(none)"}`,
+    "",
+    "Diff:",
+    rendered,
+    truncatedNote,
+  ]
+    .join("\n")
+    .replace(/\n+$/, "");
+}

--- a/apps/api/src/modules/commit-generation/services/prompt-builder.service.spec.ts
+++ b/apps/api/src/modules/commit-generation/services/prompt-builder.service.spec.ts
@@ -1,0 +1,179 @@
+import type { PolicyRuleInput } from "@commit-analyzer/contracts";
+import { parseAndStripDiff } from "@commit-analyzer/diff-parser";
+import { describe, expect, it } from "vitest";
+
+import { PROMPT_CHAR_BUDGET } from "./prompt-builder.constants.js";
+import { PromptBuilderService } from "./prompt-builder.service.js";
+import type { PromptPolicy } from "./prompt-builder.types.js";
+
+const SAMPLE_DIFF = [
+  "diff --git a/src/auth.ts b/src/auth.ts",
+  "index 1..2 100644",
+  "--- a/src/auth.ts",
+  "+++ b/src/auth.ts",
+  "@@ -1,3 +1,4 @@",
+  " export function login(user: string) {",
+  "-  return true;",
+  "+  if (!user) throw new Error('user required');",
+  "+  return true;",
+  " }",
+].join("\n");
+
+const policy = (rules: PolicyRuleInput[]): PromptPolicy => ({ rules });
+
+describe("PromptBuilderService", () => {
+  const service = new PromptBuilderService();
+  const parsed = parseAndStripDiff(SAMPLE_DIFF);
+
+  it("produces default system prompt without a policy", () => {
+    const { system } = service.build(parsed);
+    expect(system).toMatchInlineSnapshot(`
+      "You are an expert Git commit author. Produce 3 distinct commit
+      messages for the diff below. Use the Conventional Commits format.
+      Each message must:
+      - match the header format \`<type>(<scope>)?: <subject>\` where subject ≤ 72 chars, imperative mood, no trailing period
+      - include a body wrapped at 100 cols preceded by a blank line (optional unless required below)
+      - include a footer with BREAKING CHANGE or issue references only when applicable
+      - pick type from [feat,fix,docs,style,refactor,test,chore,build,ci,perf,revert]
+      - pick scope from [<any>] (omit if N/A)
+
+      Return suggestions as a JSON array of objects shaped like
+      { "type": string, "scope"?: string, "subject": string, "body"?: string, "footer"?: string }
+      with no surrounding prose."
+    `);
+  });
+
+  it("embeds a full policy as explicit constraints", () => {
+    const { system } = service.build(
+      parsed,
+      policy([
+        { ruleType: "allowedTypes", ruleValue: ["feat", "fix", "chore"] },
+        {
+          ruleType: "allowedScopes",
+          ruleValue: { kind: "list", values: ["auth", "api"] },
+        },
+        { ruleType: "maxSubjectLength", ruleValue: 50 },
+        { ruleType: "bodyRequired", ruleValue: true },
+        { ruleType: "footerRequired", ruleValue: true },
+      ]),
+    );
+    expect(system).toMatchInlineSnapshot(`
+      "You are an expert Git commit author. Produce 3 distinct commit
+      messages for the diff below. Use the Conventional Commits format.
+      Each message must:
+      - match the header format \`<type>(<scope>)?: <subject>\` where subject ≤ 50 chars, imperative mood, no trailing period
+      - include a body wrapped at 100 cols preceded by a blank line (optional unless required below)
+      - include a footer with BREAKING CHANGE or issue references only when applicable
+      - pick type from [feat,fix,chore]
+      - pick scope from [auth,api] (omit if N/A)
+
+      Additional policy constraints:
+      - A non-empty body is required for every suggestion.
+      - A footer with a BREAKING CHANGE note or issue reference is required.
+
+      Return suggestions as a JSON array of objects shaped like
+      { "type": string, "scope"?: string, "subject": string, "body"?: string, "footer"?: string }
+      with no surrounding prose."
+    `);
+  });
+
+  it("renders regex scopes inline", () => {
+    const { system } = service.build(
+      parsed,
+      policy([
+        {
+          ruleType: "allowedScopes",
+          ruleValue: { kind: "regex", pattern: "^[a-z]+$" },
+        },
+      ]),
+    );
+    expect(system).toContain("pick scope from [matching /^[a-z]+$/]");
+  });
+
+  it("skips extras when bodyRequired/footerRequired are false", () => {
+    const { system } = service.build(
+      parsed,
+      policy([
+        { ruleType: "bodyRequired", ruleValue: false },
+        { ruleType: "footerRequired", ruleValue: false },
+      ]),
+    );
+    expect(system).not.toContain("Additional policy constraints");
+  });
+
+  it("honours count option within allowed range", () => {
+    expect(service.build(parsed, undefined, { count: 5 }).system).toContain(
+      "Produce 5 distinct",
+    );
+    expect(service.build(parsed, undefined, { count: 99 }).system).toContain(
+      "Produce 5 distinct",
+    );
+    expect(service.build(parsed, undefined, { count: 0 }).system).toContain(
+      "Produce 1 distinct",
+    );
+  });
+
+  it("includes parsed diff and file summary in the user prompt", () => {
+    const { user } = service.build(parsed);
+    expect(user).toMatchInlineSnapshot(`
+      "Files touched:
+      src/auth.ts
+
+      Diff:
+      diff --git a/src/auth.ts b/src/auth.ts
+      index 1..2 100644
+      --- a/src/auth.ts
+      +++ b/src/auth.ts
+      @@ -1,3 +1,4 @@
+       export function login(user: string) {
+      -  return true;
+      +  if (!user) throw new Error('user required');
+      +  return true;
+       }"
+    `);
+  });
+
+  it("notes truncation when the parser dropped content", () => {
+    const { user } = service.build({ ...parsed, truncated: true });
+    expect(user).toContain("Diff was truncated");
+  });
+
+  it("stays under the prompt char budget for a token-budgeted parsed diff", () => {
+    const largeDiff = buildLargeDiff();
+    const parsedLarge = parseAndStripDiff(largeDiff);
+    expect(parsedLarge.truncated).toBe(true);
+    const { system, user } = service.build(parsedLarge);
+    expect(system.length + user.length).toBeLessThanOrEqual(PROMPT_CHAR_BUDGET);
+  });
+
+  it("throws if the resulting prompt exceeds the char budget", () => {
+    const oversized = {
+      files: [],
+      summary: "x".repeat(PROMPT_CHAR_BUDGET + 1),
+      truncated: false,
+    };
+    expect(() => service.build(oversized)).toThrow(/exceeds char budget/);
+  });
+});
+
+function buildLargeDiff(): string {
+  const hunks: string[] = [];
+  for (let fileIdx = 0; fileIdx < 20; fileIdx += 1) {
+    hunks.push(`diff --git a/src/f${fileIdx}.ts b/src/f${fileIdx}.ts`);
+    hunks.push("index 1..2 100644");
+    hunks.push(`--- a/src/f${fileIdx}.ts`);
+    hunks.push(`+++ b/src/f${fileIdx}.ts`);
+    for (let hunkIdx = 0; hunkIdx < 10; hunkIdx += 1) {
+      const base = hunkIdx * 20;
+      hunks.push(`@@ -${base + 1},10 +${base + 1},10 @@`);
+      for (let line = 0; line < 20; line += 1) {
+        hunks.push(
+          line % 2 === 0
+            ? `-old line ${fileIdx}-${hunkIdx}-${line}`
+            : `+new line ${fileIdx}-${hunkIdx}-${line}`,
+        );
+      }
+    }
+  }
+  return hunks.join("\n");
+}

--- a/apps/api/src/modules/commit-generation/services/prompt-builder.service.ts
+++ b/apps/api/src/modules/commit-generation/services/prompt-builder.service.ts
@@ -1,0 +1,41 @@
+import type { ParsedDiff } from "@commit-analyzer/diff-parser";
+import { Injectable } from "@nestjs/common";
+
+import {
+  DEFAULT_COUNT,
+  PROMPT_CHAR_BUDGET,
+} from "./prompt-builder.constants.js";
+import {
+  clampCount,
+  renderSystemPrompt,
+  renderUserPrompt,
+  resolvePolicy,
+} from "./prompt-builder.mappers.js";
+import type {
+  BuildPromptOptions,
+  BuiltPrompt,
+  PromptPolicy,
+} from "./prompt-builder.types.js";
+
+@Injectable()
+export class PromptBuilderService {
+  build(
+    parsed: ParsedDiff,
+    policy?: PromptPolicy,
+    options?: BuildPromptOptions,
+  ): BuiltPrompt {
+    const count = clampCount(options?.count ?? DEFAULT_COUNT);
+    const resolved = resolvePolicy(policy);
+    const system = renderSystemPrompt(count, resolved);
+    const user = renderUserPrompt(parsed);
+
+    const totalLength = system.length + user.length;
+    if (totalLength > PROMPT_CHAR_BUDGET) {
+      throw new Error(
+        `Prompt exceeds char budget: ${totalLength} > ${PROMPT_CHAR_BUDGET}`,
+      );
+    }
+
+    return { system, user };
+  }
+}

--- a/apps/api/src/modules/commit-generation/services/prompt-builder.types.ts
+++ b/apps/api/src/modules/commit-generation/services/prompt-builder.types.ts
@@ -1,0 +1,21 @@
+import type { PolicyRuleInput } from "@commit-analyzer/contracts";
+
+export type PromptPolicy = {
+  rules: ReadonlyArray<PolicyRuleInput>;
+};
+
+export type BuildPromptOptions = {
+  count?: number;
+};
+
+export type BuiltPrompt = {
+  system: string;
+  user: string;
+};
+
+export type ResolvedPolicy = {
+  allowedTypes: string;
+  allowedScopes: string;
+  maxSubjectLength: number;
+  extraInstructions: string[];
+};


### PR DESCRIPTION
## Summary
- Add `PromptBuilderService` in `apps/api/src/modules/commit-generation/services/` producing `{ system, user }` prompts from a `ParsedDiff` + optional policy.
- Defaults mirror `docs/08-algorithms.md` §4: 3 suggestions, 72-char subject cap, full type list, `<any>` scope.
- Policy rules (`allowedTypes`, `allowedScopes` list/regex, `maxSubjectLength`, `bodyRequired`, `footerRequired`) are embedded as explicit constraints in the system prompt.
- Snapshot-tested via `toMatchInlineSnapshot` to lock current phrasing; length guard throws over `PROMPT_CHAR_BUDGET` (480k chars).
- Service stays thin — constants / types / helpers split into sibling files per the repo's `no-restricted-syntax` service-hygiene rule.

Closes #51