### PR TITLE
fix(T-4.8): live llm keys on generate page

### DIFF
--- a/apps/web/src/features/generation/components/generate-view.tsx
+++ b/apps/web/src/features/generation/components/generate-view.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import type { LlmProviderName } from "@commit-analyzer/contracts";
+import type { LlmApiKey, LlmProviderName } from "@commit-analyzer/contracts";
 import { Loader2, Sparkles, Square } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
 import { MODELS_BY_PROVIDER } from "../constants";
-import { useGenerateStream } from "../hooks";
+import { useGenerateStream, useLlmKeysQuery } from "../hooks";
 import type { GeneratePageData } from "../types";
 
 import { DiffInput } from "./diff-input";
@@ -18,19 +18,21 @@ import { SuggestionList } from "./suggestion-list";
 
 const MAX_DIFF_BYTES = 1_000_000;
 
-const pickInitialProvider = (
-  keys: GeneratePageData["configuredKeys"],
-): LlmProviderName | null => {
+const pickInitialProvider = (keys: LlmApiKey[]): LlmProviderName | null => {
   const usable = keys.filter((k) => k.status !== "invalid");
   const verified = usable.find((k) => k.status === "ok");
   return (verified ?? usable[0])?.provider ?? null;
 };
 
 export const GenerateView = ({
+  userId,
   configuredKeys,
   repos,
 }: GeneratePageData) => {
   const t = useTranslations("generate");
+
+  const keysQuery = useLlmKeysQuery(userId, configuredKeys);
+  const keys = keysQuery.data?.body.items ?? configuredKeys;
 
   const [diff, setDiff] = useState("");
   const [provider, setProvider] = useState<LlmProviderName | null>(() =>
@@ -46,8 +48,14 @@ export const GenerateView = ({
   const { state, start, cancel } = useGenerateStream();
   const streaming = state.status === "streaming";
 
-  // Reset the model whenever the provider changes so we never send a model
-  // string that the newly-selected provider does not recognise.
+  useEffect(() => {
+    if (provider !== null) return;
+    const next = pickInitialProvider(keys);
+    if (!next) return;
+    setProvider(next);
+    setModel(MODELS_BY_PROVIDER[next][0] ?? null);
+  }, [keys, provider]);
+
   const handleProviderChange = useCallback((next: LlmProviderName) => {
     setProvider(next);
     setModel(MODELS_BY_PROVIDER[next][0] ?? null);
@@ -84,7 +92,7 @@ export const GenerateView = ({
       <div className="flex flex-col gap-4 rounded-xl border bg-card p-4 sm:p-6">
         <DiffInput value={diff} onChange={setDiff} disabled={streaming} />
         <ProviderSelector
-          configuredKeys={configuredKeys}
+          configuredKeys={keys}
           provider={provider}
           model={model}
           onProviderChange={handleProviderChange}

--- a/apps/web/src/features/generation/hooks.ts
+++ b/apps/web/src/features/generation/hooks.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import type { LlmApiKey } from "@commit-analyzer/contracts";
 import {
   doneFrameSchema,
   errorFrameSchema,
@@ -16,7 +17,7 @@ import {
 
 import { resolveBrowserToken, tsr } from "@/lib/api/tsr";
 
-import { generationQueryKeys } from "./queries";
+import { generationQueryKeys, llmKeysSharedQueryKey } from "./queries";
 import type { GenerateInput, StreamState } from "./types";
 
 const GENERATE_PROXY_URL = "/api/generate-proxy";
@@ -27,6 +28,19 @@ const INITIAL: StreamState = {
   error: null,
   done: null,
 };
+
+export const useLlmKeysQuery = (userId: string, initialItems: LlmApiKey[]) =>
+  tsr.auth.llmKeys.list.useQuery({
+    queryKey: [...llmKeysSharedQueryKey(userId)],
+    queryData: {},
+    initialData: {
+      status: 200,
+      body: { items: initialItems },
+      headers: new Headers(),
+    },
+    staleTime: 0,
+    retry: 0,
+  });
 
 export const usePoliciesForRepoQuery = (repoId: string | null) =>
   tsr.policies.list.useQuery({

--- a/apps/web/src/features/generation/queries.ts
+++ b/apps/web/src/features/generation/queries.ts
@@ -1,3 +1,7 @@
 export const generationQueryKeys = {
   policies: (repoId: string) => ["generation", "policies", repoId] as const,
 };
+
+// Must match features/llm-keys/queries.ts `llmKeyQueryKeys.all` — shared cache.
+export const llmKeysSharedQueryKey = (userId: string) =>
+  ["llm-keys", userId] as const;


### PR DESCRIPTION
## Summary
Adding an LLM key on /settings/llm-keys and navigating back to /generate still showed "No LLM keys configured" because the page read keys from the RSC loader snapshot (cached by App Router).

Fix: GenerateView now subscribes to the same TanStack Query cache entry (`["llm-keys", userId]`) that the llm-keys feature's upsert mutation writes to. The RSC result seeds the initial paint; the shared cache keeps subsequent state in sync across routes. Provider/model auto-pick falls through a \`useEffect\` once keys arrive if the user landed with none.

## Test plan
- [x] typecheck, lint, check-messages, knip
- [ ] Manual: no keys → /settings/llm-keys → add key → back → provider selector populated