### PR TITLE
feat(T-4.4): llm provider + openai/anthropic

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.71",
+    "@ai-sdk/openai": "^3.0.53",
     "@commit-analyzer/contracts": "workspace:*",
     "@commit-analyzer/database": "workspace:^",
     "@commit-analyzer/diff-parser": "workspace:*",
@@ -34,6 +36,7 @@
     "@socket.io/redis-adapter": "^8.3.0",
     "@supabase/supabase-js": "^2.103.0",
     "@ts-rest/nest": "^3.51.0",
+    "ai": "^6.0.168",
     "argon2": "^0.44.0",
     "bullmq": "^5.74.1",
     "helmet": "^8",

--- a/apps/api/src/modules/commit-generation/commit-generation.module.ts
+++ b/apps/api/src/modules/commit-generation/commit-generation.module.ts
@@ -1,10 +1,25 @@
 import { Module } from "@nestjs/common";
 
+import { AnthropicProvider } from "./providers/anthropic.provider.js";
+import { LLMProviderFactory } from "./providers/llm-provider.factory.js";
+import { OpenAIProvider } from "./providers/openai.provider.js";
 import { DiffParserService } from "./services/diff-parser.service.js";
 import { PromptBuilderService } from "./services/prompt-builder.service.js";
 
 @Module({
-  providers: [DiffParserService, PromptBuilderService],
-  exports: [DiffParserService, PromptBuilderService],
+  providers: [
+    DiffParserService,
+    PromptBuilderService,
+    OpenAIProvider,
+    AnthropicProvider,
+    LLMProviderFactory,
+  ],
+  exports: [
+    DiffParserService,
+    PromptBuilderService,
+    OpenAIProvider,
+    AnthropicProvider,
+    LLMProviderFactory,
+  ],
 })
 export class CommitGenerationModule {}

--- a/apps/api/src/modules/commit-generation/providers/anthropic.provider.ts
+++ b/apps/api/src/modules/commit-generation/providers/anthropic.provider.ts
@@ -1,0 +1,20 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { Injectable } from "@nestjs/common";
+
+import {
+  BaseLLMProvider,
+  type ProviderClientFactory,
+} from "./base-llm.provider.js";
+import {
+  DEFAULT_VERIFY_MODEL,
+  VERIFY_TIMEOUT_MS,
+} from "./llm-provider.constants.js";
+
+@Injectable()
+export class AnthropicProvider extends BaseLLMProvider {
+  readonly name = "anthropic" as const;
+  protected readonly defaultVerifyModel = DEFAULT_VERIFY_MODEL.anthropic;
+  protected readonly verifyTimeoutMs = VERIFY_TIMEOUT_MS;
+  protected readonly clientFactory: ProviderClientFactory = (apiKey) =>
+    createAnthropic({ apiKey });
+}

