### PR TITLE
feat(T-4.8): web generate page + sse stream

### DIFF
--- a/apps/web/messages/en/generate.json
+++ b/apps/web/messages/en/generate.json
@@ -1,0 +1,65 @@
+{
+  "title": "Generate commit message",
+  "subtitle": "Paste a diff, pick a provider, and stream commit-message suggestions. Attach a policy to get instant compliance feedback.",
+  "generate": "Generate",
+  "generating": "Generating…",
+  "cancel": "Cancel",
+  "cancelled": "Generation cancelled.",
+  "error": {
+    "title": "Generation failed"
+  },
+  "diff": {
+    "label": "Diff",
+    "placeholder": "Paste or drop a unified diff here (output of `git diff`, a `.patch`, or a `.diff` file).",
+    "hint": "Tip: drop a .patch file anywhere in the box, or paste directly.",
+    "fromFile": "Loaded from {name}",
+    "chars": "{count, plural, =0 {0 characters} one {# character} other {# characters}}",
+    "paste": "Paste",
+    "tooLarge": "Diff exceeds 1 MB. Trim it before generating.",
+    "pasteSuccess": "Diff pasted.",
+    "pasteEmpty": "Clipboard is empty.",
+    "pasteError": "Could not read clipboard.",
+    "uploadFile": "Upload .patch",
+    "fileTooLarge": "File is too large (max 1 MB)."
+  },
+  "provider": {
+    "providerLabel": "Provider",
+    "providerPlaceholder": "Select a provider",
+    "modelLabel": "Model",
+    "modelPlaceholder": "Select a model",
+    "noKeysTitle": "No LLM keys configured",
+    "noKeysDescription": "Add an OpenAI or Anthropic API key in settings to enable generation.",
+    "addKeysCta": "Manage LLM keys"
+  },
+  "policy": {
+    "repoLabel": "Repository (optional)",
+    "repoPlaceholder": "Select a repository",
+    "noRepo": "No repository",
+    "policyLabel": "Policy (optional)",
+    "policyPlaceholder": "Select a policy",
+    "policyDisabled": "Select a repository first",
+    "noPolicy": "No policy",
+    "loading": "Loading policies…"
+  },
+  "card": {
+    "compliant": "Compliant",
+    "nonCompliant": "Non-compliant",
+    "copy": "Copy",
+    "copied": "Copied",
+    "copyError": "Copy failed"
+  },
+  "rules": {
+    "allowedTypes": "Type",
+    "allowedScopes": "Scope",
+    "maxSubjectLength": "Subject length",
+    "bodyRequired": "Body",
+    "footerRequired": "Footer",
+    "format": "Format"
+  },
+  "list": {
+    "streamingEmpty": "Waiting for first suggestion…",
+    "streamingMore": "Streaming more…",
+    "idleTitle": "Suggestions will appear here",
+    "idleHint": "Submit a diff to start streaming commit-message suggestions."
+  }
+}

--- a/apps/web/messages/uk/generate.json
+++ b/apps/web/messages/uk/generate.json
@@ -1,0 +1,65 @@
+{
+  "title": "Генерація повідомлення коміту",
+  "subtitle": "Вставте diff, оберіть провайдера та стрімте варіанти повідомлень. Підключіть політику, щоб отримати миттєву перевірку.",
+  "generate": "Згенерувати",
+  "generating": "Генерація…",
+  "cancel": "Скасувати",
+  "cancelled": "Генерацію скасовано.",
+  "error": {
+    "title": "Не вдалося згенерувати"
+  },
+  "diff": {
+    "label": "Diff",
+    "placeholder": "Вставте або перетягніть сюди уніфікований diff (вивід `git diff`, файл `.patch` або `.diff`).",
+    "hint": "Порада: перетягніть .patch файл у поле або просто вставте текст.",
+    "fromFile": "Завантажено з {name}",
+    "chars": "{count, plural, =0 {0 символів} one {# символ} few {# символи} many {# символів} other {# символів}}",
+    "paste": "Вставити",
+    "tooLarge": "Diff перевищує 1 МБ. Скоротіть його перед генерацією.",
+    "pasteSuccess": "Diff вставлено.",
+    "pasteEmpty": "Буфер обміну порожній.",
+    "pasteError": "Не вдалося прочитати буфер обміну.",
+    "uploadFile": "Завантажити .patch",
+    "fileTooLarge": "Файл завеликий (макс. 1 МБ)."
+  },
+  "provider": {
+    "providerLabel": "Провайдер",
+    "providerPlaceholder": "Оберіть провайдера",
+    "modelLabel": "Модель",
+    "modelPlaceholder": "Оберіть модель",
+    "noKeysTitle": "Немає налаштованих ключів LLM",
+    "noKeysDescription": "Додайте ключ OpenAI або Anthropic у налаштуваннях, щоб увімкнути генерацію.",
+    "addKeysCta": "Керування ключами LLM"
+  },
+  "policy": {
+    "repoLabel": "Репозиторій (необовʼязково)",
+    "repoPlaceholder": "Оберіть репозиторій",
+    "noRepo": "Без репозиторію",
+    "policyLabel": "Політика (необовʼязково)",
+    "policyPlaceholder": "Оберіть політику",
+    "policyDisabled": "Спочатку оберіть репозиторій",
+    "noPolicy": "Без політики",
+    "loading": "Завантаження політик…"
+  },
+  "card": {
+    "compliant": "Відповідає",
+    "nonCompliant": "Не відповідає",
+    "copy": "Копіювати",
+    "copied": "Скопійовано",
+    "copyError": "Не вдалося скопіювати"
+  },
+  "rules": {
+    "allowedTypes": "Тип",
+    "allowedScopes": "Область",
+    "maxSubjectLength": "Довжина заголовка",
+    "bodyRequired": "Тіло",
+    "footerRequired": "Футер",
+    "format": "Формат"
+  },
+  "list": {
+    "streamingEmpty": "Очікування першої пропозиції…",
+    "streamingMore": "Надходять нові пропозиції…",
+    "idleTitle": "Пропозиції зʼявляться тут",
+    "idleHint": "Надішліть diff, щоб почати стрімити варіанти повідомлень."
+  }
+}

