### PR TITLE
fix(T-4.7): graceful llm provider error handling

### DIFF
--- a/apps/api/src/modules/auth/llm-keys.errors.ts
+++ b/apps/api/src/modules/auth/llm-keys.errors.ts
@@ -19,3 +19,24 @@ export class LlmProviderUnavailableException extends HttpException {
     );
   }
 }
+
+// OpenAI's `insufficient_quota` (billing exhausted) arrives as HTTP 429 but is
+// a permanent state, not a retry-me. Distinct code so the UI can direct the
+// user to their billing page instead of telling them to retry.
+export class LlmProviderQuotaExhaustedException extends HttpException {
+  constructor(reason: string) {
+    super(
+      { error: { code: "provider_quota_exhausted", message: reason } },
+      HttpStatus.UNPROCESSABLE_ENTITY,
+    );
+  }
+}
+
+export class LlmProviderTimeoutException extends HttpException {
+  constructor(reason: string) {
+    super(
+      { error: { code: "provider_timeout", message: reason } },
+      HttpStatus.UNPROCESSABLE_ENTITY,
+    );
+  }
+}

--- a/apps/api/src/modules/auth/llm-keys.service.test.ts
+++ b/apps/api/src/modules/auth/llm-keys.service.test.ts
@@ -5,13 +5,19 @@ import { NotFoundException } from "@nestjs/common";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CryptoService } from "../../shared/crypto.service.js";
-import { UpstreamError } from "../commit-generation/providers/llm-provider.errors.js";
+import {
+  QuotaExhaustedError,
+  TimeoutError,
+  UpstreamError,
+} from "../commit-generation/providers/llm-provider.errors.js";
 import type { LLMProviderFactory } from "../commit-generation/providers/llm-provider.factory.js";
 
 import { LlmKeyDeletedEvent } from "./events/llm-key-deleted.event.js";
 import { LlmKeyUpsertedEvent } from "./events/llm-key-upserted.event.js";
 import {
   InvalidLlmApiKeyException,
+  LlmProviderQuotaExhaustedException,
+  LlmProviderTimeoutException,
   LlmProviderUnavailableException,
 } from "./llm-keys.errors.js";
 import { LlmKeysService } from "./llm-keys.service.js";
@@ -133,13 +139,47 @@ describe("LlmKeysService", () => {
       );
     });
 
-    // UpstreamError is the only category `verify()` re-throws.
+    // UpstreamError is the generic re-thrown category.
     it("surfaces LlmProviderUnavailableException on upstream failures", async () => {
       verify.mockRejectedValueOnce(new UpstreamError("5xx"));
 
       await expect(
         makeService().upsert(USER_ID, "openai", "sk-working-maybe12345"),
       ).rejects.toBeInstanceOf(LlmProviderUnavailableException);
+      expect(repo.upsertForUser).not.toHaveBeenCalled();
+    });
+
+    // QuotaExhaustedError signals permanent billing exhaustion — must NOT be
+    // saved (unlike transient QuotaError), and must surface with its own code
+    // so the UI can point the user at billing.
+    it("surfaces LlmProviderQuotaExhaustedException on insufficient_quota", async () => {
+      verify.mockRejectedValueOnce(new QuotaExhaustedError("insufficient_quota"));
+
+      const error = await makeService()
+        .upsert(USER_ID, "openai", "sk-outoffunds12345")
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(LlmProviderQuotaExhaustedException);
+      const httpError = error as LlmProviderQuotaExhaustedException;
+      expect(httpError.getStatus()).toBe(422);
+      expect(httpError.getResponse()).toMatchObject({
+        error: { code: "provider_quota_exhausted" },
+      });
+      expect(repo.upsertForUser).not.toHaveBeenCalled();
+      expect(publish).not.toHaveBeenCalled();
+    });
+
+    it("surfaces LlmProviderTimeoutException on verify timeout", async () => {
+      verify.mockRejectedValueOnce(new TimeoutError("timed out"));
+
+      const error = await makeService()
+        .upsert(USER_ID, "openai", "sk-slowresponse12345")
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(LlmProviderTimeoutException);
+      expect((error as LlmProviderTimeoutException).getResponse()).toMatchObject(
+        { error: { code: "provider_timeout" } },
+      );
       expect(repo.upsertForUser).not.toHaveBeenCalled();
     });
   });

--- a/apps/api/src/modules/auth/llm-keys.service.ts
+++ b/apps/api/src/modules/auth/llm-keys.service.ts
@@ -5,13 +5,19 @@ import { EventBus } from "@nestjs/cqrs";
 
 import { LLM_API_KEY_REPOSITORY } from "../../common/database/tokens.js";
 import { CryptoService } from "../../shared/crypto.service.js";