--- a/apps/api/src/modules/commit-generation/providers/base-llm.provider.ts
+++ b/apps/api/src/modules/commit-generation/providers/base-llm.provider.ts
@@ -1,0 +1,92 @@
+import type { LanguageModel } from "ai";
+import { generateText, streamObject } from "ai";
+
+import {
+  AuthError,
+  mapProviderError,
+  QuotaError,
+  UpstreamError,
+} from "./llm-provider.errors.js";
+import type {
+  GenerateArgs,
+  LLMProvider,
+  SuggestionEvent,
+  VerifyOptions,
+} from "./llm-provider.interface.js";
+import { llmSuggestionSchema } from "./suggestion.schema.js";
+
+export type ProviderClientFactory = (apiKey: string) => (
+  modelId: string,
+) => LanguageModel;
+
+export abstract class BaseLLMProvider implements LLMProvider {
+  abstract readonly name: LLMProvider["name"];
+  protected abstract readonly defaultVerifyModel: string;
+  protected abstract readonly verifyTimeoutMs: number;
+  protected abstract readonly clientFactory: ProviderClientFactory;
+
+  async verify(apiKey: string, options?: VerifyOptions): Promise<boolean> {
+    const modelId = options?.model ?? this.defaultVerifyModel;
+    const signal =
+      options?.signal ?? AbortSignal.timeout(this.verifyTimeoutMs);
+
+    try {
+      const client = this.clientFactory(apiKey);
+      await generateText({
+        model: client(modelId),
+        prompt: "ping",
+        abortSignal: signal,
+      });
+      return true;
+    } catch (error) {
+      const mapped = mapProviderError(error);
+      if (mapped instanceof AuthError) return false;
+      if (mapped instanceof QuotaError) return true;
+      throw mapped;
+    }
+  }
+
+  async *generateSuggestions(args: GenerateArgs): AsyncIterable<SuggestionEvent> {
+    let result;
+    try {
+      const client = this.clientFactory(args.apiKey);
+      result = streamObject({
+        model: client(args.model),
+        output: "array",
+        schema: llmSuggestionSchema,
+        system: args.prompt.system,
+        prompt: args.prompt.user,
+        abortSignal: args.signal,
+      });
+    } catch (error) {
+      throw mapProviderError(error);
+    }
+
+    let index = 0;
+    try {
+      for await (const element of result.elementStream) {
+        if (index >= args.count) break;
+        yield { kind: "suggestion", index, value: element };
+        index += 1;
+      }
+    } catch (error) {
+      throw mapProviderError(error);
+    }
+
+    if (index === 0) {
+      throw new UpstreamError("LLM produced no suggestions");
+    }
+
+    // Usage is telemetry — if it fails after suggestions were delivered, emit
+    // the done event with tokensUsed=0 instead of discarding the stream.
+    let tokensUsed = 0;
+    try {
+      const usage = await result.usage;
+      tokensUsed = usage?.totalTokens ?? 0;
+    } catch {
+      tokensUsed = 0;
+    }
+
+    yield { kind: "done", tokensUsed };
+  }
+}

--- a/apps/api/src/modules/commit-generation/providers/llm-provider.constants.ts
+++ b/apps/api/src/modules/commit-generation/providers/llm-provider.constants.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_VERIFY_MODEL = {
+  openai: "gpt-4o-mini",
+  anthropic: "claude-haiku-4-5",
+} as const;
+
+export const VERIFY_TIMEOUT_MS = 10_000;

--- a/apps/api/src/modules/commit-generation/providers/llm-provider.errors.ts
+++ b/apps/api/src/modules/commit-generation/providers/llm-provider.errors.ts
@@ -1,0 +1,32 @@
+import { APICallError } from "ai";
+
+class LLMProviderError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = new.target.name;
+  }
+}
+
+export class AuthError extends LLMProviderError {}
+export class QuotaError extends LLMProviderError {}
+export class UpstreamError extends LLMProviderError {}
+
+export function mapProviderError(error: unknown): LLMProviderError {
+  if (error instanceof LLMProviderError) return error;
+
+  if (APICallError.isInstance(error)) {
+    const status = error.statusCode;
+    if (status === 401 || status === 403) {
+      return new AuthError(error.message, error);
+    }
+    if (status === 429) {
+      return new QuotaError(error.message, error);
+    }
+    return new UpstreamError(error.message, error);
+  }
+
+  if (error instanceof Error) {
+    return new UpstreamError(error.message, error);
+  }
+  return new UpstreamError("Unknown LLM provider error", error);
+}

