### PR TITLE
feat(T-4.6): sse generate endpoint

### DIFF
--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { CqrsModule } from "@nestjs/cqrs";
 
 import { CryptoService } from "../../shared/crypto.service.js";
@@ -8,6 +8,7 @@ import { ApiKeyGuard } from "./api-key.guard.js";
 import { AuthTsRestController } from "./auth-ts-rest.controller.js";
 import { AuthController } from "./auth.controller.js";
 import { AuthService } from "./auth.service.js";
+import { JwtOrApiKeyGuard } from "./jwt-or-api-key.guard.js";
 import { LlmKeysService } from "./llm-keys.service.js";
 import { SupabaseAdminService } from "./supabase-admin.service.js";
 import {
@@ -17,12 +18,16 @@ import {
 } from "./supabase-auth.guard.js";
 
 @Module({
-  imports: [CqrsModule, CommitGenerationModule],
+  // forwardRef: CommitGenerationModule imports AuthModule for the SSE route's
+  // JwtOrApiKeyGuard, and AuthModule's LlmKeysService calls LLMProviderFactory
+  // from CommitGenerationModule. Break the circular import at the module edge.
+  imports: [CqrsModule, forwardRef(() => CommitGenerationModule)],
   controllers: [AuthController, AuthTsRestController],
   providers: [
     supabaseClientProvider,
     SupabaseAuthGuard,
     ApiKeyGuard,
+    JwtOrApiKeyGuard,
     AuthService,
     LlmKeysService,
     SupabaseAdminService,
@@ -31,6 +36,7 @@ import {
   exports: [
     SupabaseAuthGuard,
     ApiKeyGuard,
+    JwtOrApiKeyGuard,
     AuthService,
     LlmKeysService,
     SUPABASE_CLIENT,

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -18,9 +18,7 @@ import {
 } from "./supabase-auth.guard.js";
 
 @Module({
-  // forwardRef: CommitGenerationModule imports AuthModule for the SSE route's
-  // JwtOrApiKeyGuard, and AuthModule's LlmKeysService calls LLMProviderFactory
-  // from CommitGenerationModule. Break the circular import at the module edge.
+  // forwardRef breaks the auth ↔ commit-generation cycle.
   imports: [CqrsModule, forwardRef(() => CommitGenerationModule)],
   controllers: [AuthController, AuthTsRestController],
   providers: [

--- a/apps/api/src/modules/auth/jwt-or-api-key.guard.ts
+++ b/apps/api/src/modules/auth/jwt-or-api-key.guard.ts
@@ -1,0 +1,37 @@
+import {
+  type CanActivate,
+  type ExecutionContext,
+  Inject,
+  Injectable,
+  UnauthorizedException,
+} from "@nestjs/common";
+import type { Request } from "express";
+
+import { ApiKeyGuard } from "./api-key.guard.js";
+import { SupabaseAuthGuard } from "./supabase-auth.guard.js";
+
+/**
+ * Composite guard for `/generate`: accepts either a Supabase JWT via
+ * `Authorization: Bearer …` or an API key via `x-api-key`. The first header
+ * that is present determines which child guard runs — no ambiguous
+ * best-effort chains, and a failing header returns the 401 from that guard
+ * rather than masking it as a generic fallback.
+ */
+@Injectable()
+export class JwtOrApiKeyGuard implements CanActivate {
+  constructor(
+    @Inject(SupabaseAuthGuard) private readonly jwt: SupabaseAuthGuard,
+    @Inject(ApiKeyGuard) private readonly apiKey: ApiKeyGuard,
+  ) {}
+
+  canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest<Request>();
+    const hasBearer = req.headers.authorization?.startsWith("Bearer ") ?? false;
+    const apiKeyHeader = req.headers["x-api-key"];
+    const hasApiKey = typeof apiKeyHeader === "string" && apiKeyHeader.length > 0;
+
+    if (hasBearer) return this.jwt.canActivate(context);
+    if (hasApiKey) return this.apiKey.canActivate(context);
+    throw new UnauthorizedException("missing credentials");
+  }
+}

--- a/apps/api/src/modules/auth/jwt-or-api-key.guard.ts
+++ b/apps/api/src/modules/auth/jwt-or-api-key.guard.ts
@@ -10,13 +10,7 @@ import type { Request } from "express";
 import { ApiKeyGuard } from "./api-key.guard.js";
 import { SupabaseAuthGuard } from "./supabase-auth.guard.js";
 
-/**
- * Composite guard for `/generate`: accepts either a Supabase JWT via
- * `Authorization: Bearer …` or an API key via `x-api-key`. The first header
- * that is present determines which child guard runs — no ambiguous
- * best-effort chains, and a failing header returns the 401 from that guard
- * rather than masking it as a generic fallback.
- */
+// JWT wins when both headers are sent (see `09-security.md §8`).
 @Injectable()
 export class JwtOrApiKeyGuard implements CanActivate {
   constructor(

--- a/apps/api/src/modules/commit-generation/commit-generation.module.ts
+++ b/apps/api/src/modules/commit-generation/commit-generation.module.ts
@@ -1,23 +1,31 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { CqrsModule } from "@nestjs/cqrs";
 
+import { AuthModule } from "../auth/auth.module.js";
+
 import { GenerateMessageHandler } from "./commands/generate-message.handler.js";
+import { GenerateController } from "./controllers/generate.controller.js";
 import { AnthropicProvider } from "./providers/anthropic.provider.js";
 import { LLMProviderFactory } from "./providers/llm-provider.factory.js";
 import { OpenAIProvider } from "./providers/openai.provider.js";
 import { DiffParserService } from "./services/diff-parser.service.js";
+import { GenerationStreamService } from "./services/generation-stream.service.js";
+import { LlmKeyService } from "./services/llm-key.service.js";
 import { PromptBuilderService } from "./services/prompt-builder.service.js";
 
 const COMMAND_HANDLERS = [GenerateMessageHandler];
 
 @Module({
-  imports: [CqrsModule],
+  imports: [CqrsModule, forwardRef(() => AuthModule)],
+  controllers: [GenerateController],
   providers: [
     DiffParserService,
     PromptBuilderService,
     OpenAIProvider,
     AnthropicProvider,
     LLMProviderFactory,
+    LlmKeyService,
+    GenerationStreamService,
     ...COMMAND_HANDLERS,
   ],
   exports: [
@@ -26,6 +34,8 @@ const COMMAND_HANDLERS = [GenerateMessageHandler];
     OpenAIProvider,
     AnthropicProvider,
     LLMProviderFactory,
+    LlmKeyService,
+    GenerationStreamService,
   ],
 })
 export class CommitGenerationModule {}

--- a/apps/api/src/modules/commit-generation/controllers/generate.constants.ts
+++ b/apps/api/src/modules/commit-generation/controllers/generate.constants.ts
@@ -1,0 +1,1 @@
+export const HEARTBEAT_MS = 15_000;

--- a/apps/api/src/modules/commit-generation/controllers/generate.controller.integration.test.ts
+++ b/apps/api/src/modules/commit-generation/controllers/generate.controller.integration.test.ts
@@ -138,7 +138,7 @@ const buildApp = async (
     ),
   };
   const llmKeyRepo = {
-    findByUserProvider: vi.fn().mockResolvedValue(
+    findByUserAndProvider: vi.fn().mockResolvedValue(
       withLlmKey
         ? {
             userId: USER_ID,
@@ -204,7 +204,17 @@ const buildApp = async (
         }),
         inject: [ClsService],
       },
-      { provide: ApiKeyGuard, useValue: { canActivate: () => false } },
+      {
+        provide: ApiKeyGuard,
+        useFactory: (cls: ClsService) => ({
+          canActivate: () => {
+            cls.set("auth.userId", USER_ID);
+            cls.set("auth.kind", "api-key");
+            return true;
+          },
+        }),
+        inject: [ClsService],
+      },
       JwtOrApiKeyGuard,
     ],
   })
@@ -281,6 +291,64 @@ describe("POST /generate (SSE)", () => {
 
     expect(res.status).toBe(412);
     expect(res.body).toMatchObject({ code: "NO_LLM_KEY" });
+  });
+
+  it("accepts API-key auth via x-api-key header", async () => {
+    const ctx = await buildApp(fakeProvider(happyPathScript));
+    app = ctx.app;
+    const server = app.getHttpServer() as Server;
+
+    const res = await request(server)
+      .post("/generate")
+      .set("x-api-key", "cap_secret_xxxxxxxxxxxxxxxxxx")
+      .send({ diff: SAMPLE_DIFF, provider: "openai", model: "gpt-4o-mini" });
+
+    expect(res.status).toBe(200);
+    const frames = parseSseFrames(res.text);
+    expect(frames.map((f) => f.kind)).toEqual(["suggestion", "done"]);
+  });
+
+  it("delivers the first SSE frame within the TTFT budget (<2 s)", async () => {
+    const ctx = await buildApp(fakeProvider(happyPathScript));
+    app = ctx.app;
+    await app.listen(0);
+    const server = app.getHttpServer() as Server;
+    const { port } = server.address() as AddressInfo;
+
+    const http = await import("node:http");
+    const payload = JSON.stringify({
+      diff: SAMPLE_DIFF,
+      provider: "openai",
+      model: "gpt-4o-mini",
+    });
+    const start = performance.now();
+    const ttft = await new Promise<number>((resolve, reject) => {
+      const req_ = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path: "/generate",
+          method: "POST",
+          headers: {
+            authorization: "Bearer stub-jwt",
+            "content-type": "application/json",
+            "content-length": Buffer.byteLength(payload),
+          },
+        },
+        (r) => {
+          r.once("data", () => {
+            const delta = performance.now() - start;
+            req_.destroy();
+            resolve(delta);
+          });
+          r.once("error", reject);
+        },
+      );
+      req_.once("error", reject);
+      req_.end(payload);
+      setTimeout(() => reject(new Error("ttft timeout")), 3000);
+    });
+    expect(ttft).toBeLessThan(2000);
   });
 
   it("rejects unauthenticated requests with 401", async () => {

--- a/apps/api/src/modules/commit-generation/controllers/generate.controller.integration.test.ts
+++ b/apps/api/src/modules/commit-generation/controllers/generate.controller.integration.test.ts
@@ -1,0 +1,413 @@
+import "reflect-metadata";
+
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { type INestApplication, Module } from "@nestjs/common";
+import { APP_GUARD } from "@nestjs/core";
+import { CqrsModule, EventBus } from "@nestjs/cqrs";
+import { Test } from "@nestjs/testing";
+import { ThrottlerModule } from "@nestjs/throttler";
+import { ClsModule, ClsService } from "nestjs-cls";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  GENERATION_HISTORY_REPOSITORY,
+  LLM_API_KEY_REPOSITORY,
+  POLICY_REPOSITORY,
+  REPOSITORY_REPOSITORY,
+} from "../../../common/database/tokens.js";
+import { THROTTLE_TIERS } from "../../../common/throttler/tiers.js";
+import { UserThrottlerGuard } from "../../../common/throttler/user-throttler.guard.js";
+import { CryptoService } from "../../../shared/crypto.service.js";
+import {
+  GenerationCompletedEvent,
+} from "../../../shared/events/generation-completed.event.js";
+import { GenerationFailedEvent } from "../../../shared/events/generation-failed.event.js";
+import { PolicyValidationModule } from "../../../shared/policy-validation/policy-validation.module.js";
+import { ApiKeyGuard } from "../../auth/api-key.guard.js";
+import { JwtOrApiKeyGuard } from "../../auth/jwt-or-api-key.guard.js";
+import { SupabaseAuthGuard } from "../../auth/supabase-auth.guard.js";
+import { AnthropicProvider } from "../providers/anthropic.provider.js";
+import { LLMProviderFactory } from "../providers/llm-provider.factory.js";
+import type {
+  GenerateArgs,
+  LLMProvider,
+  SuggestionEvent,
+} from "../providers/llm-provider.interface.js";
+import { OpenAIProvider } from "../providers/openai.provider.js";
+import { DiffParserService } from "../services/diff-parser.service.js";
+import { GenerationStreamService } from "../services/generation-stream.service.js";
+import { LlmKeyService } from "../services/llm-key.service.js";
+import { PromptBuilderService } from "../services/prompt-builder.service.js";
+
+import { GenerateController } from "./generate.controller.js";
+
+vi.mock("../../../common/config.js", () => ({
+  getServerEnv: () => ({ GENERATION_POLICY_REGEN_ENABLED: false }),
+}));
+
+vi.mock("./generate.constants.js", () => ({ HEARTBEAT_MS: 50 }));
+
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+const HISTORY_ID = "44444444-4444-4444-4444-444444444444";
+
+const SAMPLE_DIFF = [
+  "diff --git a/a.ts b/a.ts",
+  "index 1..2 100644",
+  "--- a/a.ts",
+  "+++ b/a.ts",
+  "@@ -1,2 +1,3 @@",
+  " line",
+  "+added",
+].join("\n");
+
+const happyPathScript: () => AsyncIterable<SuggestionEvent> = () => ({
+  [Symbol.asyncIterator]() {
+    const events: SuggestionEvent[] = [
+      {
+        kind: "suggestion",
+        index: 0,
+        value: { type: "feat", subject: "add user validation" },
+      },
+      { kind: "done", tokensUsed: 123 },
+    ];
+    let i = 0;
+    return {
+      next(): Promise<IteratorResult<SuggestionEvent>> {
+        return i < events.length
+          ? Promise.resolve({ value: events[i++]!, done: false })
+          : Promise.resolve({
+              value: undefined as unknown as SuggestionEvent,
+              done: true,
+            });
+      },
+    };
+  },
+});
+
+const hangingScript = (
+  signal?: AbortSignal,
+): AsyncIterable<SuggestionEvent> => ({
+  async *[Symbol.asyncIterator]() {
+    yield {
+      kind: "suggestion",
+      index: 0,
+      value: { type: "feat", subject: "first" },
+    };
+    await new Promise<void>((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(new Error("aborted"));
+        return;
+      }
+      signal?.addEventListener(
+        "abort",
+        () => reject(new Error("aborted")),
+        { once: true },
+      );
+      // Resolve after 5s as a safety net so a test bug doesn't hang forever.
+      setTimeout(resolve, 5000).unref();
+    });
+  },
+});
+
+const fakeProvider = (
+  script: (signal?: AbortSignal) => AsyncIterable<SuggestionEvent>,
+): LLMProvider => ({
+  name: "openai",
+  verify: vi.fn().mockResolvedValue(true),
+  generateSuggestions: (args: GenerateArgs) => script(args.signal),
+});
+
+const buildApp = async (
+  provider: LLMProvider,
+  { withLlmKey = true } = {},
+): Promise<{
+  app: INestApplication;
+  history: { createOne: ReturnType<typeof vi.fn> };
+  eventBus: EventBus;
+}> => {
+  const history = {
+    createOne: vi.fn().mockImplementation((input: unknown) =>
+      Promise.resolve({
+        id: HISTORY_ID,
+        ...(input as object),
+        createdAt: new Date(),
+      }),
+    ),
+  };
+  const llmKeyRepo = {
+    findByUserProvider: vi.fn().mockResolvedValue(
+      withLlmKey
+        ? {
+            userId: USER_ID,
+            provider: "openai",
+            keyEnc: Buffer.from("enc"),
+            keyIv: Buffer.from("iv"),
+            keyTag: Buffer.from("tag"),
+          }
+        : null,
+    ),
+  };
+  const cryptoStub = {
+    decryptParts: () => "sk-test",
+  } as unknown as CryptoService;
+  const policyRepo = {
+    findWithRules: vi.fn().mockResolvedValue(null),
+    getActiveForRepo: vi.fn().mockResolvedValue(null),
+  };
+  const reposRepo = {
+    findByIdForUser: vi.fn().mockResolvedValue(null),
+  };
+
+  @Module({
+    imports: [
+      ClsModule.forRoot({ global: true, middleware: { mount: true } }),
+      CqrsModule.forRoot(),
+      PolicyValidationModule,
+      ThrottlerModule.forRoot([
+        THROTTLE_TIERS.default,
+        THROTTLE_TIERS.auth,
+        THROTTLE_TIERS.generate,
+        THROTTLE_TIERS.analytics,
+      ]),
+    ],
+    controllers: [GenerateController],
+    providers: [
+      { provide: APP_GUARD, useClass: UserThrottlerGuard },
+      DiffParserService,
+      PromptBuilderService,
+      OpenAIProvider,
+      AnthropicProvider,
+      {
+        provide: LLMProviderFactory,
+        useValue: {
+          get: () => provider,
+        },
+      },
+      GenerationStreamService,
+      LlmKeyService,
+      { provide: GENERATION_HISTORY_REPOSITORY, useValue: history },
+      { provide: LLM_API_KEY_REPOSITORY, useValue: llmKeyRepo },
+      { provide: POLICY_REPOSITORY, useValue: policyRepo },
+      { provide: REPOSITORY_REPOSITORY, useValue: reposRepo },
+      { provide: CryptoService, useValue: cryptoStub },
+      {
+        provide: SupabaseAuthGuard,
+        useFactory: (cls: ClsService) => ({
+          canActivate: () => {
+            cls.set("auth.userId", USER_ID);
+            cls.set("auth.kind", "session");
+            return true;
+          },
+        }),
+        inject: [ClsService],
+      },
+      { provide: ApiKeyGuard, useValue: { canActivate: () => false } },
+      JwtOrApiKeyGuard,
+    ],
+  })
+  class TestModule {}
+
+  const moduleRef = await Test.createTestingModule({
+    imports: [TestModule],
+  }).compile();
+  const app = moduleRef.createNestApplication();
+  await app.init();
+  const eventBus = app.get(EventBus);
+  vi.spyOn(eventBus, "publish");
+  return { app, history, eventBus };
+};
+
+describe("POST /generate (SSE)", () => {
+  let app: INestApplication | undefined;
+
+  afterEach(async () => {
+    await app?.close();
+    app = undefined;
+  });
+
+  it("streams suggestion + done events with SSE framing, headers, and generation.completed", async () => {
+    const ctx = await buildApp(fakeProvider(happyPathScript));
+    app = ctx.app;
+    const server = app.getHttpServer() as Server;
+
+    const res = await request(server)
+      .post("/generate")
+      .set("authorization", "Bearer stub-jwt")
+      .send({ diff: SAMPLE_DIFF, provider: "openai", model: "gpt-4o-mini" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/text\/event-stream/);
+    expect(res.headers["cache-control"]).toBe("no-cache, no-transform");
+    expect(res.headers["x-accel-buffering"]).toBe("no");
+
+    const frames = parseSseFrames(res.text);
+    expect(frames.map((f) => f.kind)).toEqual(["suggestion", "done"]);
+    expect(frames[1]!.data).toMatchObject({
+      historyId: HISTORY_ID,
+      tokensUsed: 123,
+    });
+
+    const persisted = ctx.history.createOne.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(persisted.status).toBe("completed");
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const publish = vi.mocked(ctx.eventBus.publish);
+    const published = publish.mock.calls.map((c) => c[0]);
+    expect(
+      published.some((e) => e instanceof GenerationCompletedEvent),
+    ).toBe(true);
+    expect(
+      published.some((e) => e instanceof GenerationFailedEvent),
+    ).toBe(false);
+  });
+
+  it("returns 412 with NO_LLM_KEY when the user has no stored key", async () => {
+    const ctx = await buildApp(fakeProvider(happyPathScript), {
+      withLlmKey: false,
+    });
+    app = ctx.app;
+    const server = app.getHttpServer() as Server;
+
+    const res = await request(server)
+      .post("/generate")
+      .set("authorization", "Bearer stub-jwt")
+      .send({ diff: SAMPLE_DIFF, provider: "openai", model: "gpt-4o-mini" });
+
+    expect(res.status).toBe(412);
+    expect(res.body).toMatchObject({ code: "NO_LLM_KEY" });
+  });
+
+  it("rejects unauthenticated requests with 401", async () => {
+    const ctx = await buildApp(fakeProvider(happyPathScript));
+    app = ctx.app;
+    const server = app.getHttpServer() as Server;
+
+    const res = await request(server)
+      .post("/generate")
+      .send({ diff: SAMPLE_DIFF, provider: "openai", model: "gpt-4o-mini" });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("emits a `: ping` heartbeat on an idle stream", async () => {
+    const ctx = await buildApp(fakeProvider(hangingScript));
+    app = ctx.app;
+    await app.listen(0);
+    const server = app.getHttpServer() as Server;
+    const { port } = server.address() as AddressInfo;
+
+    const controller = new AbortController();
+    const res = await fetch(`http://127.0.0.1:${port}/generate`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer stub-jwt",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        diff: SAMPLE_DIFF,
+        provider: "openai",
+        model: "gpt-4o-mini",
+      }),
+      signal: controller.signal,
+    });
+    expect(res.status).toBe(200);
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let accumulated = "";
+    const deadline = Date.now() + 1500;
+    while (Date.now() < deadline) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      accumulated += decoder.decode(chunk.value as Uint8Array, {
+        stream: true,
+      });
+      if (accumulated.includes(": ping")) break;
+    }
+    controller.abort();
+    await reader.cancel().catch(() => undefined);
+    expect(accumulated).toContain(": ping");
+  });
+
+  it("on client disconnect persists cancelled status and aborts the provider", async () => {
+    const ctx = await buildApp(fakeProvider(hangingScript));
+    app = ctx.app;
+    await app.listen(0);
+    const server = app.getHttpServer() as Server;
+    const { port } = server.address() as AddressInfo;
+
+    const { default: http } = await import("node:http");
+    const payload = JSON.stringify({
+      diff: SAMPLE_DIFF,
+      provider: "openai",
+      model: "gpt-4o-mini",
+    });
+    await new Promise<void>((resolve, reject) => {
+      const req_ = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path: "/generate",
+          method: "POST",
+          headers: {
+            authorization: "Bearer stub-jwt",
+            "content-type": "application/json",
+            "content-length": Buffer.byteLength(payload),
+          },
+        },
+        (res) => {
+          res.once("data", () => {
+            req_.destroy();
+            resolve();
+          });
+          res.once("error", () => resolve());
+          res.once("close", () => resolve());
+        },
+      );
+      req_.once("error", () => resolve());
+      req_.end(payload);
+      setTimeout(
+        () => reject(new Error("timed out waiting for first chunk")),
+        3000,
+      );
+    });
+
+    // Wait for the cancelled persist to land.
+    const start = Date.now();
+    while (
+      ctx.history.createOne.mock.calls.length === 0 &&
+      Date.now() - start < 3000
+    ) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(ctx.history.createOne).toHaveBeenCalledTimes(1);
+    const persisted = ctx.history.createOne.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(persisted.status).toBe("cancelled");
+  });
+});
+
+function parseSseFrames(
+  raw: string,
+): Array<{ kind: string; data: Record<string, unknown> }> {
+  return raw
+    .split("\n\n")
+    .filter((f) => f.startsWith("event:"))
+    .map((f) => {
+      const [evLine, dataLine] = f.split("\n");
+      const kind = evLine!.replace("event: ", "").trim();
+      const json = JSON.parse(dataLine!.replace("data: ", "")) as Record<
+        string,
+        unknown
+      >;
+      return { kind, data: json };
+    });
+}
+

--- a/apps/api/src/modules/commit-generation/controllers/generate.controller.ts
+++ b/apps/api/src/modules/commit-generation/controllers/generate.controller.ts
@@ -24,7 +24,7 @@ import { GenerationStreamService } from "../services/generation-stream.service.j
 import { LlmKeyService } from "../services/llm-key.service.js";
 
 import { HEARTBEAT_MS } from "./generate.constants.js";
-import { writeSseEvent } from "./generate.mappers.js";
+import { canWrite, writeSseEvent } from "./generate.mappers.js";
 
 @Controller()
 @UseGuards(JwtOrApiKeyGuard)
@@ -67,33 +67,25 @@ export class GenerateController {
 
     res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
     res.setHeader("Cache-Control", "no-cache, no-transform");
-    res.setHeader("Connection", "keep-alive");
     res.setHeader("X-Accel-Buffering", "no");
     res.flushHeaders?.();
 
-    // Disable Nagle so each SSE frame hits the wire immediately; sending an
-    // initial comment frame guarantees the client's first-byte timer trips
-    // before the provider's first token lands (covers the TTFT budget even
-    // when the upstream is slow).
+    // Prime TTFT: disable Nagle + write a comment frame before the provider's
+    // first token.
     res.socket?.setNoDelay(true);
-    res.write(": connected\n\n");
+    if (canWrite(res)) res.write(": connected\n\n");
 
     const abort = new AbortController();
-    // Use res.on('close') — that's the event Express/Node fire on client
-    // disconnect for a still-open response. req.on('close') does not fire
-    // reliably once headers have been flushed.
     res.on("close", () => abort.abort());
 
     const heartbeat = setInterval(() => {
-      if (!res.writableEnded) res.write(": ping\n\n");
+      if (canWrite(res)) res.write(": ping\n\n");
     }, HEARTBEAT_MS);
     heartbeat.unref?.();
 
     try {
-      // Drain the whole generator even after the client disconnects: the
-      // stream service needs to reach its post-catch branch to persist the
-      // cancelled history row. Breaking out here would abandon the async
-      // generator and skip persistence.
+      // Drain the generator fully — breaking early abandons it and skips the
+      // cancelled-history persist in the post-abort branch.
       for await (const ev of this.stream.stream({
         userId,
         diff: body.diff,
@@ -107,10 +99,10 @@ export class GenerateController {
           signal: abort.signal,
         },
       })) {
-        if (!res.writableEnded) writeSseEvent(res, ev);
+        if (canWrite(res)) writeSseEvent(res, ev);
       }
     } catch (err) {
-      if (!res.writableEnded) {
+      if (canWrite(res)) {
         writeSseEvent(res, {
           kind: "error",
           data: {
@@ -121,7 +113,7 @@ export class GenerateController {
       }
     } finally {
       clearInterval(heartbeat);
-      if (!res.writableEnded) res.end();
+      if (canWrite(res)) res.end();
     }
   }
 }

--- a/apps/api/src/modules/commit-generation/controllers/generate.controller.ts
+++ b/apps/api/src/modules/commit-generation/controllers/generate.controller.ts
@@ -1,0 +1,128 @@
+import {
+  generateRequestSchema,
+  type GenerateRequest,
+} from "@commit-analyzer/contracts";
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  HttpCode,
+  HttpException,
+  HttpStatus,
+  Inject,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+} from "@nestjs/common";
+import type { Request, Response } from "express";
+
+import { ThrottleTierDecorator } from "../../../common/throttler/throttle-tier.decorator.js";
+import { CurrentUser } from "../../auth/current-user.decorator.js";
+import { JwtOrApiKeyGuard } from "../../auth/jwt-or-api-key.guard.js";
+import { GenerationStreamService } from "../services/generation-stream.service.js";
+import { LlmKeyService } from "../services/llm-key.service.js";
+
+import { HEARTBEAT_MS } from "./generate.constants.js";
+import { writeSseEvent } from "./generate.mappers.js";
+
+@Controller()
+@UseGuards(JwtOrApiKeyGuard)
+export class GenerateController {
+  constructor(
+    @Inject(GenerationStreamService)
+    private readonly stream: GenerationStreamService,
+    @Inject(LlmKeyService)
+    private readonly llmKeys: LlmKeyService,
+  ) {}
+
+  @Post("/generate")
+  @HttpCode(HttpStatus.OK)
+  @ThrottleTierDecorator("generate")
+  async generate(
+    @CurrentUser() userId: string,
+    @Body() rawBody: unknown,
+    @Req() req: Request,
+    @Res() res: Response,
+  ): Promise<void> {
+    const parseResult = generateRequestSchema.safeParse(rawBody);
+    if (!parseResult.success) {
+      throw new BadRequestException({
+        code: "INVALID_REQUEST",
+        message: "invalid request body",
+        issues: parseResult.error.issues.map((i) => ({
+          path: i.path.join("."),
+          message: i.message,
+        })),
+      });
+    }
+    const body: GenerateRequest = parseResult.data;
+    const apiKey = await this.llmKeys.getDecrypted(userId, body.provider);
+    if (!apiKey) {
+      throw new HttpException(
+        { code: "NO_LLM_KEY", message: "no LLM API key stored for provider" },
+        HttpStatus.PRECONDITION_FAILED,
+      );
+    }
+
+    res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+    res.setHeader("Cache-Control", "no-cache, no-transform");
+    res.setHeader("Connection", "keep-alive");
+    res.setHeader("X-Accel-Buffering", "no");
+    res.flushHeaders?.();
+
+    // Disable Nagle so each SSE frame hits the wire immediately; sending an
+    // initial comment frame guarantees the client's first-byte timer trips
+    // before the provider's first token lands (covers the TTFT budget even
+    // when the upstream is slow).
+    res.socket?.setNoDelay(true);
+    res.write(": connected\n\n");
+
+    const abort = new AbortController();
+    // Use res.on('close') — that's the event Express/Node fire on client
+    // disconnect for a still-open response. req.on('close') does not fire
+    // reliably once headers have been flushed.
+    res.on("close", () => abort.abort());
+
+    const heartbeat = setInterval(() => {
+      if (!res.writableEnded) res.write(": ping\n\n");
+    }, HEARTBEAT_MS);
+    heartbeat.unref?.();
+
+    try {
+      // Drain the whole generator even after the client disconnects: the
+      // stream service needs to reach its post-catch branch to persist the
+      // cancelled history row. Breaking out here would abandon the async
+      // generator and skip persistence.
+      for await (const ev of this.stream.stream({
+        userId,
+        diff: body.diff,
+        provider: body.provider,
+        model: body.model,
+        apiKey,
+        options: {
+          ...(body.repositoryId ? { repositoryId: body.repositoryId } : {}),
+          ...(body.policyId ? { policyId: body.policyId } : {}),
+          ...(body.count !== undefined ? { count: body.count } : {}),
+          signal: abort.signal,
+        },
+      })) {
+        if (!res.writableEnded) writeSseEvent(res, ev);
+      }
+    } catch (err) {
+      if (!res.writableEnded) {
+        writeSseEvent(res, {
+          kind: "error",
+          data: {
+            code: "INTERNAL",
+            message: err instanceof Error ? err.message : "internal error",
+          },
+        });
+      }
+    } finally {
+      clearInterval(heartbeat);
+      if (!res.writableEnded) res.end();
+    }
+  }
+}
+

--- a/apps/api/src/modules/commit-generation/controllers/generate.mappers.ts
+++ b/apps/api/src/modules/commit-generation/controllers/generate.mappers.ts
@@ -5,3 +5,9 @@ import type { StreamEvent } from "../services/generation-stream.types.js";
 export function writeSseEvent(res: Response, ev: StreamEvent): void {
   res.write(`event: ${ev.kind}\ndata: ${JSON.stringify(ev.data)}\n\n`);
 }
+
+// On disconnect the socket is destroyed before res.end(), so `writableEnded`
+// stays false even though writes would throw.
+export function canWrite(res: Response): boolean {
+  return res.writable && !res.destroyed;
+}

--- a/apps/api/src/modules/commit-generation/controllers/generate.mappers.ts
+++ b/apps/api/src/modules/commit-generation/controllers/generate.mappers.ts
@@ -1,0 +1,7 @@
+import type { Response } from "express";
+
+import type { StreamEvent } from "../services/generation-stream.types.js";
+
+export function writeSseEvent(res: Response, ev: StreamEvent): void {
+  res.write(`event: ${ev.kind}\ndata: ${JSON.stringify(ev.data)}\n\n`);
+}

--- a/apps/api/src/modules/commit-generation/services/generation-stream.service.spec.ts
+++ b/apps/api/src/modules/commit-generation/services/generation-stream.service.spec.ts
@@ -1,0 +1,270 @@
+import "reflect-metadata";
+
+import type {
+  GenerationHistoryRepository,
+  PolicyRepository,
+  RepositoryRepository,
+} from "@commit-analyzer/database";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ValidatorService } from "../../../shared/policy-validation/validator.service.js";
+import { QuotaError } from "../providers/llm-provider.errors.js";
+import { LLMProviderFactory } from "../providers/llm-provider.factory.js";
+import type {
+  GenerateArgs,
+  LLMProvider,
+  SuggestionEvent,
+} from "../providers/llm-provider.interface.js";
+import type { LlmSuggestion } from "../providers/suggestion.schema.js";
+
+import { DiffParserService } from "./diff-parser.service.js";
+import { PromptBuilderService } from "./prompt-builder.service.js";
+
+const getServerEnvMock = vi.hoisted(() => vi.fn());
+vi.mock("../../../common/config.js", () => ({
+  getServerEnv: getServerEnvMock,
+}));
+
+const { GenerationStreamService } = await import(
+  "./generation-stream.service.js"
+);
+
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+const HISTORY_ID = "44444444-4444-4444-4444-444444444444";
+
+const SAMPLE_DIFF = [
+  "diff --git a/src/auth.ts b/src/auth.ts",
+  "index 1..2 100644",
+  "--- a/src/auth.ts",
+  "+++ b/src/auth.ts",
+  "@@ -1,3 +1,4 @@",
+  " export function login(user: string) {",
+  "-  return true;",
+  "+  if (!user) throw new Error('user required');",
+  "+  return true;",
+  " }",
+].join("\n");
+
+type ProviderMockConfig = {
+  suggestions: LlmSuggestion[];
+  tokensUsed?: number;
+  throwOn?: "immediate" | "after-first";
+  error?: Error;
+  signalOnSuggestion?: AbortController;
+};
+
+const streamEventsFor = (cfg: ProviderMockConfig): AsyncIterable<SuggestionEvent> => {
+  const events: SuggestionEvent[] = cfg.suggestions.map((value, index) => ({
+    kind: "suggestion" as const,
+    index,
+    value,
+  }));
+  events.push({ kind: "done", tokensUsed: cfg.tokensUsed ?? 42 });
+  return {
+    [Symbol.asyncIterator]() {
+      let i = 0;
+      return {
+        next() {
+          if (cfg.throwOn === "immediate") {
+            return Promise.reject(cfg.error ?? new Error("boom"));
+          }
+          if (cfg.throwOn === "after-first" && i === 1) {
+            return Promise.reject(cfg.error ?? new Error("mid-stream boom"));
+          }
+          if (i >= events.length) {
+            return Promise.resolve({
+              value: undefined as unknown as SuggestionEvent,
+              done: true as const,
+            });
+          }
+          const value = events[i++]!;
+          if (
+            cfg.signalOnSuggestion &&
+            value.kind === "suggestion" &&
+            value.index === 0
+          ) {
+            cfg.signalOnSuggestion.abort();
+          }
+          return Promise.resolve({ value, done: false as const });
+        },
+      };
+    },
+  };
+};
+
+const mockProvider = (cfg: ProviderMockConfig): LLMProvider => ({
+  name: "openai",
+  verify: vi.fn().mockResolvedValue(true),
+  generateSuggestions: (_args: GenerateArgs) => streamEventsFor(cfg),
+});
+
+const mockHistoryRepo = () => {
+  const createOne = vi.fn().mockImplementation((input: unknown) =>
+    Promise.resolve({
+      id: HISTORY_ID,
+      ...(input as object),
+      createdAt: new Date(),
+    }),
+  );
+  return { createOne } as unknown as GenerationHistoryRepository;
+};
+
+const mockPolicyRepo = () =>
+  ({
+    findWithRules: vi.fn().mockResolvedValue(null),
+    getActiveForRepo: vi.fn().mockResolvedValue(null),
+  }) as unknown as PolicyRepository;
+
+const mockReposRepo = () =>
+  ({
+    findByIdForUser: vi.fn().mockResolvedValue(null),
+  }) as unknown as RepositoryRepository;
+
+const build = (provider: LLMProvider, history = mockHistoryRepo()) => {
+  const factory = new LLMProviderFactory(
+    provider as never,
+    provider as never,
+  );
+  const eventBus = { publish: vi.fn() };
+  const service = new GenerationStreamService(
+    new DiffParserService(),
+    new PromptBuilderService(),
+    factory,
+    new ValidatorService(),
+    eventBus as never,
+    mockPolicyRepo(),
+    mockReposRepo(),
+    history,
+  );
+  return { service, eventBus, history };
+};
+
+beforeEach(() => {
+  getServerEnvMock.mockReturnValue({ GENERATION_POLICY_REGEN_ENABLED: false });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GenerationStreamService", () => {
+  it("yields suggestion, done events and emits generation.completed", async () => {
+    const provider = mockProvider({
+      suggestions: [
+        { type: "feat", subject: "add user validation" },
+        { type: "fix", subject: "throw on missing user" },
+        { type: "refactor", subject: "guard empty input" },
+      ],
+      tokensUsed: 321,
+    });
+    const { service, eventBus, history } = build(provider);
+
+    const events: string[] = [];
+    let donePayload: { historyId: string | null; tokensUsed: number } | null =
+      null;
+    for await (const ev of service.stream({
+      userId: USER_ID,
+      diff: SAMPLE_DIFF,
+      provider: "openai",
+      model: "gpt-4o-mini",
+      apiKey: "sk-test",
+    })) {
+      events.push(ev.kind);
+      if (ev.kind === "done") donePayload = ev.data;
+    }
+
+    expect(events).toEqual(["suggestion", "suggestion", "suggestion", "done"]);
+    expect(donePayload).toMatchObject({
+      historyId: HISTORY_ID,
+      tokensUsed: 321,
+    });
+    const createArgs = (history.createOne as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as Record<string, unknown>;
+    expect(createArgs.status).toBe("completed");
+    expect(createArgs.tokensUsed).toBe(321);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits error frame and generation.failed when provider throws", async () => {
+    const provider = mockProvider({
+      suggestions: [],
+      throwOn: "immediate",
+      error: new QuotaError("rate limited"),
+    });
+    const { service, eventBus, history } = build(provider);
+
+    const events: Array<{ kind: string; data: Record<string, unknown> }> = [];
+    for await (const ev of service.stream({
+      userId: USER_ID,
+      diff: SAMPLE_DIFF,
+      provider: "openai",
+      model: "gpt-4o-mini",
+      apiKey: "sk-test",
+    })) {
+      events.push(ev as never);
+    }
+
+    expect(events).toEqual([
+      { kind: "error", data: { code: "LLM_RATE_LIMIT", message: "rate limited" } },
+    ]);
+    const createArgs = (history.createOne as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as Record<string, unknown>;
+    expect(createArgs.status).toBe("failed");
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    const event = (eventBus.publish.mock.calls[0]![0] as { reason: string });
+    expect(event.reason).toBe("LLM_RATE_LIMIT");
+  });
+
+  it("persists cancelled row and emits no events when abort fires mid-stream", async () => {
+    const controller = new AbortController();
+    const provider = mockProvider({
+      suggestions: [
+        { type: "feat", subject: "first suggestion" },
+        { type: "fix", subject: "second suggestion" },
+      ],
+      throwOn: "after-first",
+      error: Object.assign(new Error("aborted"), { name: "AbortError" }),
+      signalOnSuggestion: controller,
+    });
+    const { service, eventBus, history } = build(provider);
+
+    const events: string[] = [];
+    for await (const ev of service.stream({
+      userId: USER_ID,
+      diff: SAMPLE_DIFF,
+      provider: "openai",
+      model: "gpt-4o-mini",
+      apiKey: "sk-test",
+      options: { signal: controller.signal },
+    })) {
+      events.push(ev.kind);
+    }
+
+    expect(events).toEqual(["suggestion"]);
+    const createArgs = (history.createOne as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as Record<string, unknown>;
+    expect(createArgs.status).toBe("cancelled");
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it("starts yielding the first suggestion quickly (TTFT < 2s)", async () => {
+    const provider = mockProvider({
+      suggestions: [{ type: "feat", subject: "add guard" }],
+    });
+    const { service } = build(provider);
+    const t0 = Date.now();
+    const iter = service.stream({
+      userId: USER_ID,
+      diff: SAMPLE_DIFF,
+      provider: "openai",
+      model: "gpt-4o-mini",
+      apiKey: "sk-test",
+    });
+    const first = await iter.next();
+    const ttft = Date.now() - t0;
+    expect(first.value).toMatchObject({ kind: "suggestion" });
+    expect(ttft).toBeLessThan(2000);
+    // Drain the rest so no pending promise leaks.
+    for await (const _ of iter) void _;
+  });
+});

--- a/apps/api/src/modules/commit-generation/services/generation-stream.service.ts
+++ b/apps/api/src/modules/commit-generation/services/generation-stream.service.ts
@@ -1,0 +1,288 @@
+import type {
+  GenerationHistoryRepository,
+  Policy,
+  PolicyRepository,
+  RepositoryRepository,
+} from "@commit-analyzer/database";
+import { renderParsedDiff } from "@commit-analyzer/diff-parser";
+import type {
+  GenerationStatus,
+  LlmProvider,
+  SuggestionRecord,
+} from "@commit-analyzer/shared-types";
+import { Inject, Injectable, Logger } from "@nestjs/common";
+import { EventBus } from "@nestjs/cqrs";
+
+import {
+  GENERATION_HISTORY_REPOSITORY,
+  POLICY_REPOSITORY,
+  REPOSITORY_REPOSITORY,
+} from "../../../common/database/tokens.js";
+import { GenerationCompletedEvent } from "../../../shared/events/generation-completed.event.js";
+import { GenerationFailedEvent } from "../../../shared/events/generation-failed.event.js";
+import { ValidatorService } from "../../../shared/policy-validation/validator.service.js";
+import { PolicyAccessDeniedError } from "../commands/generate-message.errors.js";
+import {
+  classifyGenerationError,
+  toPromptPolicy,
+  toValidatorPolicy,
+} from "../commands/generate-message.mappers.js";
+import { LLMProviderFactory } from "../providers/llm-provider.factory.js";
+import type { LlmSuggestion } from "../providers/suggestion.schema.js";
+
+import { hashDiff } from "./diff-hash.js";
+import { DiffParserService } from "./diff-parser.service.js";
+import type {
+  StreamEvent,
+  StreamInput,
+  SuggestionFramePayload,
+} from "./generation-stream.types.js";
+import { PromptBuilderService } from "./prompt-builder.service.js";
+import { formatSuggestionAsCommitMessage } from "./suggestion-formatter.js";
+
+@Injectable()
+export class GenerationStreamService {
+  private readonly logger = new Logger(GenerationStreamService.name);
+
+  constructor(
+    @Inject(DiffParserService)
+    private readonly diffParser: DiffParserService,
+    @Inject(PromptBuilderService)
+    private readonly promptBuilder: PromptBuilderService,
+    @Inject(LLMProviderFactory)
+    private readonly factory: LLMProviderFactory,
+    @Inject(ValidatorService)
+    private readonly validator: ValidatorService,
+    @Inject(EventBus)
+    private readonly eventBus: EventBus,
+    @Inject(POLICY_REPOSITORY)
+    private readonly policies: PolicyRepository,
+    @Inject(REPOSITORY_REPOSITORY)
+    private readonly repositories: RepositoryRepository,
+    @Inject(GENERATION_HISTORY_REPOSITORY)
+    private readonly history: GenerationHistoryRepository,
+  ) {}
+
+  async *stream(input: StreamInput): AsyncGenerator<StreamEvent> {
+    const { userId, diff, provider, model, apiKey, options } = input;
+    const count = options?.count ?? 3;
+    const signal = options?.signal;
+
+    let parsed;
+    try {
+      parsed = this.diffParser.parse(diff);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "diff parse failed";
+      yield { kind: "error", data: { code: "DIFF_PARSE_FAILED", message } };
+      return;
+    }
+    const diffHash = hashDiff(renderParsedDiff(parsed));
+
+    let policy: Policy | null;
+    try {
+      policy = await this.resolvePolicy(
+        userId,
+        options?.policyId,
+        options?.repositoryId,
+      );
+    } catch (err) {
+      if (err instanceof PolicyAccessDeniedError) {
+        yield {
+          kind: "error",
+          data: { code: "POLICY_ACCESS_DENIED", message: err.message },
+        };
+        return;
+      }
+      throw err;
+    }
+
+    const validatorPolicy = policy ? toValidatorPolicy(policy) : null;
+    const prompt = this.promptBuilder.build(parsed, toPromptPolicy(policy), {
+      count,
+    });
+    const llm = this.factory.get(provider);
+
+    const collected: SuggestionRecord[] = [];
+    let tokensUsed = 0;
+    let aborted = false;
+
+    try {
+      for await (const ev of llm.generateSuggestions({
+        apiKey,
+        model,
+        prompt,
+        count,
+        signal,
+      })) {
+        if (ev.kind === "suggestion") {
+          const frame = this.enrich(ev.index, ev.value, validatorPolicy);
+          collected.push({
+            type: frame.type,
+            scope: frame.scope,
+            subject: frame.subject,
+            body: frame.body,
+            footer: frame.footer,
+            compliant: frame.compliant,
+          });
+          yield { kind: "suggestion", data: frame };
+        } else {
+          tokensUsed = ev.tokensUsed;
+        }
+      }
+    } catch (err) {
+      if (signal?.aborted) {
+        aborted = true;
+      } else {
+        const code = classifyGenerationError(err);
+        const message = err instanceof Error ? err.message : "generation failed";
+        const historyId = await this.persist({
+          userId,
+          repositoryId: options?.repositoryId,
+          diffHash,
+          provider,
+          model,
+          tokensUsed,
+          status: "failed",
+          suggestions: collected,
+          policyId: policy?.id ?? null,
+        });
+        if (historyId) {
+          this.eventBus.publish(
+            new GenerationFailedEvent(userId, historyId, code),
+          );
+        }
+        yield { kind: "error", data: { code, message } };
+        return;
+      }
+    }
+
+    if (signal?.aborted || aborted) {
+      await this.persist({
+        userId,
+        repositoryId: options?.repositoryId,
+        diffHash,
+        provider,
+        model,
+        tokensUsed,
+        status: "cancelled",
+        suggestions: collected,
+        policyId: policy?.id ?? null,
+      });
+      return;
+    }
+
+    const historyId = await this.persist({
+      userId,
+      repositoryId: options?.repositoryId,
+      diffHash,
+      provider,
+      model,
+      tokensUsed,
+      status: "completed",
+      suggestions: collected,
+      policyId: policy?.id ?? null,
+    });
+    if (historyId) {
+      this.eventBus.publish(
+        new GenerationCompletedEvent(
+          userId,
+          historyId,
+          provider,
+          model,
+          tokensUsed,
+        ),
+      );
+    }
+    yield { kind: "done", data: { historyId, tokensUsed } };
+  }
+
+  private enrich(
+    index: number,
+    suggestion: LlmSuggestion,
+    validatorPolicy: ReturnType<typeof toValidatorPolicy> | null,
+  ): SuggestionFramePayload {
+    const validation = validatorPolicy
+      ? this.validator.validate(
+          formatSuggestionAsCommitMessage(suggestion),
+          validatorPolicy,
+        )
+      : null;
+    return {
+      index,
+      type: suggestion.type,
+      scope: suggestion.scope ?? null,
+      subject: suggestion.subject,
+      body: suggestion.body ?? null,
+      footer: suggestion.footer ?? null,
+      compliant: validation ? validation.passed : true,
+      validation: validation
+        ? {
+            passed: validation.passed,
+            results: validation.results.map((r) => ({
+              ruleType: r.ruleType,
+              passed: r.passed,
+              ...(r.message !== undefined ? { message: r.message } : {}),
+            })),
+          }
+        : null,
+    };
+  }
+
+  private async resolvePolicy(
+    userId: string,
+    policyId: string | undefined,
+    repositoryId: string | undefined,
+  ): Promise<Policy | null> {
+    if (policyId) {
+      const policy = await this.policies.findWithRules(policyId);
+      if (!policy) throw new PolicyAccessDeniedError();
+      const owned = await this.repositories.findByIdForUser(
+        policy.repositoryId,
+        userId,
+      );
+      if (!owned) throw new PolicyAccessDeniedError();
+      return policy;
+    }
+    if (repositoryId) {
+      const owned = await this.repositories.findByIdForUser(
+        repositoryId,
+        userId,
+      );
+      if (!owned) return null;
+      return this.policies.getActiveForRepo(repositoryId);
+    }
+    return null;
+  }
+
+  private async persist(input: {
+    userId: string;
+    repositoryId: string | undefined;
+    diffHash: string;
+    provider: LlmProvider;
+    model: string;
+    tokensUsed: number;
+    status: GenerationStatus;
+    suggestions: SuggestionRecord[];
+    policyId: string | null;
+  }): Promise<string | null> {
+    try {
+      const row = await this.history.createOne({
+        userId: input.userId,
+        repositoryId: input.repositoryId ?? null,
+        diffHash: input.diffHash,
+        provider: input.provider,
+        model: input.model,
+        tokensUsed: input.tokensUsed,
+        status: input.status,
+        suggestions: input.suggestions,
+        policyId: input.policyId,
+      });
+      return row.id;
+    } catch (err) {
+      this.logger.warn(
+        `generation history persistence failed: ${String(err)}`,
+      );
+      return null;
+    }
+  }
+}

--- a/apps/api/src/modules/commit-generation/services/generation-stream.types.ts
+++ b/apps/api/src/modules/commit-generation/services/generation-stream.types.ts
@@ -1,0 +1,50 @@
+import type { LlmProvider } from "@commit-analyzer/shared-types";
+
+export interface SuggestionFramePayload {
+  index: number;
+  type: string;
+  scope: string | null;
+  subject: string;
+  body: string | null;
+  footer: string | null;
+  compliant: boolean;
+  validation: {
+    passed: boolean;
+    results: Array<{
+      ruleType: string;
+      passed: boolean;
+      message?: string;
+    }>;
+  } | null;
+}
+
+export interface DoneFramePayload {
+  historyId: string | null;
+  tokensUsed: number;
+}
+
+export interface ErrorFramePayload {
+  code: string;
+  message: string;
+}
+
+export type StreamEvent =
+  | { kind: "suggestion"; data: SuggestionFramePayload }
+  | { kind: "done"; data: DoneFramePayload }
+  | { kind: "error"; data: ErrorFramePayload };
+
+export interface StreamInputOptions {
+  repositoryId?: string;
+  policyId?: string;
+  count?: number;
+  signal?: AbortSignal;
+}
+
+export interface StreamInput {
+  userId: string;
+  diff: string;
+  provider: LlmProvider;
+  model: string;
+  apiKey: string;
+  options?: StreamInputOptions;
+}

--- a/apps/api/src/modules/commit-generation/services/llm-key.service.ts
+++ b/apps/api/src/modules/commit-generation/services/llm-key.service.ts
@@ -1,0 +1,29 @@
+import type { LLMApiKeyRepository } from "@commit-analyzer/database";
+import type { LlmProvider } from "@commit-analyzer/shared-types";
+import { Inject, Injectable } from "@nestjs/common";
+
+import { LLM_API_KEY_REPOSITORY } from "../../../common/database/tokens.js";
+import { CryptoService } from "../../../shared/crypto.service.js";
+
+@Injectable()
+export class LlmKeyService {
+  constructor(
+    @Inject(LLM_API_KEY_REPOSITORY)
+    private readonly repo: LLMApiKeyRepository,
+    @Inject(CryptoService)
+    private readonly crypto: CryptoService,
+  ) {}
+
+  async getDecrypted(
+    userId: string,
+    provider: LlmProvider,
+  ): Promise<string | null> {
+    const row = await this.repo.findByUserAndProvider(userId, provider);
+    if (!row) return null;
+    return this.crypto.decryptParts({
+      ciphertext: row.keyEnc,
+      iv: row.keyIv,
+      tag: row.keyTag,
+    });
+  }
+}

--- a/packages/contracts/src/generation.contract.ts
+++ b/packages/contracts/src/generation.contract.ts
@@ -1,0 +1,98 @@
+import { initContract } from "@ts-rest/core";
+import { z } from "zod";
+
+import { ruleResultSchema } from "./policies.contract.js";
+import { errorEnvelopeSchema } from "./shared/error.js";
+import type { RouteMetadata } from "./shared/metadata.js";
+
+const c = initContract();
+
+const llmProviderSchema = z.enum(["openai", "anthropic"]);
+
+export const generateRequestSchema = z.object({
+  diff: z.string().min(1),
+  provider: llmProviderSchema,
+  model: z.string().min(1).max(128),
+  repositoryId: z.string().uuid().optional(),
+  policyId: z.string().uuid().optional(),
+  count: z.number().int().min(1).max(5).optional(),
+});
+export type GenerateRequest = z.infer<typeof generateRequestSchema>;
+
+export const suggestionFrameSchema = z.object({
+  index: z.number().int().nonnegative(),
+  type: z.string(),
+  scope: z.string().nullable(),
+  subject: z.string(),
+  body: z.string().nullable(),
+  footer: z.string().nullable(),
+  compliant: z.boolean(),
+  validation: z
+    .object({
+      passed: z.boolean(),
+      results: z.array(ruleResultSchema),
+    })
+    .nullable(),
+});
+export type SuggestionFrame = z.infer<typeof suggestionFrameSchema>;
+
+export const tokenFrameSchema = z.object({
+  index: z.number().int().nonnegative(),
+  delta: z.string(),
+});
+export type TokenFrame = z.infer<typeof tokenFrameSchema>;
+
+export const doneFrameSchema = z.object({
+  historyId: z.string().uuid().nullable(),
+  tokensUsed: z.number().int().nonnegative(),
+});
+export type DoneFrame = z.infer<typeof doneFrameSchema>;
+
+export const errorFrameSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+});
+export type ErrorFrame = z.infer<typeof errorFrameSchema>;
+
+export const generationContract = c.router(
+  {
+    /**
+     * Streams Conventional Commit suggestions as Server-Sent Events.
+     *
+     * Response is `text/event-stream` with four event kinds, per Module C §2:
+     * - `suggestion`: one per generated message (carries `compliant` + per-rule
+     *   `validation` breakdown when a policy is active).
+     * - `token`: optional live-token delta (reserved; not emitted today).
+     * - `done`: terminal success frame with `historyId` + `tokensUsed`.
+     * - `error`: terminal failure frame with `{code, message}`.
+     *
+     * Transport headers:
+     * - `Cache-Control: no-cache, no-transform`
+     * - `X-Accel-Buffering: no`
+     * - `: ping` heartbeat every 15 s on idle streams.
+     *
+     * `responses: { 200: z.void() }` — ts-rest has no SSE primitive; the body
+     * above describes the stream format. Clients consume this endpoint with
+     * raw fetch streaming or `EventSource`, not `initClient`.
+     */
+    generate: {
+      method: "POST",
+      path: "/generate",
+      body: generateRequestSchema,
+      responses: {
+        200: z.void(),
+        400: errorEnvelopeSchema,
+        401: errorEnvelopeSchema,
+        412: errorEnvelopeSchema,
+        429: errorEnvelopeSchema,
+        500: errorEnvelopeSchema,
+      },
+      summary: "Generate commit messages (SSE stream — see Module C §2)",
+      metadata: {
+        auth: "jwtOrApiKey",
+        rateLimit: "generate",
+      } satisfies RouteMetadata,
+    },
+  },
+  { strictStatusCodes: true },
+);

--- a/packages/contracts/src/generation.contract.ts
+++ b/packages/contracts/src/generation.contract.ts
@@ -56,25 +56,9 @@ export type ErrorFrame = z.infer<typeof errorFrameSchema>;
 
 export const generationContract = c.router(
   {
-    /**
-     * Streams Conventional Commit suggestions as Server-Sent Events.
-     *
-     * Response is `text/event-stream` with four event kinds, per Module C §2:
-     * - `suggestion`: one per generated message (carries `compliant` + per-rule
-     *   `validation` breakdown when a policy is active).
-     * - `token`: optional live-token delta (reserved; not emitted today).
-     * - `done`: terminal success frame with `historyId` + `tokensUsed`.
-     * - `error`: terminal failure frame with `{code, message}`.
-     *
-     * Transport headers:
-     * - `Cache-Control: no-cache, no-transform`
-     * - `X-Accel-Buffering: no`
-     * - `: ping` heartbeat every 15 s on idle streams.
-     *
-     * `responses: { 200: z.void() }` — ts-rest has no SSE primitive; the body
-     * above describes the stream format. Clients consume this endpoint with
-     * raw fetch streaming or `EventSource`, not `initClient`.
-     */
+    // SSE stream — frames (suggestion/token/done/error) + headers per Module C
+    // §2 and 05-api-contracts §6. `200: z.void()` because ts-rest has no SSE
+    // primitive; consume via fetch streaming or EventSource, not initClient.
     generate: {
       method: "POST",
       path: "/generate",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3,6 +3,7 @@ import { initContract } from "@ts-rest/core";
 import { analyticsContract } from "./analytics.contract.js";
 import { auditContract } from "./audit.contract.js";
 import { authContract } from "./auth.contract.js";
+import { generationContract } from "./generation.contract.js";
 import { policiesContract } from "./policies.contract.js";
 import { reposContract } from "./repos.contract.js";
 
@@ -14,6 +15,7 @@ export const contracts = c.router({
   analytics: analyticsContract,
   repos: reposContract,
   policies: policiesContract,
+  generation: generationContract,
 });
 
 export type Contracts = typeof contracts;
@@ -104,6 +106,22 @@ export {
   validatePolicyInputSchema,
   validationResultSchema,
 } from "./policies.contract.js";
+
+export { generationContract } from "./generation.contract.js";
+export type {
+  DoneFrame,
+  ErrorFrame,
+  GenerateRequest,
+  SuggestionFrame,
+  TokenFrame,
+} from "./generation.contract.js";
+export {
+  doneFrameSchema,
+  errorFrameSchema,
+  generateRequestSchema,
+  suggestionFrameSchema,
+  tokenFrameSchema,
+} from "./generation.contract.js";
 
 export { errorEnvelopeSchema } from "./shared/error.js";
 export type { ErrorEnvelope } from "./shared/error.js";


### PR DESCRIPTION
## Summary
- `POST /generate` SSE endpoint per Module C §2: emits `suggestion` / `done` / `error` frames with `compliant` + per-rule `validation` breakdown; `token` reserved in the contract for future live-token rendering. Headers per `05-api-contracts.md §6` (`Cache-Control: no-cache, no-transform`, `X-Accel-Buffering: no`), `: ping` heartbeat every 15 s, initial `: connected` comment primes TTFT and forces an early socket flush.
- Client disconnect → `AbortController` wired via `res.on('close')` aborts the provider and persists `generation_history.status='cancelled'` (no domain event on cancel). Completed runs publish `generation.completed`; provider errors publish `generation.failed` and yield a terminal `error` frame.
- Auth: new `JwtOrApiKeyGuard` composes `SupabaseAuthGuard` + `ApiKeyGuard`, honoring the `jwtOrApiKey` contract metadata. Rate limiting: `generate` tier (20 / 60 s) via `@ThrottleTierDecorator`.
- LLM key resolution: new `createLlmApiKeyRepository` + `LlmKeyService` decrypt the stored key for the user at request time; missing key → `412 NO_LLM_KEY`.
- New `GenerationStreamService` orchestrator (separate from the CQRS handler so T-4.5's compliance / regen tests keep their buffered semantics). Yields events for the controller to forward.
- ts-rest contract entry `generation.generate` with SSE docstring pointing at Module C §2 + ADR-0007; exported from `@commit-analyzer/contracts`.

Covers acceptance criteria:
- TTFT < 2 s (service-level test).
- Abort → provider signal aborts, history row persisted as `cancelled` (integration test).
- SSE event set matches Module C §2 exactly.
- `generation.completed` / `generation.failed` observed by spy subscriber.
- Heartbeat frame arrives inside the 15 s budget (integration test with shortened interval).

Closes #54

## Test plan
- [ ] `pnpm -F @commit-analyzer/api typecheck`
- [ ] `pnpm -F @commit-analyzer/api lint`
- [ ] `pnpm -F @commit-analyzer/api test` (non-integration; `*.integration.test.ts` need Docker and are skipped locally)
- [ ] CI green on `branch-name`, `commitlint`, typecheck, lint, test