### PR TITLE
test(T-4.9): e2e generate spec + ttft gate

### DIFF
--- a/apps/web/e2e/generate.constants.ts
+++ b/apps/web/e2e/generate.constants.ts
@@ -1,0 +1,16 @@
+// TTFT acceptance gate per the issue body and 10-testing.md §6. Measured
+// from the moment the user clicks Generate to the first suggestion frame
+// being painted in the DOM. Shared between the stub-backed `generate.spec.ts`
+// and the live-provider `generate.live.spec.ts` so the budget can never
+// drift between the two.
+export const TTFT_BUDGET_MS = 2_000;
+
+export const SAMPLE_DIFF = `diff --git a/src/auth.ts b/src/auth.ts
+index e69de29..b6fc4c6 100644
+--- a/src/auth.ts
++++ b/src/auth.ts
+@@ -0,0 +1,3 @@
++export const signIn = async (email, password) => {
++  return await api.post("/auth/sign-in", { email, password });
++};
+`;

--- a/apps/web/e2e/generate.live.spec.ts
+++ b/apps/web/e2e/generate.live.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "./fixtures";
+
+// Optional smoke suite that exercises the same generate flow against a real
+// staging LLM provider. Skipped by default — the mock SSE stub in the main
+// `generate.spec.ts` covers PR-level CI. Enable for targeted runs by setting:
+//
+//   E2E_REAL_LLM=1                # opt-in
+//   E2E_REAL_LLM_BASE_URL=https://staging.example.com   # web app under test
+//
+// The runner expects the targeted environment to already have a valid Anthropic
+// or OpenAI key configured for the test user, and a connected repository so
+// the page renders past the empty-state guards. Auth is whatever the targeted
+// environment uses — this suite does not inject Supabase fixtures.
+const RUN_LIVE = process.env.E2E_REAL_LLM === "1";
+const LIVE_BASE_URL = process.env.E2E_REAL_LLM_BASE_URL ?? "";
+
+const SAMPLE_DIFF = `diff --git a/src/auth.ts b/src/auth.ts
+index e69de29..b6fc4c6 100644
+--- a/src/auth.ts
++++ b/src/auth.ts
+@@ -0,0 +1,3 @@
++export const signIn = async (email, password) => {
++  return await api.post("/auth/sign-in", { email, password });
++};
+`;
+
+const TTFT_BUDGET_MS = 2_000;
+
+test.describe("generate (live LLM)", () => {
+  test.skip(!RUN_LIVE, "set E2E_REAL_LLM=1 to enable the live smoke suite");
+  test.skip(
+    RUN_LIVE && !LIVE_BASE_URL,
+    "E2E_REAL_LLM=1 requires E2E_REAL_LLM_BASE_URL",
+  );
+
+  test("first suggestion streams within the TTFT budget", async ({ page }) => {
+    await page.goto(`${LIVE_BASE_URL}/generate`);
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: /generate commit message/i }),
+    ).toBeVisible();
+
+    await page.getByLabel("Diff", { exact: true }).fill(SAMPLE_DIFF);
+
+    const startedAt = Date.now();
+    await page.getByRole("button", { name: /^Generate$/ }).click();
+
+    // Don't lock the assertion to a specific subject string — real LLM output
+    // is non-deterministic. Wait for the first suggestion card instead.
+    await expect(page.getByRole("article").first()).toBeVisible({
+      timeout: TTFT_BUDGET_MS,
+    });
+    const ttftMs = Date.now() - startedAt;
+    expect(
+      ttftMs,
+      `live TTFT was ${ttftMs}ms (budget ${TTFT_BUDGET_MS}ms)`,
+    ).toBeLessThan(TTFT_BUDGET_MS);
+
+    // Stream is expected to settle within ~30 s; the per-suggestion count is
+    // bounded by the contract (max 5).
+    await expect
+      .poll(async () => (await page.getByRole("article").count()), {
+        timeout: 30_000,
+      })
+      .toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/e2e/generate.live.spec.ts
+++ b/apps/web/e2e/generate.live.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "./fixtures";
+import { SAMPLE_DIFF, TTFT_BUDGET_MS } from "./generate.constants";
 
 // Optional smoke suite that exercises the same generate flow against a real
 // staging LLM provider. Skipped by default — the mock SSE stub in the main
@@ -13,18 +14,6 @@ import { expect, test } from "./fixtures";
 // environment uses — this suite does not inject Supabase fixtures.
 const RUN_LIVE = process.env.E2E_REAL_LLM === "1";
 const LIVE_BASE_URL = process.env.E2E_REAL_LLM_BASE_URL ?? "";
-
-const SAMPLE_DIFF = `diff --git a/src/auth.ts b/src/auth.ts
-index e69de29..b6fc4c6 100644
---- a/src/auth.ts
-+++ b/src/auth.ts
-@@ -0,0 +1,3 @@
-+export const signIn = async (email, password) => {
-+  return await api.post("/auth/sign-in", { email, password });
-+};
-`;
-
-const TTFT_BUDGET_MS = 2_000;
 
 test.describe("generate (live LLM)", () => {
   test.skip(!RUN_LIVE, "set E2E_REAL_LLM=1 to enable the live smoke suite");
@@ -42,19 +31,14 @@ test.describe("generate (live LLM)", () => {
 
     await page.getByLabel("Diff", { exact: true }).fill(SAMPLE_DIFF);
 
-    const startedAt = Date.now();
     await page.getByRole("button", { name: /^Generate$/ }).click();
 
     // Don't lock the assertion to a specific subject string — real LLM output
     // is non-deterministic. Wait for the first suggestion card instead.
+    // `toBeVisible({ timeout })` is the TTFT gate.
     await expect(page.getByRole("article").first()).toBeVisible({
       timeout: TTFT_BUDGET_MS,
     });
-    const ttftMs = Date.now() - startedAt;
-    expect(
-      ttftMs,
-      `live TTFT was ${ttftMs}ms (budget ${TTFT_BUDGET_MS}ms)`,
-    ).toBeLessThan(TTFT_BUDGET_MS);
 
     // Stream is expected to settle within ~30 s; the per-suggestion count is
     // bounded by the contract (max 5).

--- a/apps/web/e2e/generate.spec.ts
+++ b/apps/web/e2e/generate.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test } from "./fixtures";
+import { MOCK_ACCESS_TOKEN, MOCK_PORT, MOCK_SEEDED_REPO_ID } from "./mock-server";
+
+const MOCK_API_BASE = `http://127.0.0.1:${MOCK_PORT}`;
+
+const SAMPLE_DIFF = `diff --git a/src/auth.ts b/src/auth.ts
+index e69de29..b6fc4c6 100644
+--- a/src/auth.ts
++++ b/src/auth.ts
+@@ -0,0 +1,3 @@
++export const signIn = async (email, password) => {
++  return await api.post("/auth/sign-in", { email, password });
++};
+`;
+
+// TTFT acceptance gate per the issue body and 10-testing.md §6. Measured from
+// the moment the user clicks Generate to the first suggestion subject being
+// painted in the DOM. The mock SSE handler flushes the first frame
+// synchronously, so any regression here points at proxy buffering or the
+// client parser, not test flake.
+const TTFT_BUDGET_MS = 2_000;
+
+const SUGGESTION_SUBJECTS = [
+  "add email + password sign-in flow",
+  "patch the long-running session refresh edge case",
+  "tidy up auth module",
+];
+
+// Covers UC-C1 (basic streaming generation) and UC-C2 (policy-aware
+// generation). The mock server stubs the SSE provider with a deterministic
+// 3-suggestion stream so the assertions are stable; the live-provider
+// counterpart lives in `generate.live.spec.ts` and is gated by E2E_REAL_LLM.
+test.describe("generate — streaming, TTFT, copy, policy badges", () => {
+  test("paste diff → first suggestion < 2 s, 3 cards with copy actions", async ({
+    authedPage: page,
+  }) => {
+    await page.goto("/generate");
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: /generate commit message/i }),
+    ).toBeVisible();
+
+    await page.getByLabel("Diff", { exact: true }).fill(SAMPLE_DIFF);
+
+    const startedAt = Date.now();
+    await page.getByRole("button", { name: /^Generate$/ }).click();
+
+    // TTFT — the first suggestion subject must be visible inside the budget.
+    // Use the subject text rather than `article` role since the streaming
+    // placeholder also renders inside a card-like container.
+    await expect(page.getByText(SUGGESTION_SUBJECTS[0]!)).toBeVisible({
+      timeout: TTFT_BUDGET_MS,
+    });
+    const ttftMs = Date.now() - startedAt;
+    expect(
+      ttftMs,
+      `TTFT was ${ttftMs}ms (budget ${TTFT_BUDGET_MS}ms)`,
+    ).toBeLessThan(TTFT_BUDGET_MS);
+
+    // Wait for the rest of the stream to flush.
+    for (const subject of SUGGESTION_SUBJECTS.slice(1)) {
+      await expect(page.getByText(subject)).toBeVisible();
+    }
+
+    // 3 suggestion cards, each with a Copy button. The header line lives in a
+    // <pre> so the cards-as-articles count is exact.
+    const cards = page.getByRole("article");
+    await expect(cards).toHaveCount(3);
+    for (let i = 0; i < 3; i++) {
+      await expect(
+        cards.nth(i).getByRole("button", { name: "Copy" }),
+      ).toBeVisible();
+    }
+
+    // No-policy stream → every suggestion is marked Compliant, no per-rule
+    // badges or destructive validation messages render.
+    await expect(page.getByText("Compliant", { exact: true })).toHaveCount(3);
+    await expect(page.getByText("Non-compliant")).toHaveCount(0);
+  });
+
+  test("with active policy → badges reflect validator results", async ({
+    authedPage: page,
+  }, testInfo) => {
+    // Seed a strict policy via the mock API so we don't have to drive the
+    // policy editor UI from the generate spec. Name is unique per
+    // attempt — the mock server keeps state across retries inside one run, so
+    // a static name would collide on the dropdown after a flaky retry.
+    const policyName = `Strict E2E (generate ${testInfo.testId} #${testInfo.retry})`;
+    const createRes = await page.request.post(
+      `${MOCK_API_BASE}/repos/${MOCK_SEEDED_REPO_ID}/policies`,
+      {
+        headers: {
+          authorization: `Bearer ${MOCK_ACCESS_TOKEN}`,
+          "content-type": "application/json",
+        },
+        data: {
+          name: policyName,
+          rules: [
+            { ruleType: "allowedTypes", ruleValue: ["feat"] },
+            { ruleType: "maxSubjectLength", ruleValue: 30 },
+          ],
+        },
+      },
+    );
+    expect(createRes.status()).toBe(201);
+    const policy = (await createRes.json()) as { id: string };
+
+    const activateRes = await page.request.post(
+      `${MOCK_API_BASE}/repos/${MOCK_SEEDED_REPO_ID}/policies/${policy.id}/activate`,
+      {
+        headers: { authorization: `Bearer ${MOCK_ACCESS_TOKEN}` },
+      },
+    );
+    expect(activateRes.status()).toBe(200);
+
+    await page.goto("/generate");
+
+    await page.getByLabel("Diff", { exact: true }).fill(SAMPLE_DIFF);
+
+    // Select the seeded repo + freshly-created policy.
+    await page.getByLabel(/^Repository/).click();
+    await page
+      .getByRole("option", { name: /acme\/seeded-repo/ })
+      .click();
+
+    await page.getByLabel(/^Policy/).click();
+    await page.getByRole("option", { name: policyName }).click();
+
+    await page.getByRole("button", { name: /^Generate$/ }).click();
+
+    // First suggestion paints — confirms the request reached the proxy with
+    // the policy id (otherwise validation field would be null and badges
+    // wouldn't render below).
+    await expect(page.getByText(SUGGESTION_SUBJECTS[0]!)).toBeVisible({
+      timeout: TTFT_BUDGET_MS,
+    });
+
+    // Wait for all three to stream in.
+    for (const subject of SUGGESTION_SUBJECTS.slice(1)) {
+      await expect(page.getByText(subject)).toBeVisible();
+    }
+
+    const cards = page.getByRole("article");
+    await expect(cards).toHaveCount(3);
+
+    // s0 "feat(auth): add email + password sign-in flow" — Type passes (feat
+    // is allowed) but the subject is 33 chars, so Subject length fails.
+    const card0 = cards.nth(0);
+    await expect(card0.getByText("Non-compliant")).toBeVisible();
+    await expect(card0.getByText(/Subject is 33 characters; max is 30/)).toBeVisible();
+
+    // s1 "fix(auth): patch the long-running…" — both rules fail.
+    const card1 = cards.nth(1);
+    await expect(card1.getByText("Non-compliant")).toBeVisible();
+    await expect(card1.getByText(/Type 'fix' is not in the allowed list/)).toBeVisible();
+
+    // s2 "chore: tidy up auth module" — Type fails, Subject length passes
+    // (19 chars). Asserts the per-rule badge granularity, not just the
+    // aggregated compliant flag.
+    const card2 = cards.nth(2);
+    await expect(card2.getByText("Non-compliant")).toBeVisible();
+    await expect(card2.getByText(/Type 'chore' is not in the allowed list/)).toBeVisible();
+  });
+});

--- a/apps/web/e2e/generate.spec.ts
+++ b/apps/web/e2e/generate.spec.ts
@@ -1,24 +1,8 @@
 import { expect, test } from "./fixtures";
+import { SAMPLE_DIFF, TTFT_BUDGET_MS } from "./generate.constants";
 import { MOCK_ACCESS_TOKEN, MOCK_PORT, MOCK_SEEDED_REPO_ID } from "./mock-server";
 
 const MOCK_API_BASE = `http://127.0.0.1:${MOCK_PORT}`;
-
-const SAMPLE_DIFF = `diff --git a/src/auth.ts b/src/auth.ts
-index e69de29..b6fc4c6 100644
---- a/src/auth.ts
-+++ b/src/auth.ts
-@@ -0,0 +1,3 @@
-+export const signIn = async (email, password) => {
-+  return await api.post("/auth/sign-in", { email, password });
-+};
-`;
-
-// TTFT acceptance gate per the issue body and 10-testing.md §6. Measured from
-// the moment the user clicks Generate to the first suggestion subject being
-// painted in the DOM. The mock SSE handler flushes the first frame
-// synchronously, so any regression here points at proxy buffering or the
-// client parser, not test flake.
-const TTFT_BUDGET_MS = 2_000;
 
 const SUGGESTION_SUBJECTS = [
   "add email + password sign-in flow",
@@ -42,20 +26,15 @@ test.describe("generate — streaming, TTFT, copy, policy badges", () => {
 
     await page.getByLabel("Diff", { exact: true }).fill(SAMPLE_DIFF);
 
-    const startedAt = Date.now();
     await page.getByRole("button", { name: /^Generate$/ }).click();
 
-    // TTFT — the first suggestion subject must be visible inside the budget.
-    // Use the subject text rather than `article` role since the streaming
-    // placeholder also renders inside a card-like container.
+    // TTFT — the first suggestion subject must be visible within the budget.
+    // Playwright's `toBeVisible({ timeout })` is the single source of truth
+    // here: it polls from the moment the click resolves and fails the test
+    // if the locator isn't satisfied inside the budget.
     await expect(page.getByText(SUGGESTION_SUBJECTS[0]!)).toBeVisible({
       timeout: TTFT_BUDGET_MS,
     });
-    const ttftMs = Date.now() - startedAt;
-    expect(
-      ttftMs,
-      `TTFT was ${ttftMs}ms (budget ${TTFT_BUDGET_MS}ms)`,
-    ).toBeLessThan(TTFT_BUDGET_MS);
 
     // Wait for the rest of the stream to flush.
     for (const subject of SUGGESTION_SUBJECTS.slice(1)) {
@@ -82,9 +61,10 @@ test.describe("generate — streaming, TTFT, copy, policy badges", () => {
     authedPage: page,
   }, testInfo) => {
     // Seed a strict policy via the mock API so we don't have to drive the
-    // policy editor UI from the generate spec. Name is unique per
-    // attempt — the mock server keeps state across retries inside one run, so
-    // a static name would collide on the dropdown after a flaky retry.
+    // policy editor UI from the generate spec. Name is unique per attempt
+    // because mock-server module state persists across in-run retries (by
+    // design — see `policies` Map in mock-server.ts), so a static name would
+    // collide on the dropdown after a flaky retry.
     const policyName = `Strict E2E (generate ${testInfo.testId} #${testInfo.retry})`;
     const createRes = await page.request.post(
       `${MOCK_API_BASE}/repos/${MOCK_SEEDED_REPO_ID}/policies`,
@@ -143,22 +123,44 @@ test.describe("generate — streaming, TTFT, copy, policy badges", () => {
     const cards = page.getByRole("article");
     await expect(cards).toHaveCount(3);
 
+    // Validator-message assertions are scoped to the per-rule failure list
+    // (the suggestion-card renders one <li> per failing rule with a
+    // "<Label>: <message>" prefix). They check structure (length numbers,
+    // forbidden type tokens) rather than verbatim wording: the mock and the
+    // production rules currently phrase the same failure differently
+    // (mock: "Type 'X' is not in the allowed list" vs.
+    //  prod: 'type "X" is not allowed. Allowed: …'). Pinning to mock copy
+    // would let prod-side phrasing drift ship UI regressions silently.
+
     // s0 "feat(auth): add email + password sign-in flow" — Type passes (feat
     // is allowed) but the subject is 33 chars, so Subject length fails.
     const card0 = cards.nth(0);
     await expect(card0.getByText("Non-compliant")).toBeVisible();
-    await expect(card0.getByText(/Subject is 33 characters; max is 30/)).toBeVisible();
+    const card0Failures = card0.getByRole("listitem");
+    await expect(card0Failures).toHaveCount(1);
+    await expect(
+      card0Failures.filter({ hasText: /^Subject length:/ }),
+    ).toContainText(/\b33\b.*\b30\b/);
 
-    // s1 "fix(auth): patch the long-running…" — both rules fail.
+    // s1 "fix(auth): patch the long-running…" — both rules fail; per-rule
+    // failure list contains both Type and Subject length entries.
     const card1 = cards.nth(1);
     await expect(card1.getByText("Non-compliant")).toBeVisible();
-    await expect(card1.getByText(/Type 'fix' is not in the allowed list/)).toBeVisible();
+    const card1Failures = card1.getByRole("listitem");
+    await expect(card1Failures).toHaveCount(2);
+    await expect(
+      card1Failures.filter({ hasText: /^Type:/ }),
+    ).toContainText(/['"]?fix['"]?/);
 
     // s2 "chore: tidy up auth module" — Type fails, Subject length passes
     // (19 chars). Asserts the per-rule badge granularity, not just the
     // aggregated compliant flag.
     const card2 = cards.nth(2);
     await expect(card2.getByText("Non-compliant")).toBeVisible();
-    await expect(card2.getByText(/Type 'chore' is not in the allowed list/)).toBeVisible();
+    const card2Failures = card2.getByRole("listitem");
+    await expect(card2Failures).toHaveCount(1);
+    await expect(
+      card2Failures.filter({ hasText: /^Type:/ }),
+    ).toContainText(/['"]?chore['"]?/);
   });
 });

--- a/apps/web/e2e/mock-server.ts
+++ b/apps/web/e2e/mock-server.ts
@@ -224,6 +224,103 @@ const validateAgainstRules = (
   return { passed: results.every((r) => r.passed), results };
 };
 
+// ─── LLM keys + generate fixtures ───────────────────────────────────────────
+
+// One pre-seeded "ok" key per supported provider. The generate page picks the
+// first verified key as the default selection — keep this list non-empty so
+// the spec doesn't have to navigate through the "no keys configured" empty
+// state before submitting.
+const LLM_KEYS = [
+  {
+    id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    provider: "anthropic" as const,
+    status: "ok" as const,
+    createdAt: "2024-02-01T00:00:00.000Z",
+  },
+];
+
+// Three deterministic suggestions used by the SSE stub. Subjects are written
+// to fail the strict E2E policy (allowedTypes = [feat], maxSubjectLength = 30)
+// so the badges-reflect-validation acceptance criterion is exercised end-to-end
+// without relying on probabilistic LLM output.
+type StubSuggestion = {
+  type: string;
+  scope: string | null;
+  subject: string;
+  body: string | null;
+  footer: string | null;
+};
+
+const STUB_SUGGESTIONS: StubSuggestion[] = [
+  {
+    type: "feat",
+    scope: "auth",
+    subject: "add email + password sign-in flow",
+    body: null,
+    footer: null,
+  },
+  {
+    type: "fix",
+    scope: "auth",
+    subject: "patch the long-running session refresh edge case",
+    body: null,
+    footer: null,
+  },
+  {
+    type: "chore",
+    scope: null,
+    subject: "tidy up auth module",
+    body: null,
+    footer: null,
+  },
+];
+
+// Inter-frame delay for the SSE stream. The spec asserts TTFT (first
+// suggestion frame visible in the DOM) < 2 s, so the first chunk is flushed
+// immediately and subsequent ones spaced just enough that the client can
+// observe the streaming behaviour.
+const STUB_FRAME_GAP_MS = 50;
+
+const sendSseEvent = (
+  res: ServerResponse,
+  event: string,
+  data: unknown,
+): void => {
+  res.write(`event: ${event}\n`);
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+};
+
+const buildSuggestionFrame = (
+  index: number,
+  stub: StubSuggestion,
+  policyRules: MockPolicyRule[] | null,
+) => {
+  const headerLine = `${stub.type}${stub.scope ? `(${stub.scope})` : ""}: ${stub.subject}`;
+  if (!policyRules) {
+    return {
+      index,
+      type: stub.type,
+      scope: stub.scope,
+      subject: stub.subject,
+      body: stub.body,
+      footer: stub.footer,
+      compliant: true,
+      validation: null,
+    };
+  }
+  const validation = validateAgainstRules(headerLine, policyRules);
+  return {
+    index,
+    type: stub.type,
+    scope: stub.scope,
+    subject: stub.subject,
+    body: stub.body,
+    footer: stub.footer,
+    compliant: validation.passed,
+    validation,
+  };
+};
+
 // ─── Sync simulation state ──────────────────────────────────────────────────
 
 type PendingSync = { syncJobId: string };
@@ -510,6 +607,76 @@ const handleRequest = async (
         return;
     }
     sendJson(req, res, 404, { message: "not found" });
+    return;
+  }
+
+  // ── LLM keys ─────────────────────────────────────────────────────────────
+  if (req.method === "GET" && pathname === "/llm-keys") {
+    if (!isAuthorized(req)) {
+      sendJson(req, res, 401, { message: "unauthorized" });
+      return;
+    }
+    sendJson(req, res, 200, { items: LLM_KEYS });
+    return;
+  }
+
+  // ── Generate (SSE) ───────────────────────────────────────────────────────
+  if (req.method === "POST" && pathname === "/generate") {
+    if (!isAuthorized(req)) {
+      sendJson(req, res, 401, { message: "unauthorized" });
+      return;
+    }
+    const body = (await readJsonBody(req)) as {
+      policyId?: unknown;
+      repositoryId?: unknown;
+    };
+    const policyId = typeof body.policyId === "string" ? body.policyId : null;
+    const policy = policyId ? (policies.get(policyId) ?? null) : null;
+    const policyRules = policy ? policy.rules : null;
+
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+      ...corsHeaders(req),
+    });
+
+    let cancelled = false;
+    req.on("close", () => {
+      cancelled = true;
+    });
+
+    // Flush headers + first frame immediately. The TTFT acceptance assertion
+    // measures from the submit click to the first suggestion card being
+    // visible in the DOM, so any delay before the first write directly eats
+    // into the budget.
+    sendSseEvent(
+      res,
+      "suggestion",
+      buildSuggestionFrame(0, STUB_SUGGESTIONS[0]!, policyRules),
+    );
+
+    let i = 1;
+    const writeNext = (): void => {
+      if (cancelled) return;
+      if (i >= STUB_SUGGESTIONS.length) {
+        sendSseEvent(res, "done", {
+          historyId: "11111111-2222-4222-8222-333333333333",
+          tokensUsed: 1234,
+        });
+        res.end();
+        return;
+      }
+      sendSseEvent(
+        res,
+        "suggestion",
+        buildSuggestionFrame(i, STUB_SUGGESTIONS[i]!, policyRules),
+      );
+      i += 1;
+      setTimeout(writeNext, STUB_FRAME_GAP_MS);
+    };
+    setTimeout(writeNext, STUB_FRAME_GAP_MS);
     return;
   }
 

--- a/apps/web/e2e/mock-server.ts
+++ b/apps/web/e2e/mock-server.ts
@@ -164,6 +164,10 @@ type MockPolicy = {
   updatedAt: string;
 };
 
+// Module-scoped: state persists for the life of the worker process.
+// Intentional — Playwright retries within a run reuse this Map so a flaky
+// retry doesn't lose seeded fixtures, and `resetState()` clears it only at
+// startup/teardown.
 const policies = new Map<string, MockPolicy>();
 
 const listPoliciesForRepo = (repoId: string): MockPolicy[] =>
@@ -217,7 +221,12 @@ const validateAgainstRules = (
             };
       }
       default:
-        return { ruleType: rule.ruleType, passed: true };
+        // Surface mock drift early — silently passing unknown rule types
+        // would let new validators ship with green E2Es while the mock is
+        // not actually exercising them.
+        throw new Error(
+          `validateAgainstRules: unknown ruleType "${rule.ruleType}" — extend the mock when adding new rules.`,
+        );
     }
   });
 
@@ -275,11 +284,10 @@ const STUB_SUGGESTIONS: StubSuggestion[] = [
   },
 ];
 
-// Inter-frame delay for the SSE stream. The spec asserts TTFT (first
-// suggestion frame visible in the DOM) < 2 s, so the first chunk is flushed
-// immediately and subsequent ones spaced just enough that the client can
-// observe the streaming behaviour.
-const STUB_FRAME_GAP_MS = 50;
+// Inter-frame delay for the SSE stream. Kept at 0 — the spec only asserts
+// the final card count and the per-suggestion content, not mid-stream UI
+// state, so spacing the frames just slows the test without buying signal.
+const STUB_FRAME_GAP_MS = 0;
 
 const sendSseEvent = (
   res: ServerResponse,

--- a/apps/web/e2e/server-env-stub.ts
+++ b/apps/web/e2e/server-env-stub.ts
@@ -1,0 +1,22 @@
+// Full server-env schema stub for the Playwright webServer. The
+// `/api/generate-proxy` route calls `loadServerEnv()` at module load and
+// fails the dev build hard if any var is missing, so even the e2e setup that
+// only cares about API_URL / WEB_ORIGIN has to provide values for the rest
+// of the schema. Kept as a single record so future routes that read more
+// server vars can extend this file instead of editing playwright.config.ts.
+import { MOCK_PORT } from "./mock-server";
+
+export const TEST_SERVER_ENV: Record<string, string> = {
+  APP_URL: "http://localhost:3000",
+  API_URL: `http://127.0.0.1:${MOCK_PORT}`,
+  WEB_ORIGIN: "http://localhost:3000",
+  DATABASE_URL: "postgres://stub:stub@127.0.0.1:5432/stub",
+  REDIS_URL: "redis://127.0.0.1:6379",
+  SUPABASE_URL: `http://127.0.0.1:${MOCK_PORT}`,
+  SUPABASE_ANON_KEY: "mock-anon-key",
+  SUPABASE_SERVICE_ROLE_KEY: "mock-service-role-key",
+  GITHUB_CLIENT_ID: "mock-github-client-id",
+  GITHUB_CLIENT_SECRET: "mock-github-client-secret",
+  // 32 zero bytes, base64-encoded — schema requires exactly 32 raw bytes.
+  ENCRYPTION_KEY_BASE64: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+};

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
+import { TEST_SERVER_ENV } from "./e2e/server-env-stub";
+
 const MOCK_PORT = 54321;
 
 export default defineConfig({
@@ -30,22 +32,7 @@ export default defineConfig({
       NEXT_PUBLIC_SUPABASE_ANON_KEY: "mock-anon-key",
       NEXT_PUBLIC_API_URL: `http://127.0.0.1:${MOCK_PORT}`,
       NEXT_PUBLIC_APP_URL: "http://localhost:3000",
-      // The /api/generate-proxy route calls loadServerEnv() at module load and
-      // fails the dev build hard if any var is missing. Stub the full server
-      // schema so the proxy reaches the mock SSE handler. APP_URL / API_URL /
-      // WEB_ORIGIN are the values the proxy actually reads; everything else is
-      // schema-required filler.
-      APP_URL: "http://localhost:3000",
-      API_URL: `http://127.0.0.1:${MOCK_PORT}`,
-      WEB_ORIGIN: "http://localhost:3000",
-      DATABASE_URL: "postgres://stub:stub@127.0.0.1:5432/stub",
-      REDIS_URL: "redis://127.0.0.1:6379",
-      SUPABASE_URL: `http://127.0.0.1:${MOCK_PORT}`,
-      SUPABASE_ANON_KEY: "mock-anon-key",
-      SUPABASE_SERVICE_ROLE_KEY: "mock-service-role-key",
-      GITHUB_CLIENT_ID: "mock-github-client-id",
-      GITHUB_CLIENT_SECRET: "mock-github-client-secret",
-      ENCRYPTION_KEY_BASE64: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      ...TEST_SERVER_ENV,
     },
   },
 });

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -30,6 +30,22 @@ export default defineConfig({
       NEXT_PUBLIC_SUPABASE_ANON_KEY: "mock-anon-key",
       NEXT_PUBLIC_API_URL: `http://127.0.0.1:${MOCK_PORT}`,
       NEXT_PUBLIC_APP_URL: "http://localhost:3000",
+      // The /api/generate-proxy route calls loadServerEnv() at module load and
+      // fails the dev build hard if any var is missing. Stub the full server
+      // schema so the proxy reaches the mock SSE handler. APP_URL / API_URL /
+      // WEB_ORIGIN are the values the proxy actually reads; everything else is
+      // schema-required filler.
+      APP_URL: "http://localhost:3000",
+      API_URL: `http://127.0.0.1:${MOCK_PORT}`,
+      WEB_ORIGIN: "http://localhost:3000",
+      DATABASE_URL: "postgres://stub:stub@127.0.0.1:5432/stub",
+      REDIS_URL: "redis://127.0.0.1:6379",
+      SUPABASE_URL: `http://127.0.0.1:${MOCK_PORT}`,
+      SUPABASE_ANON_KEY: "mock-anon-key",
+      SUPABASE_SERVICE_ROLE_KEY: "mock-service-role-key",
+      GITHUB_CLIENT_ID: "mock-github-client-id",
+      GITHUB_CLIENT_SECRET: "mock-github-client-secret",
+      ENCRYPTION_KEY_BASE64: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add `generate.spec.ts` covering UC-C1/UC-C2: paste diff → first SSE frame visible < 2 s (TTFT gate), 3 suggestion cards rendered, each with a Copy action; with an active policy, per-suggestion badges + per-rule failure messages reflect the validator output.
- Extend the in-process mock server with a `/llm-keys` GET fixture (one verified Anthropic key) and a deterministic SSE handler at `/generate` that flushes the first frame immediately so the TTFT budget is meaningful instead of dominated by warm-up.
- Add `generate.live.spec.ts` — same flow against a real staging LLM provider, gated behind `E2E_REAL_LLM=1` + `E2E_REAL_LLM_BASE_URL`. Skipped by default so PR-level CI stays deterministic.
- Stub the full server-env schema in `playwright.config.ts` so the `/api/generate-proxy` route's `loadServerEnv()` doesn't crash on missing `DATABASE_URL`/`REDIS_URL`/`ENCRYPTION_KEY_BASE64` etc. when the route is hit from the browser.

Closes #57