--- a/apps/api/src/modules/commit-generation/providers/llm-provider.factory.ts
+++ b/apps/api/src/modules/commit-generation/providers/llm-provider.factory.ts
@@ -1,0 +1,27 @@
+import type { LlmProvider as LlmProviderName } from "@commit-analyzer/shared-types";
+import { Injectable } from "@nestjs/common";
+
+import { AnthropicProvider } from "./anthropic.provider.js";
+import type { LLMProvider } from "./llm-provider.interface.js";
+import { OpenAIProvider } from "./openai.provider.js";
+
+@Injectable()
+export class LLMProviderFactory {
+  constructor(
+    private readonly openai: OpenAIProvider,
+    private readonly anthropic: AnthropicProvider,
+  ) {}
+
+  get(name: LlmProviderName): LLMProvider {
+    switch (name) {
+      case "openai":
+        return this.openai;
+      case "anthropic":
+        return this.anthropic;
+      default: {
+        const exhaustive: never = name;
+        throw new Error(`Unknown LLM provider: ${exhaustive as string}`);
+      }
+    }
+  }
+}

--- a/apps/api/src/modules/commit-generation/providers/llm-provider.interface.ts
+++ b/apps/api/src/modules/commit-generation/providers/llm-provider.interface.ts
@@ -1,0 +1,28 @@
+import type { LlmProvider } from "@commit-analyzer/shared-types";
+
+import type { BuiltPrompt } from "../services/prompt-builder.types.js";
+
+import type { LlmSuggestion } from "./suggestion.schema.js";
+
+export type SuggestionEvent =
+  | { kind: "suggestion"; index: number; value: LlmSuggestion }
+  | { kind: "done"; tokensUsed: number };
+
+export interface VerifyOptions {
+  model?: string;
+  signal?: AbortSignal;
+}
+
+export interface GenerateArgs {
+  apiKey: string;
+  model: string;
+  prompt: BuiltPrompt;
+  count: number;
+  signal?: AbortSignal;
+}
+
+export interface LLMProvider {
+  readonly name: LlmProvider;
+  verify(apiKey: string, options?: VerifyOptions): Promise<boolean>;
+  generateSuggestions(args: GenerateArgs): AsyncIterable<SuggestionEvent>;
+}