-import { mapProviderError } from "../commit-generation/providers/llm-provider.errors.js";
+import {
+  mapProviderError,
+  QuotaExhaustedError,
+  TimeoutError,
+} from "../commit-generation/providers/llm-provider.errors.js";
 import { LLMProviderFactory } from "../commit-generation/providers/llm-provider.factory.js";
 
 import { LlmKeyDeletedEvent } from "./events/llm-key-deleted.event.js";
 import { LlmKeyUpsertedEvent } from "./events/llm-key-upserted.event.js";
 import {
   InvalidLlmApiKeyException,
+  LlmProviderQuotaExhaustedException,
+  LlmProviderTimeoutException,
   LlmProviderUnavailableException,
 } from "./llm-keys.errors.js";
 
@@ -36,18 +42,30 @@ export class LlmKeysService {
     provider: LlmProviderName,
     key: string,
   ): Promise<LLMApiKey> {
-    // `BaseLLMProvider.verify()` collapses upstream errors into a boolean:
-    // AuthError → false, QuotaError → true (valid but rate-limited), and
-    // other upstream failures are the only path that throws. So we only need
-    // to handle the boolean and the upstream-error throw here.
+    // `BaseLLMProvider.verify()` collapses outcomes into:
+    //   AuthError → false ("provider rejected the API key"),
+    //   QuotaError (plain 429 rate-limit) → true (transient; allow save),
+    //   QuotaExhaustedError / TimeoutError / UpstreamError → thrown.
+    // The thrown errors are translated below into distinct 422 codes so the UI
+    // can show actionable messages instead of a generic "unavailable".
     let verified: boolean;
     try {
       verified = await this.providers.get(provider).verify(key);
     } catch (err) {
       const mapped = mapProviderError(err);
       this.logger.warn(
-        `LLM verify threw for provider=${provider}: ${mapped.message}`,
+        `LLM verify threw for provider=${provider}: ${mapped.name}: ${mapped.message}`,
       );
+      if (mapped instanceof QuotaExhaustedError) {
+        throw new LlmProviderQuotaExhaustedException(
+          `${provider} account has no remaining quota — add billing credit and try again`,
+        );
+      }
+      if (mapped instanceof TimeoutError) {
+        throw new LlmProviderTimeoutException(
+          `timed out contacting ${provider}; please retry`,
+        );
+      }
       throw new LlmProviderUnavailableException(
         "could not verify the API key with the provider",
       );

--- a/apps/api/src/modules/commit-generation/commands/generate-message.mappers.ts
+++ b/apps/api/src/modules/commit-generation/commands/generate-message.mappers.ts
@@ -4,6 +4,8 @@ import type { ValidatorPolicy } from "../../../shared/policy-validation/validato
 import {
   AuthError,
   QuotaError,
+  QuotaExhaustedError,
+  TimeoutError,
   UpstreamError,
 } from "../providers/llm-provider.errors.js";
 import type { PromptPolicy } from "../services/prompt-builder.types.js";
@@ -37,7 +39,9 @@ export const toValidatorPolicy = (policy: Policy): ValidatorPolicy => ({
 
 export const classifyGenerationError = (error: unknown): string => {
   if (error instanceof AuthError) return "LLM_AUTH";
+  if (error instanceof QuotaExhaustedError) return "LLM_QUOTA_EXHAUSTED";
   if (error instanceof QuotaError) return "LLM_RATE_LIMIT";
+  if (error instanceof TimeoutError) return "LLM_TIMEOUT";
   if (error instanceof UpstreamError) return "LLM_UPSTREAM";
   if (error instanceof Error && error.constructor.name !== "Error") {
     return error.constructor.name;

--- a/apps/api/src/modules/commit-generation/providers/base-llm.provider.ts
+++ b/apps/api/src/modules/commit-generation/providers/base-llm.provider.ts
@@ -32,15 +32,22 @@ export abstract class BaseLLMProvider implements LLMProvider {
 
     try {
       const client = this.clientFactory(apiKey);
+      // maxRetries: 0 — verify is a UI-facing health check, so the 10s timeout
+      // covers exactly one round-trip instead of being consumed by retries with
+      // backoff (otherwise a transient 429 can mask itself as a timeout).
       await generateText({
         model: client(modelId),
         prompt: "ping",
         abortSignal: signal,
+        maxRetries: 0,
       });
       return true;
     } catch (error) {
       const mapped = mapProviderError(error);
       if (mapped instanceof AuthError) return false;
+      // Plain rate-limit is transient — let the user save the key. Quota
+      // exhaustion and timeouts propagate so the service surfaces a specific
+      // reason to the UI.
       if (mapped instanceof QuotaError) return true;
       throw mapped;
     }

--- a/apps/api/src/modules/commit-generation/providers/llm-provider.errors.ts
+++ b/apps/api/src/modules/commit-generation/providers/llm-provider.errors.ts
@@ -1,4 +1,4 @@
-import { APICallError } from "ai";
+import { APICallError, RetryError } from "ai";
 
 class LLMProviderError extends Error {
   constructor(message: string, cause?: unknown) {
@@ -9,10 +9,68 @@ class LLMProviderError extends Error {
 
 export class AuthError extends LLMProviderError {}
 export class QuotaError extends LLMProviderError {}
+export class QuotaExhaustedError extends LLMProviderError {}
+export class TimeoutError extends LLMProviderError {}
 export class UpstreamError extends LLMProviderError {}
+
+const INSUFFICIENT_QUOTA_CODE = "insufficient_quota";
+
+// OpenAI returns 429 for both rate-limit and out-of-credit; only the body's
+// `error.code` distinguishes them. Distinguishing matters: rate-limit is
+// transient (let the user save the key), billing-exhausted is not.
+const isInsufficientQuota = (error: APICallError): boolean => {
+  const data = (error as { data?: unknown }).data;
+  if (
+    data &&
+    typeof data === "object" &&
+    "error" in data &&
+    data.error &&
+    typeof data.error === "object" &&
+    "code" in data.error &&
+    (data.error as { code?: unknown }).code === INSUFFICIENT_QUOTA_CODE
+  ) {
+    return true;
+  }
+  const body = error.responseBody;
+  if (typeof body === "string" && body.includes(INSUFFICIENT_QUOTA_CODE)) {
+    return true;
+  }
+  return false;
+};
+
+const isAbortLike = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  if (error.name === "AbortError" || error.name === "TimeoutError") return true;
+  const cause = (error as { cause?: unknown }).cause;
+  return isAbortLike(cause);
+};
+
+const pickUnderlying = (retry: RetryError): unknown => {
+  if (retry.lastError !== undefined) return retry.lastError;
+  const list = retry.errors;
+  return list.length > 0 ? list[list.length - 1] : undefined;
+};
 
 export function mapProviderError(error: unknown): LLMProviderError {
   if (error instanceof LLMProviderError) return error;
+
+  // The AI SDK retries transient failures and re-throws as `RetryError` with
+  // the underlying errors attached. Classify the last attempt so callers see
+  // the real cause, not an opaque wrapper.
+  if (RetryError.isInstance(error)) {
+    const underlying = pickUnderlying(error);
+    if (underlying !== undefined && underlying !== error) {
+      return mapProviderError(underlying);
+    }
+    return new UpstreamError(error.message, error);
+  }
+
+  if (isAbortLike(error)) {
+    return new TimeoutError(
+      error instanceof Error ? error.message : "request aborted",
+      error,
+    );
+  }
 
   if (APICallError.isInstance(error)) {
     const status = error.statusCode;
@@ -20,7 +78,9 @@ export function mapProviderError(error: unknown): LLMProviderError {
       return new AuthError(error.message, error);
     }
     if (status === 429) {
-      return new QuotaError(error.message, error);
+      return isInsufficientQuota(error)
+        ? new QuotaExhaustedError(error.message, error)
+        : new QuotaError(error.message, error);
     }
     return new UpstreamError(error.message, error);
   }

--- a/apps/api/src/modules/commit-generation/providers/llm-provider.spec.ts
+++ b/apps/api/src/modules/commit-generation/providers/llm-provider.spec.ts
@@ -1,4 +1,4 @@
-import { APICallError } from "ai";
+import { APICallError, RetryError } from "ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -34,6 +34,8 @@ const { AnthropicProvider } = await import("./anthropic.provider.js");
 const {
   AuthError,
   QuotaError,
+  QuotaExhaustedError,
+  TimeoutError,
   UpstreamError,
 } = await import("./llm-provider.errors.js");
 const { LLMProviderFactory } = await import("./llm-provider.factory.js");
@@ -41,12 +43,31 @@ const { OpenAIProvider } = await import("./openai.provider.js");
 
 const buildPrompt = () => ({ system: "sys", user: "usr" });
 
-const apiCallError = (statusCode: number) =>
+const apiCallError = (
+  statusCode: number,
+  options: { data?: unknown; responseBody?: string } = {},
+) =>
   new APICallError({
     message: `status ${statusCode}`,
     url: "https://example.test/v1",
     requestBodyValues: {},
     statusCode,
+    data: options.data,
+    responseBody: options.responseBody,
+  });
+
+const insufficientQuotaError = () =>
+  apiCallError(429, {
+    data: {
+      error: {
+        message: "You exceeded your current quota",
+        type: "insufficient_quota",
+        code: "insufficient_quota",
+      },
+    },
+    responseBody: JSON.stringify({
+      error: { type: "insufficient_quota", code: "insufficient_quota" },
+    }),
   });
 
 const fakeStream = <T>(values: T[]): AsyncIterable<T> => ({
@@ -141,6 +162,68 @@ describe.each([
     it("returns true when the upstream rejects with 429 (rate limited)", async () => {
       generateTextMock.mockRejectedValueOnce(apiCallError(429));
       await expect(create().verify("sk-test")).resolves.toBe(true);
+    });
+
+    it("throws QuotaExhaustedError on 429 insufficient_quota (billing)", async () => {
+      generateTextMock.mockRejectedValueOnce(insufficientQuotaError());
+      await expect(create().verify("sk-test")).rejects.toBeInstanceOf(
+        QuotaExhaustedError,
+      );
+    });
+
+    it("throws QuotaExhaustedError when responseBody (no parsed data) indicates insufficient_quota", async () => {
+      generateTextMock.mockRejectedValueOnce(
+        apiCallError(429, {
+          responseBody: '{"error":{"code":"insufficient_quota"}}',
+        }),
+      );
+      await expect(create().verify("sk-test")).rejects.toBeInstanceOf(
+        QuotaExhaustedError,
+      );
+    });
+
+    it("unwraps a RetryError wrapping a 401 and returns false", async () => {
+      const inner = apiCallError(401);
+      generateTextMock.mockRejectedValueOnce(
+        new RetryError({
+          message: "retries exhausted",
+          reason: "maxRetriesExceeded",
+          errors: [inner],
+        }),
+      );
+      await expect(create().verify("sk-bad")).resolves.toBe(false);
+    });
+
+    it("unwraps a RetryError wrapping 429 insufficient_quota", async () => {
+      const inner = insufficientQuotaError();
+      generateTextMock.mockRejectedValueOnce(
+        new RetryError({
+          message: "retries exhausted",
+          reason: "errorNotRetryable",
+          errors: [inner],
+        }),
+      );
+      await expect(create().verify("sk-test")).rejects.toBeInstanceOf(
+        QuotaExhaustedError,
+      );
+    });
+
+    it("throws TimeoutError when the request is aborted", async () => {
+      const abort = new Error("The operation was aborted");
+      abort.name = "AbortError";
+      generateTextMock.mockRejectedValueOnce(abort);
+      await expect(create().verify("sk-test")).rejects.toBeInstanceOf(
+        TimeoutError,
+      );
+    });
+
+    it("disables SDK retries so the 10s timeout isn't split across attempts", async () => {
+      generateTextMock.mockResolvedValueOnce({ text: "pong" });
+      await create().verify("sk-test");
+      const call = generateTextMock.mock.calls[0]![0] as {
+        maxRetries?: number;
+      };
+      expect(call.maxRetries).toBe(0);
     });
 
     it("throws UpstreamError on a 500", async () => {


### PR DESCRIPTION
## Summary

- Unwrap `RetryError` from `ai` v6 so the underlying provider error drives classification instead of an opaque wrapper.
- Detect OpenAI `insufficient_quota` inside 429 responses and surface it as a distinct `provider_quota_exhausted` 422 (billing exhaustion is permanent — must not be saved like a transient rate-limit).
- Detect `AbortError`/`TimeoutError` → new `TimeoutError` → `provider_timeout` 422 with an actionable message.
- `BaseLLMProvider.verify()` passes `maxRetries: 0` so the 10s timeout covers one round-trip instead of being consumed by SDK-level retries with backoff.
- `classifyGenerationError` learns `LLM_QUOTA_EXHAUSTED` + `LLM_TIMEOUT` for the SSE path.

**Why:** reported in local dev — a valid OpenAI key with no credit hit the verify flow and the dialog showed only "could not verify the API key with the provider". Upstream was actually HTTP 429 `insufficient_quota`, which the SDK retried + wrapped in `RetryError`, hiding the real cause.

## Test plan

- [x] `pnpm --filter @commit-analyzer/api exec vitest run` — 421/421 pass
- [x] `pnpm --filter @commit-analyzer/api typecheck` — clean
- [ ] Manual: add an exhausted OpenAI key in Settings → LLM keys; confirm the dialog shows the billing message inline instead of the generic one.
- [ ] Manual: add a valid funded key; confirm save still works.