### PR TITLE
fix(T-4.7): map anthropic 400 low-credit to quota

### DIFF
--- a/apps/api/src/modules/commit-generation/providers/llm-provider.errors.ts
+++ b/apps/api/src/modules/commit-generation/providers/llm-provider.errors.ts
@@ -14,6 +14,9 @@ export class TimeoutError extends LLMProviderError {}
 export class UpstreamError extends LLMProviderError {}
 
 const INSUFFICIENT_QUOTA_CODE = "insufficient_quota";
+// Anthropic does not use a stable error code for billing exhaustion — it
+// returns invalid_request_error (HTTP 400) with this human-readable message.
+const ANTHROPIC_LOW_CREDIT_MARKER = "credit balance is too low";
 
 // OpenAI returns 429 for both rate-limit and out-of-credit; only the body's
 // `error.code` distinguishes them. Distinguishing matters: rate-limit is
@@ -33,6 +36,35 @@ const isInsufficientQuota = (error: APICallError): boolean => {
   }
   const body = error.responseBody;
   if (typeof body === "string" && body.includes(INSUFFICIENT_QUOTA_CODE)) {
+    return true;
+  }
+  return false;
+};
+
+// Anthropic surfaces billing exhaustion as 400 invalid_request_error with a
+// "credit balance is too low" message, not 429. Detecting it here lets the
+// service raise the same actionable QuotaExhausted path as OpenAI.
+const isAnthropicLowCredit = (error: APICallError): boolean => {
+  const data = (error as { data?: unknown }).data;
+  if (
+    data &&
+    typeof data === "object" &&
+    "error" in data &&
+    data.error &&
+    typeof data.error === "object" &&
+    "message" in data.error &&
+    typeof (data.error as { message?: unknown }).message === "string" &&
+    (data.error as { message: string }).message
+      .toLowerCase()
+      .includes(ANTHROPIC_LOW_CREDIT_MARKER)
+  ) {
+    return true;
+  }
+  const body = error.responseBody;
+  if (
+    typeof body === "string" &&
+    body.toLowerCase().includes(ANTHROPIC_LOW_CREDIT_MARKER)
+  ) {
     return true;
   }
   return false;
@@ -81,6 +113,9 @@ export function mapProviderError(error: unknown): LLMProviderError {
       return isInsufficientQuota(error)
         ? new QuotaExhaustedError(error.message, error)
         : new QuotaError(error.message, error);
+    }
+    if (status === 400 && isAnthropicLowCredit(error)) {
+      return new QuotaExhaustedError(error.message, error);
     }
     return new UpstreamError(error.message, error);
   }

--- a/apps/api/src/modules/commit-generation/providers/llm-provider.spec.ts
+++ b/apps/api/src/modules/commit-generation/providers/llm-provider.spec.ts
@@ -182,6 +182,38 @@ describe.each([
       );
     });
 
+    // Anthropic returns 400 invalid_request_error (not 429) when the account
+    // is out of credit. Without the dedicated branch this would surface as a
+    // generic "could not verify" upstream error.
+    it("throws QuotaExhaustedError on Anthropic-style 400 'credit balance is too low'", async () => {
+      generateTextMock.mockRejectedValueOnce(
+        apiCallError(400, {
+          data: {
+            error: {
+              type: "invalid_request_error",
+              message:
+                "Your credit balance is too low to access the Anthropic API.",
+            },
+          },
+        }),
+      );
+      await expect(create().verify("sk-test")).rejects.toBeInstanceOf(
+        QuotaExhaustedError,
+      );
+    });
+
+    it("throws QuotaExhaustedError when only responseBody carries the Anthropic low-credit message", async () => {
+      generateTextMock.mockRejectedValueOnce(
+        apiCallError(400, {
+          responseBody:
+            '{"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API."}}',
+        }),
+      );
+      await expect(create().verify("sk-test")).rejects.toBeInstanceOf(
+        QuotaExhaustedError,
+      );
+    });
+
     it("unwraps a RetryError wrapping a 401 and returns false", async () => {
       const inner = apiCallError(401);
       generateTextMock.mockRejectedValueOnce(


### PR DESCRIPTION
## Summary
- Anthropic returns HTTP 400 `invalid_request_error` with "credit balance is too low" for billing exhaustion (OpenAI uses 429 + `insufficient_quota`). The mapper only handled the OpenAI shape, so valid Anthropic keys with no credit failed verification with a generic "could not verify the API key with the provider" instead of the actionable quota message.
- Added `isAnthropicLowCredit` detector (parsed `data.error.message` + raw `responseBody`); routed status 400 matches to `QuotaExhaustedError` so the service raises `LlmProviderQuotaExhaustedException` (422 `provider_quota_exhausted`).
- Covered both providers with two new spec cases (parsed-data path and responseBody-only path).

## Test plan
- [x] `pnpm --filter @commit-analyzer/api exec vitest run src/modules/commit-generation/providers/llm-provider.spec.ts` (41 passed)
- [ ] Manual: add an out-of-credit Anthropic key in Settings → expect "add billing credit" message, not generic verify failure