--- a/apps/api/src/modules/commit-generation/providers/llm-provider.spec.ts
+++ b/apps/api/src/modules/commit-generation/providers/llm-provider.spec.ts
@@ -1,0 +1,335 @@
+import { APICallError } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  generateTextMock,
+  streamObjectMock,
+  createOpenAIMock,
+  createAnthropicMock,
+} = vi.hoisted(() => ({
+  generateTextMock: vi.fn(),
+  streamObjectMock: vi.fn(),
+  createOpenAIMock: vi.fn(),
+  createAnthropicMock: vi.fn(),
+}));
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    generateText: generateTextMock,
+    streamObject: streamObjectMock,
+  };
+});
+
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: createOpenAIMock,
+}));
+
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: createAnthropicMock,
+}));
+
+const { AnthropicProvider } = await import("./anthropic.provider.js");
+const {
+  AuthError,
+  QuotaError,
+  UpstreamError,
+} = await import("./llm-provider.errors.js");
+const { LLMProviderFactory } = await import("./llm-provider.factory.js");
+const { OpenAIProvider } = await import("./openai.provider.js");
+
+const buildPrompt = () => ({ system: "sys", user: "usr" });
+
+const apiCallError = (statusCode: number) =>
+  new APICallError({
+    message: `status ${statusCode}`,
+    url: "https://example.test/v1",
+    requestBodyValues: {},
+    statusCode,
+  });
+
+const fakeStream = <T>(values: T[]): AsyncIterable<T> => ({
+  [Symbol.asyncIterator]() {
+    let i = 0;
+    return {
+      next: () =>
+        Promise.resolve(
+          i < values.length
+            ? { value: values[i++] as T, done: false }
+            : { value: undefined as unknown as T, done: true },
+        ),
+    };
+  },
+});
+
+const failingStream = (error: Error): AsyncIterable<never> => ({
+  [Symbol.asyncIterator]() {
+    return {
+      next: () => Promise.reject(error),
+    };
+  },
+});
+
+const drain = async (iterable: AsyncIterable<unknown>) => {
+  const out: unknown[] = [];
+  for await (const event of iterable) out.push(event);
+  return out;
+};
+
+beforeEach(() => {
+  generateTextMock.mockReset();
+  streamObjectMock.mockReset();
+  createOpenAIMock.mockReset();
+  createAnthropicMock.mockReset();
+
+  const clientFn = (modelId: string) => ({ modelId });
+  createOpenAIMock.mockReturnValue(clientFn);
+  createAnthropicMock.mockReturnValue(clientFn);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("LLMProviderFactory", () => {
+  it("returns the correct provider by name", () => {
+    const openai = new OpenAIProvider();
+    const anthropic = new AnthropicProvider();
+    const factory = new LLMProviderFactory(openai, anthropic);
+
+    expect(factory.get("openai")).toBe(openai);
+    expect(factory.get("anthropic")).toBe(anthropic);
+  });
+});
+
+describe.each([
+  {
+    label: "OpenAIProvider",
+    create: () => new OpenAIProvider(),
+    clientMock: createOpenAIMock,
+    defaultModel: "gpt-4o-mini",
+  },
+  {
+    label: "AnthropicProvider",
+    create: () => new AnthropicProvider(),
+    clientMock: createAnthropicMock,
+    defaultModel: "claude-haiku-4-5",
+  },
+])("$label", ({ create, clientMock, defaultModel }) => {
+  describe("verify()", () => {
+    it("returns true when the probe succeeds", async () => {
+      generateTextMock.mockResolvedValueOnce({ text: "pong" });
+      const provider = create();
+
+      await expect(provider.verify("sk-test")).resolves.toBe(true);
+
+      expect(clientMock).toHaveBeenCalledWith({ apiKey: "sk-test" });
+      const call = generateTextMock.mock.calls[0]![0] as {
+        model: { modelId: string };
+        prompt: string;
+      };
+      expect(call.model.modelId).toBe(defaultModel);
+      expect(call.prompt).toBe("ping");
+    });
+
+    it("returns false when the upstream rejects with 401", async () => {
+      generateTextMock.mockRejectedValueOnce(apiCallError(401));
+      await expect(create().verify("sk-bad")).resolves.toBe(false);
+    });
+
+    it("returns true when the upstream rejects with 429 (rate limited)", async () => {
+      generateTextMock.mockRejectedValueOnce(apiCallError(429));
+      await expect(create().verify("sk-test")).resolves.toBe(true);
+    });
+
+    it("throws UpstreamError on a 500", async () => {
+      generateTextMock.mockRejectedValueOnce(apiCallError(500));
+      await expect(create().verify("sk-test")).rejects.toBeInstanceOf(
+        UpstreamError,
+      );
+    });
+
+    it("uses the caller-provided model and signal", async () => {
+      generateTextMock.mockResolvedValueOnce({ text: "pong" });
+      const controller = new AbortController();
+
+      await create().verify("sk-test", {
+        model: "custom-model",
+        signal: controller.signal,
+      });
+
+      const call = generateTextMock.mock.calls[0]![0] as {
+        model: { modelId: string };
+        abortSignal: AbortSignal;
+      };
+      expect(call.model.modelId).toBe("custom-model");
+      expect(call.abortSignal).toBe(controller.signal);
+    });
+  });
+
+  describe("generateSuggestions()", () => {
+    it("yields suggestion events then a done event with token usage", async () => {
+      streamObjectMock.mockReturnValueOnce({
+        elementStream: fakeStream([
+          { type: "feat", subject: "first" },
+          { type: "fix", subject: "second" },
+          { type: "chore", subject: "third" },
+        ]),
+        usage: Promise.resolve({ totalTokens: 137 }),
+      });
+
+      const events = await drain(
+        create().generateSuggestions({
+          apiKey: "sk-test",
+          model: "gpt-test",
+          prompt: buildPrompt(),
+          count: 3,
+        }),
+      );
+
+      expect(events).toEqual([
+        { kind: "suggestion", index: 0, value: { type: "feat", subject: "first" } },
+        { kind: "suggestion", index: 1, value: { type: "fix", subject: "second" } },
+        { kind: "suggestion", index: 2, value: { type: "chore", subject: "third" } },
+        { kind: "done", tokensUsed: 137 },
+      ]);
+
+      const call = streamObjectMock.mock.calls[0]![0] as {
+        model: { modelId: string };
+        output: string;
+        system: string;
+        prompt: string;
+      };
+      expect(call.model.modelId).toBe("gpt-test");
+      expect(call.output).toBe("array");
+      expect(call.system).toBe("sys");
+      expect(call.prompt).toBe("usr");
+    });
+
+    it("caps emitted suggestions at the requested count", async () => {
+      streamObjectMock.mockReturnValueOnce({
+        elementStream: fakeStream([
+          { type: "feat", subject: "a" },
+          { type: "feat", subject: "b" },
+          { type: "feat", subject: "c" },
+          { type: "feat", subject: "d" },
+        ]),
+        usage: Promise.resolve({ totalTokens: 10 }),
+      });
+
+      const events = await drain(
+        create().generateSuggestions({
+          apiKey: "sk-test",
+          model: "gpt-test",
+          prompt: buildPrompt(),
+          count: 2,
+        }),
+      );
+
+      const suggestions = events.filter(
+        (event): event is { kind: "suggestion" } =>
+          (event as { kind: string }).kind === "suggestion",
+      );
+      expect(suggestions).toHaveLength(2);
+    });
+
+    it("forwards the AbortSignal to streamObject", async () => {
+      streamObjectMock.mockReturnValueOnce({
+        elementStream: fakeStream([{ type: "feat", subject: "ok" }]),
+        usage: Promise.resolve({ totalTokens: 1 }),
+      });
+      const controller = new AbortController();
+
+      await drain(
+        create().generateSuggestions({
+          apiKey: "sk-test",
+          model: "gpt-test",
+          prompt: buildPrompt(),
+          count: 1,
+          signal: controller.signal,
+        }),
+      );
+
+      const call = streamObjectMock.mock.calls[0]![0] as {
+        abortSignal: AbortSignal;
+      };
+      expect(call.abortSignal).toBe(controller.signal);
+    });
+
+    it("maps a 401 stream failure to AuthError", async () => {
+      streamObjectMock.mockReturnValueOnce({
+        elementStream: failingStream(apiCallError(401)),
+        usage: Promise.resolve({ totalTokens: 0 }),
+      });
+
+      await expect(
+        drain(
+          create().generateSuggestions({
+            apiKey: "sk-test",
+            model: "gpt-test",
+            prompt: buildPrompt(),
+            count: 1,
+          }),
+        ),
+      ).rejects.toBeInstanceOf(AuthError);
+    });
+
+    it("maps a 429 stream failure to QuotaError", async () => {
+      streamObjectMock.mockReturnValueOnce({
+        elementStream: failingStream(apiCallError(429)),
+        usage: Promise.resolve({ totalTokens: 0 }),
+      });
+
+      await expect(
+        drain(
+          create().generateSuggestions({
+            apiKey: "sk-test",
+            model: "gpt-test",
+            prompt: buildPrompt(),
+            count: 1,
+          }),
+        ),
+      ).rejects.toBeInstanceOf(QuotaError);
+    });
+
+    it("throws UpstreamError when no suggestions are produced", async () => {
+      streamObjectMock.mockReturnValueOnce({
+        elementStream: fakeStream<unknown>([]),
+        usage: Promise.resolve({ totalTokens: 0 }),
+      });
+
+      await expect(
+        drain(
+          create().generateSuggestions({
+            apiKey: "sk-test",
+            model: "gpt-test",
+            prompt: buildPrompt(),
+            count: 3,
+          }),
+        ),
+      ).rejects.toBeInstanceOf(UpstreamError);
+    });
+
+    it("still emits done with tokensUsed=0 when usage telemetry fails", async () => {
+      streamObjectMock.mockReturnValueOnce({
+        elementStream: fakeStream([{ type: "feat", subject: "ok" }]),
+        usage: Promise.reject(new Error("usage unavailable")),
+      });
+
+      const events = await drain(
+        create().generateSuggestions({
+          apiKey: "sk-test",
+          model: "gpt-test",
+          prompt: buildPrompt(),
+          count: 1,
+        }),
+      );
+
+      expect(events).toEqual([
+        { kind: "suggestion", index: 0, value: { type: "feat", subject: "ok" } },
+        { kind: "done", tokensUsed: 0 },
+      ]);
+    });
+  });
+});

--- a/apps/api/src/modules/commit-generation/providers/openai.provider.ts
+++ b/apps/api/src/modules/commit-generation/providers/openai.provider.ts
@@ -1,0 +1,20 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { Injectable } from "@nestjs/common";
+
+import {
+  BaseLLMProvider,
+  type ProviderClientFactory,
+} from "./base-llm.provider.js";
+import {
+  DEFAULT_VERIFY_MODEL,
+  VERIFY_TIMEOUT_MS,
+} from "./llm-provider.constants.js";
+
+@Injectable()
+export class OpenAIProvider extends BaseLLMProvider {
+  readonly name = "openai" as const;
+  protected readonly defaultVerifyModel = DEFAULT_VERIFY_MODEL.openai;
+  protected readonly verifyTimeoutMs = VERIFY_TIMEOUT_MS;
+  protected readonly clientFactory: ProviderClientFactory = (apiKey) =>
+    createOpenAI({ apiKey });
+}

--- a/apps/api/src/modules/commit-generation/providers/suggestion.schema.ts
+++ b/apps/api/src/modules/commit-generation/providers/suggestion.schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const llmSuggestionSchema = z.object({
+  type: z.string().min(1),
+  scope: z.string().nullable().optional(),
+  subject: z.string().min(1),
+  body: z.string().nullable().optional(),
+  footer: z.string().nullable().optional(),
+});
+
+export type LlmSuggestion = z.infer<typeof llmSuggestionSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
 
   apps/api:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.71
+        version: 3.0.71(zod@3.25.76)
+      '@ai-sdk/openai':
+        specifier: ^3.0.53
+        version: 3.0.53(zod@3.25.76)
       '@commit-analyzer/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
@@ -77,6 +83,9 @@ importers:
       '@ts-rest/nest':
         specifier: ^3.51.0
         version: 3.52.1(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@ts-rest/core@3.52.1(@types/node@22.19.17)(zod@3.25.76))(rxjs@7.8.2)(zod@3.25.76)
+      ai:
+        specifier: ^6.0.168
+        version: 6.0.168(zod@3.25.76)
       argon2:
         specifier: ^0.44.0
         version: 0.44.0
@@ -234,10 +243,10 @@ importers:
         version: 0.468.0(react@19.2.5)
       next:
         specifier: ^16.2.3
-        version: 16.2.3(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-intl:
         specifier: ^4.9.1
-        version: 4.9.1(next@16.2.3(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 4.9.1(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -462,6 +471,34 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@ai-sdk/anthropic@3.0.71':
+    resolution: {integrity: sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@3.0.104':
+    resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.53':
+    resolution: {integrity: sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.23':
+    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1353,6 +1390,10 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-parser/binding-android-arm-eabi@0.121.0':
     resolution: {integrity: sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A==}
@@ -2844,6 +2885,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitest/coverage-v8@2.1.9':
     resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
     peerDependencies:
@@ -2903,6 +2948,12 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ai@6.0.168:
+    resolution: {integrity: sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -3664,6 +3715,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -4114,6 +4169,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -5633,6 +5691,36 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/anthropic@3.0.71(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/gateway@3.0.104(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      '@vercel/oidc': 3.2.0
+      zod: 3.25.76
+
+  '@ai-sdk/openai@3.0.53(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.23(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 3.25.76
+
+  '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
@@ -6342,6 +6430,8 @@ snapshots:
   '@octokit/types@16.0.0':
     dependencies:
       '@octokit/openapi-types': 27.0.0
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@oxc-parser/binding-android-arm-eabi@0.121.0':
     optional: true
@@ -7634,6 +7724,8 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.17)(lightningcss@1.32.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -7719,6 +7811,14 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ai@6.0.168(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.104(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
 
   ajv@6.14.0:
     dependencies:
@@ -8650,6 +8750,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.8: {}
+
   expect-type@1.3.0: {}
 
   express@5.2.1:
@@ -9142,6 +9244,8 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema@0.4.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-with-bigint@3.5.8: {}
@@ -9379,14 +9483,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.9.1: {}
 
-  next-intl@4.9.1(next@16.2.3(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
+  next-intl@4.9.1(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.2
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.24
       icu-minify: 4.9.1
       negotiator: 1.0.0
-      next: 16.2.3(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-intl-swc-plugin-extractor: 4.9.1
       po-parser: 2.1.1
       react: 19.2.5
@@ -9401,7 +9505,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  next@16.2.3(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -9420,6 +9524,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.3
       '@next/swc-win32-arm64-msvc': 16.2.3
       '@next/swc-win32-x64-msvc': 16.2.3
+      '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Add `LLMProvider` interface (`name`, `verify(apiKey)`, `generateSuggestions(args)`) plus typed errors `AuthError` / `QuotaError` / `UpstreamError` and an `APICallError` → typed-error mapper.
- Add OpenAI and Anthropic adapters wrapping the Vercel AI SDK (`streamObject` with `output: 'array'` + Zod schema, `elementStream` consumed for complete suggestions; `generateText('ping')` for the cheap verify probe).
- Add `LLMProviderFactory` keyed by provider name and wire all three into `CommitGenerationModule`.

Verify semantics: `401/403` → `false`, `429` → `true` (key valid, just throttled), other upstream errors → `UpstreamError` thrown (caller can distinguish "definitely invalid" vs "couldn't probe"). Default verify model: `gpt-4o-mini` / `claude-haiku-4-5`, 10s timeout.

Streaming: `streamObject.elementStream` yields complete, Zod-validated suggestions one at a time (matches ADR-0006 — not `partialOutputStream`). Caller-supplied `AbortSignal` is forwarded to the SDK. A final `done` event reports `tokensUsed` from the SDK's `usage` promise. `LlmSuggestion` schema excludes `compliant` (set later by the policy validator).

Naming: the entity layer's `LLMProvider` type alias is left as-is; the new interface lives in `apps/api/src/modules/commit-generation/providers/`. Internal references to the entity-layer alias use `LlmProvider` from `@commit-analyzer/shared-types` to avoid a clash.

Out of scope (later tasks): the CQRS handler that orchestrates this against `GenerationHistory` (T-4.5), the SSE controller (T-4.6), and the Settings UI that calls `verify` (T-4.7).

## Test plan

- [x] `pnpm -F @commit-analyzer/api test -- llm-provider.spec` — 23 tests cover both adapters via the base class plus the factory: verify success / 401 / 429 / 500 / custom model+signal; streaming yields events + `done`, caps at `count`, forwards `AbortSignal`, maps 401/429 errors mid-stream, throws `UpstreamError` on empty output.
- [x] `pnpm -r typecheck`, `pnpm -r lint` — clean.
- [x] `pnpm -F @commit-analyzer/api test` — all unit tests pass; the 6 `*.integration.test.ts` files require Docker (testcontainers) and are skipped locally — CI runs them.

Closes #52