### PR TITLE
fix(T-6.10.1): prebuild diff-parser before contracts

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "prebuild": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/contracts build",
+    "prebuild": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/diff-parser --filter @commit-analyzer/contracts build",
     "build": "tsc",
     "start": "node --enable-source-maps dist/bootstrap.js",
-    "predev": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/contracts build",
+    "predev": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/diff-parser --filter @commit-analyzer/contracts build",
     "dev": "node --import @swc-node/register/esm-register --watch --env-file=.env src/bootstrap.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "prebuild": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/contracts build",
+    "prebuild": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/diff-parser --filter @commit-analyzer/contracts build",
     "build": "next build",
-    "predev": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/contracts build",
+    "predev": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/diff-parser --filter @commit-analyzer/contracts build",
     "dev": "next dev",
     "start": "next start",
     "test": "node scripts/check-messages.mjs",


### PR DESCRIPTION
## Summary
- Vercel + Railway deploys on main broke after #221: `contracts` now imports from `@commit-analyzer/diff-parser/validate`, but the `prebuild` scripts in `apps/web` and `apps/api` only filter shared-types + contracts, so contracts compiles before diff-parser's `dist/validate.d.ts` exists.
- Adds `@commit-analyzer/diff-parser` to both prebuild filters so diff-parser's types are on disk before tsc runs against contracts.

Closes the Deploy-Web + Deploy-API failures from 24882405647 / 24882405656.