--- a/apps/web/src/app/[locale]/(dashboard)/generate/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/generate/page.tsx
@@ -1,9 +1,9 @@
-import { Sparkles } from "lucide-react";
 import type { Metadata } from "next";
 import { type Locale } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
-import { ComingSoonCard } from "@/components/layout/coming-soon-card";
+import { GenerateView } from "@/features/generation/components/generate-view";
+import { getGeneratePageData } from "@/features/generation/server";
 
 export async function generateMetadata({
   params,
@@ -11,10 +11,7 @@ export async function generateMetadata({
   params: Promise<{ locale: Locale }>;
 }): Promise<Metadata> {
   const { locale } = await params;
-  const t = await getTranslations({
-    locale,
-    namespace: "placeholders.generate",
-  });
+  const t = await getTranslations({ locale, namespace: "generate" });
   return { title: t("title") };
 }
 
@@ -25,14 +22,8 @@ export default async function GeneratePage({
 }) {
   const { locale } = await params;
   setRequestLocale(locale);
-  const t = await getTranslations("placeholders");
 
-  return (
-    <ComingSoonCard
-      icon={<Sparkles className="h-5 w-5" />}
-      title={t("generate.title")}
-      description={t("generate.description")}
-      badge={t("comingInPhase", { phase: 2 })}
-    />
-  );
+  const data = await getGeneratePageData();
+
+  return <GenerateView {...data} />;
 }

--- a/apps/web/src/app/api/generate-proxy/route.ts
+++ b/apps/web/src/app/api/generate-proxy/route.ts
@@ -8,7 +8,7 @@ const FORWARD_PATH = "/v1/generate";
 const { API_URL, WEB_ORIGIN } = loadServerEnv();
 const FORWARD_URL = `${API_URL.replace(/\/$/u, "")}${FORWARD_PATH}`;
 
-export const POST = async (req: NextRequest): Promise<NextResponse> => {
+export const POST = async (req: NextRequest): Promise<Response> => {
   if (req.headers.get("origin") !== WEB_ORIGIN) {
     return NextResponse.json({ error: "forbidden_origin" }, { status: 403 });
   }
@@ -21,19 +21,60 @@ export const POST = async (req: NextRequest): Promise<NextResponse> => {
   if (auth) forwardHeaders.set("authorization", auth);
   const cookie = req.headers.get("cookie");
   if (cookie) forwardHeaders.set("cookie", cookie);
+  // Upstream only serves SSE on this route; force the accept header so a
+  // misconfigured client does not negotiate something else.
+  forwardHeaders.set("accept", "text/event-stream");
 
-  const upstream = await fetch(FORWARD_URL, {
-    method: "POST",
-    headers: forwardHeaders,
-    body,
-  });
+  let upstream: Response;
+  try {
+    upstream = await fetch(FORWARD_URL, {
+      method: "POST",
+      headers: forwardHeaders,
+      body,
+      // Abort the upstream fetch when the client disconnects so the SSE
+      // session terminates promptly (cancel button, tab close).
+      signal: req.signal,
+    });
+  } catch (err) {
+    if (req.signal.aborted) {
+      return new Response(null, { status: 499 });
+    }
+    return NextResponse.json(
+      {
+        error: {
+          code: "UPSTREAM_UNREACHABLE",
+          message: err instanceof Error ? err.message : "upstream fetch failed",
+        },
+      },
+      { status: 502 },
+    );
+  }
 
-  const responseBody = await upstream.text();
-  return new NextResponse(responseBody, {
-    status: upstream.status,
+  // Error envelopes come back as buffered JSON; pass them through untouched.
+  if (upstream.status !== 200 || !upstream.body) {
+    const text = await upstream.text();
+    return new Response(text, {
+      status: upstream.status,
+      headers: {
+        "content-type":
+          upstream.headers.get("content-type") ?? "application/json",
+      },
+    });
+  }
+
+  // Stream the SSE body straight through. Buffering here would defeat the
+  // < 2 s TTFT acceptance criterion. `X-Accel-Buffering: no` keeps upstream
+  // proxies from coalescing chunks; `no-cache, no-transform` keeps browsers
+  // and edge caches from holding frames.
+  return new Response(upstream.body, {
+    status: 200,
     headers: {
       "content-type":
-        upstream.headers.get("content-type") ?? "application/json",
+        upstream.headers.get("content-type") ??
+        "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache, no-transform",
+      "x-accel-buffering": "no",
+      connection: "keep-alive",
     },
   });
 };

--- a/apps/web/src/features/generation/components/diff-input.tsx
+++ b/apps/web/src/features/generation/components/diff-input.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { ClipboardPaste, FileCode2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback, useId, useRef, useState, type DragEvent } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  value: string;
+  onChange: (next: string) => void;
+  disabled?: boolean;
+};
+
+const MAX_BYTES = 1_000_000;
+
+export const DiffInput = ({ value, onChange, disabled }: Props) => {
+  const t = useTranslations("generate.diff");
+  const textareaId = useId();
+  const [dragOver, setDragOver] = useState(false);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handlePaste = useCallback(async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (!text) {
+        toast.error(t("pasteEmpty"));
+        return;
+      }
+      onChange(text);
+      setFileName(null);
+      toast.success(t("pasteSuccess"));
+    } catch {
+      toast.error(t("pasteError"));
+    }
+  }, [onChange, t]);
+
+  const readFile = useCallback(
+    async (file: File) => {
+      if (file.size > MAX_BYTES) {
+        toast.error(t("fileTooLarge"));
+        return;
+      }
+      const text = await file.text();
+      onChange(text);
+      setFileName(file.name);
+    },
+    [onChange, t],
+  );
+
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setDragOver(false);
+      const file = event.dataTransfer.files[0];
+      if (!file) return;
+      void readFile(file);
+    },
+    [readFile],
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <label htmlFor={textareaId} className="text-sm font-medium">
+          {t("label")}
+        </label>
+        <div className="flex items-center gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".patch,.diff,text/plain"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) void readFile(file);
+              e.target.value = "";
+            }}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={disabled}
+            className="cursor-pointer"
+          >
+            <FileCode2 aria-hidden="true" />
+            <span className="hidden sm:inline">{t("uploadFile")}</span>
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void handlePaste()}
+            disabled={disabled}
+            className="cursor-pointer"
+          >
+            <ClipboardPaste aria-hidden="true" />
+            <span className="hidden sm:inline">{t("paste")}</span>
+          </Button>
+        </div>
+      </div>
+      <div
+        onDragOver={(e) => {
+          e.preventDefault();
+          if (!disabled) setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={handleDrop}
+        className={cn(
+          "rounded-lg border bg-card transition-colors",
+          dragOver && "border-primary ring-2 ring-primary/30",
+        )}
+      >
+        <textarea
+          id={textareaId}
+          value={value}
+          onChange={(e) => {
+            onChange(e.target.value);
+            setFileName(null);
+          }}
+          disabled={disabled}
+          spellCheck={false}
+          placeholder={t("placeholder")}
+          className={cn(
+            "block min-h-[220px] w-full resize-y rounded-lg bg-transparent px-3 py-2 font-mono text-xs leading-relaxed text-foreground",
+            "placeholder:text-muted-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "disabled:cursor-not-allowed disabled:opacity-60",
+          )}
+        />
+      </div>
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>{fileName ? t("fromFile", { name: fileName }) : t("hint")}</span>
+        <span>{t("chars", { count: value.length })}</span>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/features/generation/components/generate-view.tsx
+++ b/apps/web/src/features/generation/components/generate-view.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import type { LlmProviderName } from "@commit-analyzer/contracts";
+import { Loader2, Sparkles, Square } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+import { MODELS_BY_PROVIDER } from "../constants";
+import { useGenerateStream } from "../hooks";
+import type { GeneratePageData } from "../types";
+
+import { DiffInput } from "./diff-input";
+import { PolicyPicker } from "./policy-picker";
+import { ProviderSelector } from "./provider-selector";
+import { SuggestionList } from "./suggestion-list";
+
+const MAX_DIFF_BYTES = 1_000_000;
+
+const pickInitialProvider = (
+  keys: GeneratePageData["configuredKeys"],
+): LlmProviderName | null => {
+  const usable = keys.filter((k) => k.status !== "invalid");
+  const verified = usable.find((k) => k.status === "ok");
+  return (verified ?? usable[0])?.provider ?? null;
+};
+
+export const GenerateView = ({
+  configuredKeys,
+  repos,
+}: GeneratePageData) => {
+  const t = useTranslations("generate");
+
+  const [diff, setDiff] = useState("");
+  const [provider, setProvider] = useState<LlmProviderName | null>(() =>
+    pickInitialProvider(configuredKeys),
+  );
+  const [model, setModel] = useState<string | null>(() => {
+    const initial = pickInitialProvider(configuredKeys);
+    return initial ? (MODELS_BY_PROVIDER[initial][0] ?? null) : null;
+  });
+  const [repoId, setRepoId] = useState<string | null>(null);
+  const [policyId, setPolicyId] = useState<string | null>(null);
+
+  const { state, start, cancel } = useGenerateStream();
+  const streaming = state.status === "streaming";
+
+  // Reset the model whenever the provider changes so we never send a model
+  // string that the newly-selected provider does not recognise.
+  const handleProviderChange = useCallback((next: LlmProviderName) => {
+    setProvider(next);
+    setModel(MODELS_BY_PROVIDER[next][0] ?? null);
+  }, []);
+
+  const diffBytes = new TextEncoder().encode(diff).length;
+  const diffTooLarge = diffBytes > MAX_DIFF_BYTES;
+
+  const canSubmit =
+    !streaming &&
+    diff.trim().length > 0 &&
+    !diffTooLarge &&
+    provider !== null &&
+    model !== null;
+
+  const handleSubmit = useCallback(() => {
+    if (!provider || !model) return;
+    void start({
+      diff,
+      provider,
+      model,
+      ...(repoId ? { repositoryId: repoId } : {}),
+      ...(policyId ? { policyId } : {}),
+    });
+  }, [diff, provider, model, repoId, policyId, start]);
+
+  return (
+    <section className="flex flex-col gap-6">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold tracking-tight">{t("title")}</h1>
+        <p className="text-sm text-muted-foreground">{t("subtitle")}</p>
+      </header>
+
+      <div className="flex flex-col gap-4 rounded-xl border bg-card p-4 sm:p-6">
+        <DiffInput value={diff} onChange={setDiff} disabled={streaming} />
+        <ProviderSelector
+          configuredKeys={configuredKeys}
+          provider={provider}
+          model={model}
+          onProviderChange={handleProviderChange}
+          onModelChange={setModel}
+          disabled={streaming}
+        />
+        <PolicyPicker
+          repos={repos}
+          repoId={repoId}
+          policyId={policyId}
+          onRepoChange={(next) => {
+            setRepoId(next);
+            setPolicyId(null);
+          }}
+          onPolicyChange={setPolicyId}
+          disabled={streaming}
+        />
+
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {diffTooLarge ? (
+            <p className="mr-auto text-xs text-destructive">
+              {t("diff.tooLarge")}
+            </p>
+          ) : null}
+          {streaming ? (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={cancel}
+              className="cursor-pointer"
+            >
+              <Square aria-hidden="true" />
+              {t("cancel")}
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="cursor-pointer"
+          >
+            {streaming ? (
+              <Loader2 className="animate-spin" aria-hidden="true" />
+            ) : (
+              <Sparkles aria-hidden="true" />
+            )}
+            {streaming ? t("generating") : t("generate")}
+          </Button>
+        </div>
+
+        {state.status === "error" && state.error ? (
+          <div
+            role="alert"
+            className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm"
+          >
+            <p className="font-medium text-destructive">
+              {t("error.title")}
+            </p>
+            <p className="mt-1 text-destructive/80">
+              <span className="font-mono text-xs">{state.error.code}</span>
+              {" — "}
+              {state.error.message}
+            </p>
+          </div>
+        ) : null}
+
+        {state.status === "cancelled" ? (
+          <div className="rounded-lg border bg-muted/40 p-3 text-sm text-muted-foreground">
+            {t("cancelled")}
+          </div>
+        ) : null}
+      </div>
+
+      <SuggestionList
+        suggestions={state.suggestions}
+        streaming={streaming}
+        empty={state.status === "idle"}
+      />
+    </section>
+  );
+};

--- a/apps/web/src/features/generation/components/policy-picker.tsx
+++ b/apps/web/src/features/generation/components/policy-picker.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import type { ConnectedRepo } from "@commit-analyzer/contracts";
+import { Loader2, ShieldCheck } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useId } from "react";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import { usePoliciesForRepoQuery } from "../hooks";
+
+const NONE_VALUE = "__none__";
+
+type Props = {
+  repos: ConnectedRepo[];
+  repoId: string | null;
+  policyId: string | null;
+  onRepoChange: (next: string | null) => void;
+  onPolicyChange: (next: string | null) => void;
+  disabled?: boolean;
+};
+
+export const PolicyPicker = ({
+  repos,
+  repoId,
+  policyId,
+  onRepoChange,
+  onPolicyChange,
+  disabled,
+}: Props) => {
+  const t = useTranslations("generate.policy");
+  const repoFieldId = useId();
+  const policyFieldId = useId();
+
+  const policiesQuery = usePoliciesForRepoQuery(repoId);
+  const policies =
+    policiesQuery.data?.status === 200 ? policiesQuery.data.body.items : [];
+
+  // Clear stale policy selection when the repo changes or the fetched list no
+  // longer includes the previously selected policy.
+  useEffect(() => {
+    if (!policyId) return;
+    if (!repoId) {
+      onPolicyChange(null);
+      return;
+    }
+    if (!policiesQuery.isSuccess) return;
+    const stillPresent = policies.some((p) => p.id === policyId);
+    if (!stillPresent) onPolicyChange(null);
+  }, [policyId, repoId, policiesQuery.isSuccess, policies, onPolicyChange]);
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <div className="flex flex-col gap-2">
+        <label htmlFor={repoFieldId} className="text-sm font-medium">
+          {t("repoLabel")}
+        </label>
+        <Select
+          value={repoId ?? NONE_VALUE}
+          onValueChange={(v) => onRepoChange(v === NONE_VALUE ? null : v)}
+          disabled={disabled || repos.length === 0}
+        >
+          <SelectTrigger id={repoFieldId} className="cursor-pointer">
+            <SelectValue placeholder={t("repoPlaceholder")} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={NONE_VALUE} className="cursor-pointer">
+              {t("noRepo")}
+            </SelectItem>
+            {repos.map((r) => (
+              <SelectItem key={r.id} value={r.id} className="cursor-pointer">
+                <span className="truncate">{r.fullName}</span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor={policyFieldId} className="text-sm font-medium">
+          {t("policyLabel")}
+        </label>
+        <Select
+          value={policyId ?? NONE_VALUE}
+          onValueChange={(v) => onPolicyChange(v === NONE_VALUE ? null : v)}
+          disabled={disabled || !repoId}
+        >
+          <SelectTrigger id={policyFieldId} className="cursor-pointer">
+            <SelectValue
+              placeholder={
+                repoId ? t("policyPlaceholder") : t("policyDisabled")
+              }
+            />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={NONE_VALUE} className="cursor-pointer">
+              {t("noPolicy")}
+            </SelectItem>
+            {policies.map((p) => (
+              <SelectItem key={p.id} value={p.id} className="cursor-pointer">
+                <span className="flex items-center gap-2">
+                  {p.isActive ? (
+                    <ShieldCheck
+                      className="h-3.5 w-3.5 text-primary"
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                  <span className="truncate">{p.name}</span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {policiesQuery.isFetching && repoId ? (
+          <p className="flex items-center gap-1 text-xs text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+            {t("loading")}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/features/generation/components/provider-selector.tsx
+++ b/apps/web/src/features/generation/components/provider-selector.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import type { LlmApiKey, LlmProviderName } from "@commit-analyzer/contracts";
+import { AlertCircle, KeyRound } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useId } from "react";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Link } from "@/i18n/navigation";
+
+import { MODELS_BY_PROVIDER } from "../constants";
+
+type Props = {
+  configuredKeys: LlmApiKey[];
+  provider: LlmProviderName | null;
+  model: string | null;
+  onProviderChange: (next: LlmProviderName) => void;
+  onModelChange: (next: string) => void;
+  disabled?: boolean;
+};
+
+export const ProviderSelector = ({
+  configuredKeys,
+  provider,
+  model,
+  onProviderChange,
+  onModelChange,
+  disabled,
+}: Props) => {
+  const t = useTranslations("generate.provider");
+  const tProviders = useTranslations("llmKeys.providers");
+  const providerId = useId();
+  const modelId = useId();
+
+  // Keys with status "invalid" would 412 at stream start; hide them so the
+  // user isn't offered a broken option. "unknown" keys (never successfully
+  // verified) stay available — they may still work at generate time.
+  const usableKeys = configuredKeys.filter((k) => k.status !== "invalid");
+
+  if (usableKeys.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed p-4 text-sm">
+        <div className="flex items-start gap-3">
+          <AlertCircle
+            className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <div className="flex flex-col gap-2">
+            <p className="font-medium">{t("noKeysTitle")}</p>
+            <p className="text-muted-foreground">{t("noKeysDescription")}</p>
+            <Link
+              href="/settings/llm-keys"
+              className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+            >
+              <KeyRound className="h-4 w-4" aria-hidden="true" />
+              {t("addKeysCta")}
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const availableModels = provider ? MODELS_BY_PROVIDER[provider] : [];
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <div className="flex flex-col gap-2">
+        <label htmlFor={providerId} className="text-sm font-medium">
+          {t("providerLabel")}
+        </label>
+        <Select
+          value={provider ?? undefined}
+          onValueChange={(v) => onProviderChange(v as LlmProviderName)}
+          disabled={disabled}
+        >
+          <SelectTrigger id={providerId} className="cursor-pointer">
+            <SelectValue placeholder={t("providerPlaceholder")} />
+          </SelectTrigger>
+          <SelectContent>
+            {usableKeys.map((key) => (
+              <SelectItem
+                key={key.provider}
+                value={key.provider}
+                className="cursor-pointer"
+              >
+                {tProviders(key.provider)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor={modelId} className="text-sm font-medium">
+          {t("modelLabel")}
+        </label>
+        <Select
+          value={model ?? undefined}
+          onValueChange={onModelChange}
+          disabled={disabled || !provider}
+        >
+          <SelectTrigger id={modelId} className="cursor-pointer">
+            <SelectValue placeholder={t("modelPlaceholder")} />
+          </SelectTrigger>
+          <SelectContent>
+            {availableModels.map((m) => (
+              <SelectItem key={m} value={m} className="cursor-pointer">
+                <span className="font-mono text-xs">{m}</span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/features/generation/components/suggestion-card.tsx
+++ b/apps/web/src/features/generation/components/suggestion-card.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import type { SuggestionFrame } from "@commit-analyzer/contracts";
+import { Check, Copy, ShieldAlert, ShieldCheck } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+import { formatAsCommitMessage } from "../format";
+
+type Props = {
+  suggestion: SuggestionFrame;
+};
+
+const COPY_FEEDBACK_MS = 1500;
+
+export const SuggestionCard = ({ suggestion }: Props) => {
+  const t = useTranslations("generate.card");
+  const tRules = useTranslations("generate.rules");
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    const text = formatAsCommitMessage(suggestion);
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      toast.success(t("copied"));
+      window.setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+    } catch {
+      toast.error(t("copyError"));
+    }
+  }, [suggestion, t]);
+
+  const headerLine = `${suggestion.type}${
+    suggestion.scope ? `(${suggestion.scope})` : ""
+  }: ${suggestion.subject}`;
+
+  return (
+    <article className="flex flex-col gap-3 rounded-xl border bg-card p-4">
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          {suggestion.compliant ? (
+            <Badge variant="success" className="gap-1">
+              <ShieldCheck className="h-3 w-3" aria-hidden="true" />
+              {t("compliant")}
+            </Badge>
+          ) : (
+            <Badge variant="destructive" className="gap-1">
+              <ShieldAlert className="h-3 w-3" aria-hidden="true" />
+              {t("nonCompliant")}
+            </Badge>
+          )}
+          {suggestion.validation?.results.map((r, i) => (
+            <Badge
+              key={`${r.ruleType}-${i}`}
+              variant={r.passed ? "secondary" : "destructive"}
+              className="gap-1"
+              title={r.message}
+            >
+              {r.passed ? (
+                <Check className="h-3 w-3" aria-hidden="true" />
+              ) : (
+                <ShieldAlert className="h-3 w-3" aria-hidden="true" />
+              )}
+              {tRules(r.ruleType)}
+            </Badge>
+          ))}
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => void handleCopy()}
+          className="cursor-pointer shrink-0"
+          aria-label={t("copy")}
+        >
+          {copied ? (
+            <Check aria-hidden="true" />
+          ) : (
+            <Copy aria-hidden="true" />
+          )}
+          <span className="hidden sm:inline">
+            {copied ? t("copied") : t("copy")}
+          </span>
+        </Button>
+      </header>
+      <pre className="whitespace-pre-wrap break-words rounded-lg bg-muted/50 p-3 font-mono text-xs leading-relaxed">
+        {headerLine}
+        {suggestion.body ? `\n\n${suggestion.body}` : ""}
+        {suggestion.footer ? `\n\n${suggestion.footer}` : ""}
+      </pre>
+      {suggestion.validation &&
+        suggestion.validation.results.some(
+          (r) => !r.passed && r.message,
+        ) ? (
+        <ul className="flex flex-col gap-1 text-xs text-destructive">
+          {suggestion.validation.results
+            .filter((r) => !r.passed && r.message)
+            .map((r, i) => (
+              <li key={`msg-${r.ruleType}-${i}`}>
+                <span className="font-medium">{tRules(r.ruleType)}:</span>{" "}
+                {r.message}
+              </li>
+            ))}
+        </ul>
+      ) : null}
+    </article>
+  );
+};

--- a/apps/web/src/features/generation/components/suggestion-list.tsx
+++ b/apps/web/src/features/generation/components/suggestion-list.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { SuggestionFrame } from "@commit-analyzer/contracts";
+import { Loader2, Sparkles } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { SuggestionCard } from "./suggestion-card";
+
+type Props = {
+  suggestions: SuggestionFrame[];
+  streaming: boolean;
+  empty: boolean;
+};
+
+export const SuggestionList = ({ suggestions, streaming, empty }: Props) => {
+  const t = useTranslations("generate.list");
+
+  if (suggestions.length === 0) {
+    if (streaming) {
+      return (
+        <div
+          className="flex items-center gap-2 rounded-lg border border-dashed p-6 text-sm text-muted-foreground"
+          aria-live="polite"
+        >
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          {t("streamingEmpty")}
+        </div>
+      );
+    }
+    if (empty) {
+      return (
+        <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed p-8 text-center">
+          <Sparkles
+            className="h-5 w-5 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <p className="text-sm font-medium">{t("idleTitle")}</p>
+          <p className="text-xs text-muted-foreground">{t("idleHint")}</p>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  const sorted = [...suggestions].sort((a, b) => a.index - b.index);
+
+  return (
+    <div
+      className="flex flex-col gap-3"
+      aria-live="polite"
+      aria-busy={streaming}
+    >
+      {sorted.map((s) => (
+        <SuggestionCard key={s.index} suggestion={s} />
+      ))}
+      {streaming ? (
+        <div className="flex items-center gap-2 rounded-lg border border-dashed p-3 text-xs text-muted-foreground">
+          <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+          {t("streamingMore")}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/web/src/features/generation/constants.ts
+++ b/apps/web/src/features/generation/constants.ts
@@ -1,0 +1,13 @@
+import type { LlmProviderName } from "@commit-analyzer/contracts";
+
+// Curated shortlist surfaced in the provider/model dropdown. The first entry
+// for each provider is the default; anything the provider itself accepts can
+// still be sent — the API forwards the `model` string as-is.
+export const MODELS_BY_PROVIDER: Record<LlmProviderName, string[]> = {
+  openai: ["gpt-4o-mini", "gpt-4o", "gpt-4.1-mini"],
+  anthropic: [
+    "claude-haiku-4-5",
+    "claude-sonnet-4-5",
+    "claude-3-5-haiku-latest",
+  ],
+};

--- a/apps/web/src/features/generation/format.ts
+++ b/apps/web/src/features/generation/format.ts
@@ -1,0 +1,13 @@
+import type { SuggestionFrame } from "@commit-analyzer/contracts";
+
+// Mirrors api/src/.../suggestion-formatter.ts. Kept client-side so the copy
+// button doesn't need a round trip and can stay responsive even after the
+// stream is done.
+export const formatAsCommitMessage = (s: SuggestionFrame): string => {
+  const scope = s.scope ? `(${s.scope})` : "";
+  const header = `${s.type}${scope}: ${s.subject}`;
+  const parts = [header];
+  if (s.body) parts.push("", s.body);
+  if (s.footer) parts.push("", s.footer);
+  return parts.join("\n");
+};

--- a/apps/web/src/features/generation/hooks.ts
+++ b/apps/web/src/features/generation/hooks.ts
@@ -1,0 +1,259 @@
+"use client";
+
+import {
+  doneFrameSchema,
+  errorFrameSchema,
+  suggestionFrameSchema,
+} from "@commit-analyzer/contracts";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+
+import { resolveBrowserToken, tsr } from "@/lib/api/tsr";
+
+import { generationQueryKeys } from "./queries";
+import type { GenerateInput, StreamState } from "./types";
+
+const GENERATE_PROXY_URL = "/api/generate-proxy";
+
+const INITIAL: StreamState = {
+  status: "idle",
+  suggestions: [],
+  error: null,
+  done: null,
+};
+
+export const usePoliciesForRepoQuery = (repoId: string | null) =>
+  tsr.policies.list.useQuery({
+    queryKey: [...generationQueryKeys.policies(repoId ?? "none")],
+    // The query never fires when `repoId` is null (see `enabled`), so the
+    // placeholder path param is dead weight but keeps the types happy.
+    queryData: { params: { repoId: repoId ?? "__disabled__" } },
+    enabled: Boolean(repoId),
+    staleTime: 30_000,
+    retry: 0,
+  });
+
+type Frame = { event: string; data: string };
+
+// Minimal SSE frame parser. Splits the rolling buffer on `\n\n` which
+// terminates a frame per the SSE spec, ignores `: ping` heartbeat comments,
+// and collects `event:` / `data:` field lines. The API emits single-line
+// `data:` payloads, so we don't concatenate multi-line data here.
+function extractFrames(buffer: string): { frames: Frame[]; rest: string } {
+  const frames: Frame[] = [];
+  let rest = buffer;
+  let idx = rest.indexOf("\n\n");
+  while (idx !== -1) {
+    const block = rest.slice(0, idx);
+    rest = rest.slice(idx + 2);
+    let event = "message";
+    const dataLines: string[] = [];
+    for (const line of block.split("\n")) {
+      if (line.startsWith(":")) continue; // heartbeat / comment
+      if (line.startsWith("event:")) event = line.slice(6).trim();
+      else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
+    }
+    if (dataLines.length > 0) frames.push({ event, data: dataLines.join("\n") });
+    idx = rest.indexOf("\n\n");
+  }
+  return { frames, rest };
+}
+
+export const useGenerateStream = () => {
+  const [state, setState] = useState<StreamState>(INITIAL);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Abort any in-flight stream when the owning component unmounts so the
+  // upstream provider call terminates promptly on navigation instead of
+  // running until completion in the background.
+  useEffect(
+    () => () => {
+      abortRef.current?.abort();
+      abortRef.current = null;
+    },
+    [],
+  );
+
+  const start = useCallback(async (input: GenerateInput) => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setState({
+      status: "streaming",
+      suggestions: [],
+      error: null,
+      done: null,
+    });
+
+    const token = await resolveBrowserToken();
+
+    let res: Response;
+    try {
+      res = await window.fetch(GENERATE_PROXY_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "text/event-stream",
+          ...(token ? { authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify(input),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      if (controller.signal.aborted) {
+        setState((s) => ({ ...s, status: "cancelled" }));
+        return;
+      }
+      setState((s) => ({
+        ...s,
+        status: "error",
+        error: {
+          code: "NETWORK",
+          message: err instanceof Error ? err.message : "network error",
+        },
+      }));
+      return;
+    }
+
+    if (!res.ok || !res.body) {
+      const text = await res.text().catch(() => "");
+      const envelope = parseErrorEnvelope(text);
+      setState((s) => ({
+        ...s,
+        status: "error",
+        error: {
+          code: envelope.code ?? `HTTP_${res.status}`,
+          message: envelope.message ?? res.statusText ?? "request failed",
+        },
+      }));
+      return;
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder("utf-8");
+    let buffer = "";
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const { frames, rest } = extractFrames(buffer);
+        buffer = rest;
+        for (const frame of frames) {
+          applyFrame(frame, setState);
+        }
+      }
+    } catch (err) {
+      if (controller.signal.aborted) {
+        setState((s) => ({ ...s, status: "cancelled" }));
+        return;
+      }
+      setState((s) => ({
+        ...s,
+        status: "error",
+        error: {
+          code: "STREAM",
+          message: err instanceof Error ? err.message : "stream error",
+        },
+      }));
+      return;
+    } finally {
+      if (abortRef.current === controller) abortRef.current = null;
+    }
+
+    setState((s) => (s.status === "streaming" ? { ...s, status: "done" } : s));
+  }, []);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
+  return { state, start, cancel };
+};
+
+function applyFrame(
+  frame: Frame,
+  setState: Dispatch<SetStateAction<StreamState>>,
+) {
+  const parsed = safeJson(frame.data);
+  if (!parsed) return;
+
+  if (frame.event === "suggestion") {
+    const result = suggestionFrameSchema.safeParse(parsed);
+    if (!result.success) return;
+    const suggestion = result.data;
+    setState((s) => ({
+      ...s,
+      suggestions: mergeSuggestion(s.suggestions, suggestion),
+    }));
+    return;
+  }
+  if (frame.event === "done") {
+    const result = doneFrameSchema.safeParse(parsed);
+    if (!result.success) return;
+    setState((s) => ({
+      ...s,
+      status: s.status === "streaming" ? "done" : s.status,
+      done: result.data,
+    }));
+    return;
+  }
+  if (frame.event === "error") {
+    const result = errorFrameSchema.safeParse(parsed);
+    if (!result.success) return;
+    setState((s) => ({ ...s, status: "error", error: result.data }));
+  }
+}
+
+// Providers may re-emit a suggestion at the same index (rare, but the
+// contract allows it); keep the latest so the card reflects the final state.
+function mergeSuggestion(
+  list: StreamState["suggestions"],
+  incoming: StreamState["suggestions"][number],
+): StreamState["suggestions"] {
+  const existing = list.findIndex((s) => s.index === incoming.index);
+  if (existing === -1) return [...list, incoming];
+  const copy = list.slice();
+  copy[existing] = incoming;
+  return copy;
+}
+
+function safeJson(text: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+// Narrow the JSON-parsed envelope to the {code,message} shape without tripping
+// the strict `Record<string,unknown>` return of safeJson.
+function parseErrorEnvelope(text: string): {
+  code?: string;
+  message?: string;
+} {
+  const parsed = safeJson(text);
+  if (!parsed) return {};
+  const errorField = (parsed as { error?: unknown }).error;
+  if (errorField && typeof errorField === "object") {
+    const e = errorField as { code?: unknown; message?: unknown };
+    return {
+      ...(typeof e.code === "string" ? { code: e.code } : {}),
+      ...(typeof e.message === "string" ? { message: e.message } : {}),
+    };
+  }
+  return {};
+}
+

--- a/apps/web/src/features/generation/queries.ts
+++ b/apps/web/src/features/generation/queries.ts
@@ -1,0 +1,3 @@
+export const generationQueryKeys = {
+  policies: (repoId: string) => ["generation", "policies", repoId] as const,
+};

--- a/apps/web/src/features/generation/server.ts
+++ b/apps/web/src/features/generation/server.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+import { createServerTsRestClient } from "@/lib/api/tsr";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+import type { GeneratePageData } from "./types";
+
+export const getGeneratePageData = async (): Promise<GeneratePageData> => {
+  const supabase = await createSupabaseServerClient();
+  const { data } = await supabase.auth.getSession();
+  const accessToken = data.session?.access_token ?? null;
+  const userId = data.session?.user.id ?? "anonymous";
+
+  const client = createServerTsRestClient(accessToken);
+  const [keysRes, reposRes] = await Promise.all([
+    client.auth.llmKeys.list(),
+    client.repos.listConnected(),
+  ]);
+
+  if (keysRes.status !== 200) {
+    throw new Error(`Failed to load LLM keys (status ${keysRes.status})`);
+  }
+  if (reposRes.status !== 200) {
+    throw new Error(
+      `Failed to load connected repositories (status ${reposRes.status})`,
+    );
+  }
+
+  return {
+    userId,
+    configuredKeys: keysRes.body.items,
+    repos: reposRes.body.items,
+  };
+};

--- a/apps/web/src/features/generation/types.ts
+++ b/apps/web/src/features/generation/types.ts
@@ -1,0 +1,37 @@
+import type {
+  ConnectedRepo,
+  DoneFrame,
+  ErrorFrame,
+  LlmApiKey,
+  LlmProviderName,
+  SuggestionFrame,
+} from "@commit-analyzer/contracts";
+
+export type GeneratePageData = {
+  userId: string;
+  configuredKeys: LlmApiKey[];
+  repos: ConnectedRepo[];
+};
+
+export type StreamStatus =
+  | "idle"
+  | "streaming"
+  | "done"
+  | "cancelled"
+  | "error";
+
+export type StreamState = {
+  status: StreamStatus;
+  suggestions: SuggestionFrame[];
+  error: ErrorFrame | null;
+  done: DoneFrame | null;
+};
+
+export type GenerateInput = {
+  diff: string;
+  provider: LlmProviderName;
+  model: string;
+  repositoryId?: string;
+  policyId?: string;
+  count?: number;
+};

--- a/apps/web/src/global.d.ts
+++ b/apps/web/src/global.d.ts
@@ -4,6 +4,7 @@ import type auth from "../messages/en/auth.json";
 import type common from "../messages/en/common.json";
 import type dashboard from "../messages/en/dashboard.json";
 import type errors from "../messages/en/errors.json";
+import type generate from "../messages/en/generate.json";
 import type landing from "../messages/en/landing.json";
 import type llmKeys from "../messages/en/llmKeys.json";
 import type login from "../messages/en/login.json";
@@ -24,6 +25,7 @@ type Messages = {
   common: typeof common;
   dashboard: typeof dashboard;
   errors: typeof errors;
+  generate: typeof generate;
   landing: typeof landing;
   llmKeys: typeof llmKeys;
   login: typeof login;

--- a/apps/web/src/i18n/request.ts
+++ b/apps/web/src/i18n/request.ts
@@ -7,6 +7,7 @@ import en_auth from "../../messages/en/auth.json";
 import en_common from "../../messages/en/common.json";
 import en_dashboard from "../../messages/en/dashboard.json";
 import en_errors from "../../messages/en/errors.json";
+import en_generate from "../../messages/en/generate.json";
 import en_landing from "../../messages/en/landing.json";
 import en_llmKeys from "../../messages/en/llmKeys.json";
 import en_login from "../../messages/en/login.json";
@@ -23,6 +24,7 @@ import uk_auth from "../../messages/uk/auth.json";
 import uk_common from "../../messages/uk/common.json";
 import uk_dashboard from "../../messages/uk/dashboard.json";
 import uk_errors from "../../messages/uk/errors.json";
+import uk_generate from "../../messages/uk/generate.json";
 import uk_landing from "../../messages/uk/landing.json";
 import uk_llmKeys from "../../messages/uk/llmKeys.json";
 import uk_login from "../../messages/uk/login.json";
@@ -44,6 +46,7 @@ const messagesByLocale: Record<(typeof routing.locales)[number], Messages> = {
     common: en_common,
     dashboard: en_dashboard,
     errors: en_errors,
+    generate: en_generate,
     landing: en_landing,
     llmKeys: en_llmKeys,
     login: en_login,
@@ -62,6 +65,7 @@ const messagesByLocale: Record<(typeof routing.locales)[number], Messages> = {
     common: uk_common,
     dashboard: uk_dashboard,
     errors: uk_errors,
+    generate: uk_generate,
     landing: uk_landing,
     llmKeys: uk_llmKeys,
     login: uk_login,

--- a/apps/web/src/lib/api/tsr.ts
+++ b/apps/web/src/lib/api/tsr.ts
@@ -42,7 +42,7 @@ const TOKEN_REFRESH_LEEWAY_SECONDS = 60;
  * stale, which surfaces as a transient error card on screens that gate UI on
  * `isError` / `failureReason`.
  */
-const resolveBrowserToken = async (): Promise<string | undefined> => {
+export const resolveBrowserToken = async (): Promise<string | undefined> => {
   try {
     const supabase = getBrowserSupabase();
     const { data } = await supabase.auth.getSession();


### PR DESCRIPTION
## Summary
- Adds `/[locale]/generate` page backed by a new `features/generation/` folder (server loader, `useGenerateStream` SSE hook, queries).
- Components: `DiffInput` (textarea + paste-from-clipboard + drag-drop .patch upload), `ProviderSelector` (providers from configured LLM keys + curated per-provider model list), `PolicyPicker` (optional repo + active policy), `SuggestionList` / `SuggestionCard` (streamed cards with compliance + per-rule badges, copy-as-commit-message).
- `useGenerateStream` posts to `/api/generate-proxy`, parses `suggestion` / `done` / `error` SSE frames with zod contracts, supports `cancel` via `AbortController`, and surfaces inline error / cancelled states.
- Converts `/api/generate-proxy` from buffered `.text()` to streaming pass-through (TTFT < 2 s acceptance). Forwards `Authorization` / cookies, sets `X-Accel-Buffering: no` + `Cache-Control: no-cache, no-transform`, aborts upstream on client disconnect.
- i18n: new `generate` namespace (`en` + `uk`), registered in `global.d.ts` + `i18n/request.ts`, passes `check-messages`.
- Exports `resolveBrowserToken` from `lib/api/tsr` so the hook can attach a Supabase bearer token to the proxy call.

## Acceptance criteria
- [x] User sees first token < 2 s on a typical diff — proxy now streams the upstream body directly.
- [x] Cancel button aborts stream — `AbortController` on the client + `req.signal` wired into upstream fetch, server persists `cancelled` state.
- [x] Copy places CC-formatted message on clipboard — `formatAsCommitMessage` + `navigator.clipboard.writeText`.

## Test plan
- [x] `pnpm -F @commit-analyzer/web typecheck`
- [x] `pnpm -F @commit-analyzer/web lint` (only pre-existing sr-only warnings)
- [x] `pnpm -F @commit-analyzer/web test` (message catalog check)
- [x] `pnpm -r typecheck`
- [ ] Manual smoke: configure an LLM key, paste a diff, verify streaming cards, cancel, copy

Closes #56