### PR TITLE
feat(T-6.12): tab scroll + split highlighting

### DIFF
--- a/apps/web/e2e/generate.constants.ts
+++ b/apps/web/e2e/generate.constants.ts
@@ -15,6 +15,26 @@ index e69de29..b6fc4c6 100644
 +};
 `;
 
+export const TS_PLUS_JSON_DIFF = `diff --git a/src/util.ts b/src/util.ts
+index 1111111..2222222 100644
+--- a/src/util.ts
++++ b/src/util.ts
+@@ -1,2 +1,3 @@
+-const old = 1;
++export const answer = 42;
++export function greet(name: string) { return "hi " + name; }
+ const keep = true;
+diff --git a/config/app.json b/config/app.json
+index 3333333..4444444 100644
+--- a/config/app.json
++++ b/config/app.json
+@@ -1,3 +1,3 @@
+ {
+-  "version": "1.0.0"
++  "version": "1.1.0"
+ }
+`;
+
 export const MULTI_FILE_DIFF = `diff --git a/src/a.ts b/src/a.ts
 index 1111111..2222222 100644
 --- a/src/a.ts

--- a/apps/web/e2e/generate.spec.ts
+++ b/apps/web/e2e/generate.spec.ts
@@ -280,10 +280,7 @@ test.describe("generate — streaming, TTFT, copy, policy badges", () => {
     ).toHaveAttribute("aria-checked", "true");
   });
 
-  // T-6.12 — split mode must show language-aware highlighting (classHighlighter
-  // maps keywords/strings/etc. to `tok-*` classes, which are the testable hook
-  // here). A TS file gets a `tok-keyword` span on "export"; a JSON file picks
-  // up property-name/string classes via the lang-json parser.
+  // T-6.12 — classHighlighter emits `tok-*` classes; that's the testable hook.
   test("split mode renders language-aware syntax highlighting", async ({
     authedPage: page,
   }) => {

--- a/apps/web/e2e/generate.spec.ts
+++ b/apps/web/e2e/generate.spec.ts
@@ -4,6 +4,7 @@ import { expect, test } from "./fixtures";
 import {
   MULTI_FILE_DIFF,
   SAMPLE_DIFF,
+  TS_PLUS_JSON_DIFF,
   TTFT_BUDGET_MS,
 } from "./generate.constants";
 import { MOCK_ACCESS_TOKEN, MOCK_PORT, MOCK_SEEDED_REPO_ID } from "./mock-server";
@@ -277,5 +278,38 @@ test.describe("generate — streaming, TTFT, copy, policy badges", () => {
     await expect(
       page.getByRole("radio", { name: /^split$/i }),
     ).toHaveAttribute("aria-checked", "true");
+  });
+
+  // T-6.12 — split mode must show language-aware highlighting (classHighlighter
+  // maps keywords/strings/etc. to `tok-*` classes, which are the testable hook
+  // here). A TS file gets a `tok-keyword` span on "export"; a JSON file picks
+  // up property-name/string classes via the lang-json parser.
+  test("split mode renders language-aware syntax highlighting", async ({
+    authedPage: page,
+  }) => {
+    await openGenerate(page);
+    await setEditorDiff(page, TS_PLUS_JSON_DIFF);
+
+    const tablist = page.getByRole("tablist", { name: /files in this diff/i });
+    await expect(tablist).toBeVisible();
+
+    await page.getByRole("radio", { name: /^split$/i }).click();
+
+    const rightPane = page.locator('[data-testid="split-diff-right"]');
+    await expect(rightPane).toBeVisible();
+
+    // TS file active first → `export` keyword must pick up a tok-keyword span.
+    const keywordSpan = rightPane.locator("span.tok-keyword", {
+      hasText: "export",
+    });
+    await expect(keywordSpan.first()).toBeVisible();
+
+    // Switch to the JSON file → lang-json produces property-name spans.
+    const tabs = tablist.getByRole("tab");
+    await tabs.nth(1).click();
+    const jsonPropertySpan = rightPane.locator(
+      "span.tok-propertyName, span.tok-string",
+    );
+    await expect(jsonPropertySpan.first()).toBeVisible();
   });
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,13 @@
   },
   "dependencies": {
     "@codemirror/commands": "^6",
+    "@codemirror/lang-css": "^6",
+    "@codemirror/lang-html": "^6",
+    "@codemirror/lang-javascript": "^6",
+    "@codemirror/lang-json": "^6",
+    "@codemirror/lang-markdown": "^6",
+    "@codemirror/lang-python": "^6",
+    "@codemirror/lang-yaml": "^6",
     "@codemirror/language": "^6",
     "@codemirror/legacy-modes": "^6",
     "@codemirror/state": "^6",

--- a/apps/web/src/features/generation/components/diff-file-tabs.tsx
+++ b/apps/web/src/features/generation/components/diff-file-tabs.tsx
@@ -163,75 +163,75 @@ export const DiffFileTabs = ({
           onKeyDown={handleKeyDown}
           className="flex items-stretch gap-1 overflow-x-auto whitespace-nowrap px-1 py-1 scrollbar-thin"
         >
-        {tabs.map((tab, idx) => {
-          const Icon = ICON_BY_KIND[tab.changeKind];
-          const iconClass = ICON_CLASS_BY_KIND[tab.changeKind];
-          const isActive = idx === safeActive;
-          const tabId = `${tabListId}-tab-${idx}`;
-          return (
-            <Tooltip key={`${tab.path}-${idx}`}>
-              <TooltipTrigger asChild>
-                <button
-                  ref={(el) => {
-                    buttonsRef.current[idx] = el;
-                  }}
-                  type="button"
-                  role="tab"
-                  id={tabId}
-                  aria-selected={isActive}
-                  aria-controls={panelId}
-                  tabIndex={isActive ? 0 : -1}
-                  onClick={() => onSelect(idx)}
-                  data-kind={tab.changeKind}
-                  className={cn(
-                    "group relative flex shrink-0 cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                    "border border-transparent",
-                    isActive
-                      ? "bg-background text-foreground shadow-sm border-border after:absolute after:inset-x-2 after:-bottom-1 after:h-0.5 after:rounded-full after:bg-primary after:content-['']"
-                      : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
-                  )}
-                >
-                  <Icon
-                    aria-hidden="true"
-                    className={cn("size-3.5 shrink-0", iconClass)}
-                  />
-                  <span
-                    dir="rtl"
-                    className="max-w-[16rem] truncate text-left font-mono"
+          {tabs.map((tab, idx) => {
+            const Icon = ICON_BY_KIND[tab.changeKind];
+            const iconClass = ICON_CLASS_BY_KIND[tab.changeKind];
+            const isActive = idx === safeActive;
+            const tabId = `${tabListId}-tab-${idx}`;
+            return (
+              <Tooltip key={`${tab.path}-${idx}`}>
+                <TooltipTrigger asChild>
+                  <button
+                    ref={(el) => {
+                      buttonsRef.current[idx] = el;
+                    }}
+                    type="button"
+                    role="tab"
+                    id={tabId}
+                    aria-selected={isActive}
+                    aria-controls={panelId}
+                    tabIndex={isActive ? 0 : -1}
+                    onClick={() => onSelect(idx)}
+                    data-kind={tab.changeKind}
+                    className={cn(
+                      "group relative flex shrink-0 cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                      "border border-transparent",
+                      isActive
+                        ? "bg-background text-foreground shadow-sm border-border after:absolute after:inset-x-2 after:-bottom-1 after:h-0.5 after:rounded-full after:bg-primary after:content-['']"
+                        : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
+                    )}
                   >
-                    {tab.path}
-                  </span>
-                  {!tab.isBinary &&
-                  (tab.additions > 0 || tab.deletions > 0) ? (
-                    <span className="flex shrink-0 items-center gap-1 text-[10px] font-medium tabular-nums">
-                      <span className="text-emerald-600 dark:text-emerald-400">
-                        +{tab.additions}
-                      </span>
-                      <span className="text-rose-600 dark:text-rose-400">
-                        -{tab.deletions}
-                      </span>
+                    <Icon
+                      aria-hidden="true"
+                      className={cn("size-3.5 shrink-0", iconClass)}
+                    />
+                    <span
+                      dir="rtl"
+                      className="max-w-[16rem] truncate text-left font-mono"
+                    >
+                      {tab.path}
                     </span>
-                  ) : null}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" align="start">
-                <div className="flex flex-col gap-0.5">
-                  <span className="font-mono text-[11px]">
-                    {tabLabel(tab)}
-                  </span>
-                  <span className="text-muted-foreground">
-                    {tab.changeKind === "added" && t("tabs.added")}
-                    {tab.changeKind === "modified" && t("tabs.modified")}
-                    {tab.changeKind === "deleted" && t("tabs.deleted")}
-                    {tab.changeKind === "renamed" && t("tabs.renamed")}
-                    {tab.changeKind === "binary" && t("tabs.binary")}
-                  </span>
-                </div>
-              </TooltipContent>
-            </Tooltip>
-          );
-        })}
+                    {!tab.isBinary &&
+                    (tab.additions > 0 || tab.deletions > 0) ? (
+                      <span className="flex shrink-0 items-center gap-1 text-[10px] font-medium tabular-nums">
+                        <span className="text-emerald-600 dark:text-emerald-400">
+                          +{tab.additions}
+                        </span>
+                        <span className="text-rose-600 dark:text-rose-400">
+                          -{tab.deletions}
+                        </span>
+                      </span>
+                    ) : null}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" align="start">
+                  <div className="flex flex-col gap-0.5">
+                    <span className="font-mono text-[11px]">
+                      {tabLabel(tab)}
+                    </span>
+                    <span className="text-muted-foreground">
+                      {tab.changeKind === "added" && t("tabs.added")}
+                      {tab.changeKind === "modified" && t("tabs.modified")}
+                      {tab.changeKind === "deleted" && t("tabs.deleted")}
+                      {tab.changeKind === "renamed" && t("tabs.renamed")}
+                      {tab.changeKind === "binary" && t("tabs.binary")}
+                    </span>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
         </div>
       </div>
     </TooltipProvider>

--- a/apps/web/src/features/generation/components/diff-file-tabs.tsx
+++ b/apps/web/src/features/generation/components/diff-file-tabs.tsx
@@ -14,6 +14,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
   type KeyboardEvent,
 } from "react";
 
@@ -66,6 +67,8 @@ export const DiffFileTabs = ({
   const t = useTranslations("generate.diff.viewer");
   const listRef = useRef<HTMLDivElement | null>(null);
   const buttonsRef = useRef<Array<HTMLButtonElement | null>>([]);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
 
   const safeActive = useMemo(() => {
     if (tabs.length === 0) return 0;
@@ -79,6 +82,25 @@ export const DiffFileTabs = ({
     if (!btn) return;
     btn.scrollIntoView({ block: "nearest", inline: "nearest" });
   }, [safeActive]);
+
+  useEffect(() => {
+    const el = listRef.current;
+    if (!el) return;
+    const update = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = el;
+      setCanScrollLeft(scrollLeft > 0);
+      setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 1);
+    };
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    const ro =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(update);
+    ro?.observe(el);
+    return () => {
+      el.removeEventListener("scroll", update);
+      ro?.disconnect();
+    };
+  }, [tabs.length]);
 
   const focusTab = useCallback((index: number) => {
     const btn = buttonsRef.current[index];
@@ -119,15 +141,28 @@ export const DiffFileTabs = ({
 
   return (
     <TooltipProvider delayDuration={200}>
-      <div
-        ref={listRef}
-        id={tabListId}
-        role="tablist"
-        aria-orientation="horizontal"
-        aria-label={t("tabs.listLabel")}
-        onKeyDown={handleKeyDown}
-        className="flex min-w-0 flex-1 items-stretch gap-1 overflow-x-auto whitespace-nowrap px-1 py-1 scrollbar-thin"
-      >
+      <div className="relative min-w-0 flex-1">
+        {canScrollLeft ? (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-muted/60 via-muted/20 to-transparent"
+          />
+        ) : null}
+        {canScrollRight ? (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-muted/60 via-muted/20 to-transparent"
+          />
+        ) : null}
+        <div
+          ref={listRef}
+          id={tabListId}
+          role="tablist"
+          aria-orientation="horizontal"
+          aria-label={t("tabs.listLabel")}
+          onKeyDown={handleKeyDown}
+          className="flex items-stretch gap-1 overflow-x-auto whitespace-nowrap px-1 py-1 scrollbar-thin"
+        >
         {tabs.map((tab, idx) => {
           const Icon = ICON_BY_KIND[tab.changeKind];
           const iconClass = ICON_CLASS_BY_KIND[tab.changeKind];
@@ -149,7 +184,7 @@ export const DiffFileTabs = ({
                   onClick={() => onSelect(idx)}
                   data-kind={tab.changeKind}
                   className={cn(
-                    "group relative flex min-w-0 cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors",
+                    "group relative flex shrink-0 cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors",
                     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                     "border border-transparent",
                     isActive
@@ -197,6 +232,7 @@ export const DiffFileTabs = ({
             </Tooltip>
           );
         })}
+        </div>
       </div>
     </TooltipProvider>
   );

--- a/apps/web/src/features/generation/components/split-diff-pane.tsx
+++ b/apps/web/src/features/generation/components/split-diff-pane.tsx
@@ -15,7 +15,10 @@ import {
 } from "@codemirror/state";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { Decoration, EditorView, lineNumbers } from "@codemirror/view";
-import type { ParsedFile } from "@commit-analyzer/diff-parser";
+import {
+  extensionToLanguageKey,
+  type ParsedFile,
+} from "@commit-analyzer/diff-parser";
 import {
   buildStrippedSplitDocs,
   syncScroll,
@@ -28,10 +31,7 @@ import { useEffect, useMemo, useRef } from "react";
 
 import { cn } from "@/lib/utils";
 
-import {
-  extensionToLanguageKey,
-  loadLanguageExtension,
-} from "../resolve-language";
+import { loadLanguageExtension } from "../resolve-language";
 
 type Props = {
   file: ParsedFile;
@@ -102,12 +102,12 @@ const SIGNAL_CLASS: Record<SplitLineSignal, string | null> = {
 
 function buildLineDecorations(
   doc: string,
-  signals: SplitLineSignal[],
+  signals: readonly SplitLineSignal[],
 ): Extension {
   const builder = new RangeSetBuilder<Decoration>();
   let pos = 0;
-  for (let i = 0; i < signals.length; i += 1) {
-    const cls = SIGNAL_CLASS[signals[i]!];
+  for (const sig of signals) {
+    const cls = SIGNAL_CLASS[sig];
     if (cls) {
       builder.add(pos, pos, Decoration.line({ class: cls }));
     }

--- a/apps/web/src/features/generation/components/split-diff-pane.tsx
+++ b/apps/web/src/features/generation/components/split-diff-pane.tsx
@@ -3,20 +3,35 @@
 import {
   HighlightStyle,
   StreamLanguage,
+  defaultHighlightStyle,
   syntaxHighlighting,
 } from "@codemirror/language";
 import { diff } from "@codemirror/legacy-modes/mode/diff";
-import { Compartment, EditorState } from "@codemirror/state";
+import {
+  Compartment,
+  EditorState,
+  RangeSetBuilder,
+  type Extension,
+} from "@codemirror/state";
 import { oneDark } from "@codemirror/theme-one-dark";
-import { EditorView, lineNumbers } from "@codemirror/view";
+import { Decoration, EditorView, lineNumbers } from "@codemirror/view";
 import type { ParsedFile } from "@commit-analyzer/diff-parser";
-import { buildSplitDocs, syncScroll } from "@commit-analyzer/diff-parser/split-view";
-import { tags as t } from "@lezer/highlight";
+import {
+  buildStrippedSplitDocs,
+  syncScroll,
+  type SplitLineSignal,
+} from "@commit-analyzer/diff-parser/split-view";
+import { classHighlighter, tags as t } from "@lezer/highlight";
 import { FileDigit } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { cn } from "@/lib/utils";
+
+import {
+  extensionToLanguageKey,
+  loadLanguageExtension,
+} from "../resolve-language";
 
 type Props = {
   file: ParsedFile;
@@ -41,23 +56,67 @@ const paneTheme = EditorView.theme({
     color: "var(--muted-foreground)",
   },
   ".cm-line": { padding: "0 8px" },
+  ".cm-line.cm-diff-add": {
+    backgroundColor: "rgba(34, 197, 94, 0.12)",
+  },
+  ".cm-line.cm-diff-del": {
+    backgroundColor: "rgba(244, 63, 94, 0.12)",
+  },
+  ".cm-line.cm-diff-empty": {
+    backgroundColor: "rgba(148, 163, 184, 0.08)",
+  },
+  ".cm-line.cm-diff-header": {
+    color: "var(--muted-foreground)",
+    fontStyle: "italic",
+  },
+  "&.cm-dark .cm-line.cm-diff-add": {
+    backgroundColor: "rgba(34, 197, 94, 0.18)",
+  },
+  "&.cm-dark .cm-line.cm-diff-del": {
+    backgroundColor: "rgba(244, 63, 94, 0.2)",
+  },
+  "&.cm-dark .cm-line.cm-diff-empty": {
+    backgroundColor: "rgba(148, 163, 184, 0.14)",
+  },
 });
 
-const lightHighlight = HighlightStyle.define([
-  { tag: t.inserted, color: "#15803d" },
-  { tag: t.deleted, color: "#b91c1c" },
+const diffAccentLight = HighlightStyle.define([
   { tag: t.heading, color: "#0f172a", fontWeight: "600" },
   { tag: t.meta, color: "#64748b" },
 ]);
 
-const darkHighlight = HighlightStyle.define([
-  { tag: t.inserted, color: "#86efac" },
-  { tag: t.deleted, color: "#fca5a5" },
+const diffAccentDark = HighlightStyle.define([
   { tag: t.heading, color: "#f1f5f9", fontWeight: "600" },
   { tag: t.meta, color: "#94a3b8" },
 ]);
 
 const diffLanguage = StreamLanguage.define(diff);
+
+const SIGNAL_CLASS: Record<SplitLineSignal, string | null> = {
+  context: null,
+  add: "cm-diff-add",
+  del: "cm-diff-del",
+  empty: "cm-diff-empty",
+  header: "cm-diff-header",
+};
+
+function buildLineDecorations(
+  doc: string,
+  signals: SplitLineSignal[],
+): Extension {
+  const builder = new RangeSetBuilder<Decoration>();
+  let pos = 0;
+  for (let i = 0; i < signals.length; i += 1) {
+    const cls = SIGNAL_CLASS[signals[i]!];
+    if (cls) {
+      builder.add(pos, pos, Decoration.line({ class: cls }));
+    }
+    const nl = doc.indexOf("\n", pos);
+    if (nl < 0) break;
+    pos = nl + 1;
+  }
+  return EditorView.decorations.of(builder.finish());
+}
 
 export default function SplitDiffPane({
   file,
@@ -74,13 +133,32 @@ export default function SplitDiffPane({
   const themeCompartmentRight = useRef(new Compartment());
   const ariaCompartmentLeft = useRef(new Compartment());
   const ariaCompartmentRight = useRef(new Compartment());
+  const langCompartmentLeft = useRef(new Compartment());
+  const langCompartmentRight = useRef(new Compartment());
+  const decoCompartmentLeft = useRef(new Compartment());
+  const decoCompartmentRight = useRef(new Compartment());
 
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
 
-  const { leftDoc, rightDoc } = file.isBinary
-    ? { leftDoc: binaryPlaceholder, rightDoc: binaryPlaceholder }
-    : buildSplitDocs(file);
+  const stripped = useMemo(() => {
+    if (file.isBinary) {
+      return {
+        leftDoc: binaryPlaceholder,
+        rightDoc: binaryPlaceholder,
+        lineCount: 0,
+        leftSignals: [] as SplitLineSignal[],
+        rightSignals: [] as SplitLineSignal[],
+      };
+    }
+    return buildStrippedSplitDocs(file);
+  }, [file, binaryPlaceholder]);
+
+  const { leftDoc, rightDoc, leftSignals, rightSignals } = stripped;
+  const languageKey = useMemo(
+    () => (file.isBinary ? null : extensionToLanguageKey(file.path)),
+    [file.isBinary, file.path],
+  );
 
   useEffect(() => {
     const leftParent = leftRef.current;
@@ -89,20 +167,29 @@ export default function SplitDiffPane({
 
     const themeExtFor = (dark: boolean) =>
       dark
-        ? [oneDark, syntaxHighlighting(darkHighlight)]
-        : [syntaxHighlighting(lightHighlight)];
+        ? [oneDark, syntaxHighlighting(diffAccentDark)]
+        : [syntaxHighlighting(diffAccentLight)];
     const ariaExtFor = (label: string) =>
       EditorView.contentAttributes.of({ "aria-label": label });
+
+    const commonExtensions = [
+      lineNumbers(),
+      paneTheme,
+      syntaxHighlighting(defaultHighlightStyle),
+      syntaxHighlighting(classHighlighter),
+      EditorState.readOnly.of(true),
+      EditorView.editable.of(false),
+      EditorView.lineWrapping,
+    ];
 
     const leftState = EditorState.create({
       doc: leftDoc,
       extensions: [
-        lineNumbers(),
-        diffLanguage,
-        paneTheme,
-        EditorState.readOnly.of(true),
-        EditorView.editable.of(false),
-        EditorView.lineWrapping,
+        ...commonExtensions,
+        langCompartmentLeft.current.of(diffLanguage),
+        decoCompartmentLeft.current.of(
+          buildLineDecorations(leftDoc, leftSignals),
+        ),
         themeCompartmentLeft.current.of(themeExtFor(isDark)),
         ariaCompartmentLeft.current.of(ariaExtFor(leftAriaLabel)),
       ],
@@ -110,12 +197,11 @@ export default function SplitDiffPane({
     const rightState = EditorState.create({
       doc: rightDoc,
       extensions: [
-        lineNumbers(),
-        diffLanguage,
-        paneTheme,
-        EditorState.readOnly.of(true),
-        EditorView.editable.of(false),
-        EditorView.lineWrapping,
+        ...commonExtensions,
+        langCompartmentRight.current.of(diffLanguage),
+        decoCompartmentRight.current.of(
+          buildLineDecorations(rightDoc, rightSignals),
+        ),
         themeCompartmentRight.current.of(themeExtFor(isDark)),
         ariaCompartmentRight.current.of(ariaExtFor(rightAriaLabel)),
       ],
@@ -144,18 +230,66 @@ export default function SplitDiffPane({
     const currentLeft = lv.state.doc.toString();
     const currentRight = rv.state.doc.toString();
     if (currentLeft !== leftDoc) {
-      lv.dispatch({ changes: { from: 0, to: currentLeft.length, insert: leftDoc } });
+      lv.dispatch({
+        changes: { from: 0, to: currentLeft.length, insert: leftDoc },
+      });
     }
     if (currentRight !== rightDoc) {
-      rv.dispatch({ changes: { from: 0, to: currentRight.length, insert: rightDoc } });
+      rv.dispatch({
+        changes: { from: 0, to: currentRight.length, insert: rightDoc },
+      });
     }
-  }, [leftDoc, rightDoc]);
+    lv.dispatch({
+      effects: decoCompartmentLeft.current.reconfigure(
+        buildLineDecorations(leftDoc, leftSignals),
+      ),
+    });
+    rv.dispatch({
+      effects: decoCompartmentRight.current.reconfigure(
+        buildLineDecorations(rightDoc, rightSignals),
+      ),
+    });
+  }, [leftDoc, rightDoc, leftSignals, rightSignals]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const lv = leftViewRef.current;
+    const rv = rightViewRef.current;
+    if (!lv || !rv) return;
+    if (!languageKey) {
+      lv.dispatch({
+        effects: langCompartmentLeft.current.reconfigure(diffLanguage),
+      });
+      rv.dispatch({
+        effects: langCompartmentRight.current.reconfigure(diffLanguage),
+      });
+      return;
+    }
+    void loadLanguageExtension(languageKey).then((ext) => {
+      if (cancelled) return;
+      const lvNow = leftViewRef.current;
+      const rvNow = rightViewRef.current;
+      if (lvNow) {
+        lvNow.dispatch({
+          effects: langCompartmentLeft.current.reconfigure(ext),
+        });
+      }
+      if (rvNow) {
+        rvNow.dispatch({
+          effects: langCompartmentRight.current.reconfigure(ext),
+        });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [languageKey]);
 
   useEffect(() => {
     const themeExtFor = (dark: boolean) =>
       dark
-        ? [oneDark, syntaxHighlighting(darkHighlight)]
-        : [syntaxHighlighting(lightHighlight)];
+        ? [oneDark, syntaxHighlighting(diffAccentDark)]
+        : [syntaxHighlighting(diffAccentLight)];
     const lv = leftViewRef.current;
     const rv = rightViewRef.current;
     if (lv) {
@@ -210,11 +344,13 @@ export default function SplitDiffPane({
     <div className="grid grid-cols-2 divide-x overflow-hidden rounded-b-lg border border-t-0 bg-card">
       <div
         ref={leftRef}
-        className={cn("min-w-0 bg-rose-50/30 dark:bg-rose-950/20")}
+        data-testid="split-diff-left"
+        className={cn("min-w-0 bg-rose-50/20 dark:bg-rose-950/10")}
       />
       <div
         ref={rightRef}
-        className={cn("min-w-0 bg-emerald-50/30 dark:bg-emerald-950/20")}
+        data-testid="split-diff-right"
+        className={cn("min-w-0 bg-emerald-50/20 dark:bg-emerald-950/10")}
       />
     </div>
   );

--- a/apps/web/src/features/generation/resolve-language.ts
+++ b/apps/web/src/features/generation/resolve-language.ts
@@ -1,0 +1,61 @@
+import type { Extension } from "@codemirror/state";
+import {
+  extensionToLanguageKey,
+  type LanguageKey,
+} from "@commit-analyzer/diff-parser";
+
+export { extensionToLanguageKey };
+export type { LanguageKey };
+
+const cache = new Map<LanguageKey, Promise<Extension>>();
+
+export function loadLanguageExtension(key: LanguageKey): Promise<Extension> {
+  let pending = cache.get(key);
+  if (pending) return pending;
+  pending = (async (): Promise<Extension> => {
+    switch (key) {
+      case "typescript": {
+        const m = await import("@codemirror/lang-javascript");
+        return m.javascript({ typescript: true });
+      }
+      case "tsx": {
+        const m = await import("@codemirror/lang-javascript");
+        return m.javascript({ typescript: true, jsx: true });
+      }
+      case "javascript": {
+        const m = await import("@codemirror/lang-javascript");
+        return m.javascript();
+      }
+      case "jsx": {
+        const m = await import("@codemirror/lang-javascript");
+        return m.javascript({ jsx: true });
+      }
+      case "json": {
+        const m = await import("@codemirror/lang-json");
+        return m.json();
+      }
+      case "python": {
+        const m = await import("@codemirror/lang-python");
+        return m.python();
+      }
+      case "markdown": {
+        const m = await import("@codemirror/lang-markdown");
+        return m.markdown();
+      }
+      case "css": {
+        const m = await import("@codemirror/lang-css");
+        return m.css();
+      }
+      case "html": {
+        const m = await import("@codemirror/lang-html");
+        return m.html();
+      }
+      case "yaml": {
+        const m = await import("@codemirror/lang-yaml");
+        return m.yaml();
+      }
+    }
+  })();
+  cache.set(key, pending);
+  return pending;
+}

--- a/apps/web/src/features/generation/resolve-language.ts
+++ b/apps/web/src/features/generation/resolve-language.ts
@@ -1,11 +1,5 @@
 import type { Extension } from "@codemirror/state";
-import {
-  extensionToLanguageKey,
-  type LanguageKey,
-} from "@commit-analyzer/diff-parser";
-
-export { extensionToLanguageKey };
-export type { LanguageKey };
+import type { LanguageKey } from "@commit-analyzer/diff-parser";
 
 const cache = new Map<LanguageKey, Promise<Extension>>();
 

--- a/packages/diff-parser/src/index.ts
+++ b/packages/diff-parser/src/index.ts
@@ -8,6 +8,12 @@ export {
   type DiffValidationResult,
 } from "./validate.js";
 
+export {
+  extensionToLanguageKey,
+  LANGUAGE_KEYS,
+  type LanguageKey,
+} from "./language-key.js";
+
 export type ParsedHunk = {
   header: string;
   lines: string[];

--- a/packages/diff-parser/src/language-key.spec.ts
+++ b/packages/diff-parser/src/language-key.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { extensionToLanguageKey } from "./language-key.js";
+
+describe("extensionToLanguageKey", () => {
+  it.each([
+    ["src/auth.ts", "typescript"],
+    ["src/auth.mts", "typescript"],
+    ["src/auth.cts", "typescript"],
+    ["src/page.tsx", "tsx"],
+    ["src/util.js", "javascript"],
+    ["src/util.mjs", "javascript"],
+    ["src/util.cjs", "javascript"],
+    ["src/page.jsx", "jsx"],
+    ["tsconfig.json", "json"],
+    ["eslint.jsonc", "json"],
+    ["scripts/build.py", "python"],
+    ["README.md", "markdown"],
+    ["styles.css", "css"],
+    ["index.html", "html"],
+    ["legacy.htm", "html"],
+    ["pnpm-workspace.yaml", "yaml"],
+    ["ci/workflow.yml", "yaml"],
+  ] as const)("maps %s → %s", (path, key) => {
+    expect(extensionToLanguageKey(path)).toBe(key);
+  });
+
+  it("is case-insensitive on the extension", () => {
+    expect(extensionToLanguageKey("Page.TSX")).toBe("tsx");
+    expect(extensionToLanguageKey("app.JSON")).toBe("json");
+  });
+
+  it("returns null for unknown extensions", () => {
+    expect(extensionToLanguageKey("bin/program.exe")).toBeNull();
+    expect(extensionToLanguageKey("Dockerfile.prod")).toBeNull();
+  });
+
+  it("returns null when the path has no extension", () => {
+    expect(extensionToLanguageKey("Dockerfile")).toBeNull();
+    expect(extensionToLanguageKey("LICENSE")).toBeNull();
+    expect(extensionToLanguageKey("")).toBeNull();
+  });
+
+  it("treats dotfiles as having no extension", () => {
+    expect(extensionToLanguageKey(".env")).toBeNull();
+    expect(extensionToLanguageKey(".gitignore")).toBeNull();
+  });
+
+  it("uses only the filename portion, not the directory", () => {
+    expect(extensionToLanguageKey("src.ts/README")).toBeNull();
+    expect(extensionToLanguageKey("deep/nested/path/util.py")).toBe("python");
+  });
+});

--- a/packages/diff-parser/src/language-key.ts
+++ b/packages/diff-parser/src/language-key.ts
@@ -1,0 +1,45 @@
+export const LANGUAGE_KEYS = [
+  "typescript",
+  "tsx",
+  "javascript",
+  "jsx",
+  "json",
+  "python",
+  "markdown",
+  "css",
+  "html",
+  "yaml",
+] as const;
+
+export type LanguageKey = (typeof LANGUAGE_KEYS)[number];
+
+const EXTENSION_MAP: Readonly<Record<string, LanguageKey>> = {
+  ts: "typescript",
+  mts: "typescript",
+  cts: "typescript",
+  tsx: "tsx",
+  js: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  jsx: "jsx",
+  json: "json",
+  jsonc: "json",
+  py: "python",
+  md: "markdown",
+  markdown: "markdown",
+  css: "css",
+  html: "html",
+  htm: "html",
+  yaml: "yaml",
+  yml: "yaml",
+};
+
+export function extensionToLanguageKey(path: string): LanguageKey | null {
+  if (!path) return null;
+  const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  const base = slash >= 0 ? path.slice(slash + 1) : path;
+  const dot = base.lastIndexOf(".");
+  if (dot <= 0) return null;
+  const ext = base.slice(dot + 1).toLowerCase();
+  return EXTENSION_MAP[ext] ?? null;
+}

--- a/packages/diff-parser/src/split-view.spec.ts
+++ b/packages/diff-parser/src/split-view.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildSplitDocs,
+  buildStrippedSplitDocs,
   syncScroll,
   type ScrollSyncTarget,
 } from "./split-view.js";
@@ -107,6 +108,121 @@ describe("buildSplitDocs", () => {
     );
     expect(docs.leftDoc).toBe("@@ -1,2 +1,2 @@\n---old yaml marker");
     expect(docs.rightDoc).toBe("@@ -1,2 +1,2 @@\n+++new yaml marker");
+  });
+});
+
+describe("buildStrippedSplitDocs", () => {
+  it("strips +/-/space prefix so content is valid source", () => {
+    const docs = buildStrippedSplitDocs(
+      file([
+        {
+          header: "@@ -1,2 +1,2 @@",
+          lines: [" ctx", "-oldline", "+newline"],
+        },
+      ]),
+    );
+    expect(docs.leftDoc.split("\n")).toEqual([
+      "@@ -1,2 +1,2 @@",
+      "ctx",
+      "oldline",
+    ]);
+    expect(docs.rightDoc.split("\n")).toEqual([
+      "@@ -1,2 +1,2 @@",
+      "ctx",
+      "newline",
+    ]);
+    expect(docs.leftSignals).toEqual(["header", "context", "del"]);
+    expect(docs.rightSignals).toEqual(["header", "context", "add"]);
+  });
+
+  it("emits empty padding lines with empty signal on the shorter side", () => {
+    const docs = buildStrippedSplitDocs(
+      file([
+        {
+          header: "@@ -1,1 +1,3 @@",
+          lines: ["-only-del", "+n1", "+n2", "+n3"],
+        },
+      ]),
+    );
+    expect(docs.leftDoc.split("\n")).toEqual([
+      "@@ -1,1 +1,3 @@",
+      "only-del",
+      "",
+      "",
+    ]);
+    expect(docs.rightDoc.split("\n")).toEqual([
+      "@@ -1,1 +1,3 @@",
+      "n1",
+      "n2",
+      "n3",
+    ]);
+    expect(docs.leftSignals).toEqual(["header", "del", "empty", "empty"]);
+    expect(docs.rightSignals).toEqual(["header", "add", "add", "add"]);
+    expect(docs.lineCount).toBe(4);
+  });
+
+  it("keeps left and right line counts aligned across mixed blocks", () => {
+    const docs = buildStrippedSplitDocs(
+      file([
+        {
+          header: "@@ -1,4 +1,4 @@",
+          lines: [" ctx-a", "-del-b", "+add-b", " ctx-c"],
+        },
+      ]),
+    );
+    const left = docs.leftDoc.split("\n");
+    const right = docs.rightDoc.split("\n");
+    expect(left.length).toBe(right.length);
+    expect(left).toEqual(["@@ -1,4 +1,4 @@", "ctx-a", "del-b", "ctx-c"]);
+    expect(right).toEqual(["@@ -1,4 +1,4 @@", "ctx-a", "add-b", "ctx-c"]);
+    expect(docs.leftSignals.length).toBe(docs.rightSignals.length);
+  });
+
+  it("pads the right side when del count exceeds add count", () => {
+    const docs = buildStrippedSplitDocs(
+      file([
+        {
+          header: "@@ -1,3 +1,1 @@",
+          lines: ["-d1", "-d2", "-d3", "+n1"],
+        },
+      ]),
+    );
+    expect(docs.rightDoc.split("\n")).toEqual([
+      "@@ -1,3 +1,1 @@",
+      "n1",
+      "",
+      "",
+    ]);
+    expect(docs.rightSignals).toEqual(["header", "add", "empty", "empty"]);
+  });
+
+  it("leaves lines that don't start with +/-/space unchanged (no-newline marker)", () => {
+    const docs = buildStrippedSplitDocs(
+      file([
+        {
+          header: "@@ -1,2 +1,2 @@",
+          lines: [" ctx", "\\ No newline at end of file"],
+        },
+      ]),
+    );
+    expect(docs.leftDoc.split("\n")).toEqual([
+      "@@ -1,2 +1,2 @@",
+      "ctx",
+      "\\ No newline at end of file",
+    ]);
+  });
+
+  it("preserves content that happens to start with ++/-- markers", () => {
+    const docs = buildStrippedSplitDocs(
+      file([
+        {
+          header: "@@ -1,2 +1,2 @@",
+          lines: ["---yaml-del", "+++yaml-add"],
+        },
+      ]),
+    );
+    expect(docs.leftDoc).toBe("@@ -1,2 +1,2 @@\n--yaml-del");
+    expect(docs.rightDoc).toBe("@@ -1,2 +1,2 @@\n++yaml-add");
   });
 });
 

--- a/packages/diff-parser/src/split-view.spec.ts
+++ b/packages/diff-parser/src/split-view.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  buildSplitDocs,
   buildStrippedSplitDocs,
   syncScroll,
   type ScrollSyncTarget,
@@ -20,98 +19,17 @@ function file(hunks: { header: string; lines: string[] }[]): ParsedFile {
   };
 }
 
-describe("buildSplitDocs", () => {
-  it("aligns context lines on both sides", () => {
-    const docs = buildSplitDocs(
-      file([
-        {
-          header: "@@ -1,3 +1,3 @@",
-          lines: [" a", " b", " c"],
-        },
-      ]),
-    );
-    expect(docs.leftDoc.split("\n")).toEqual([
-      "@@ -1,3 +1,3 @@",
-      " a",
-      " b",
-      " c",
-    ]);
-    expect(docs.rightDoc).toBe(docs.leftDoc);
-    expect(docs.lineCount).toBe(4);
-  });
-
-  it("pairs consecutive - and + lines", () => {
-    const docs = buildSplitDocs(
-      file([
-        {
-          header: "@@ -1,2 +1,2 @@",
-          lines: ["-old1", "-old2", "+new1", "+new2"],
-        },
-      ]),
-    );
-    const left = docs.leftDoc.split("\n");
-    const right = docs.rightDoc.split("\n");
-    expect(left).toEqual(["@@ -1,2 +1,2 @@", "-old1", "-old2"]);
-    expect(right).toEqual(["@@ -1,2 +1,2 @@", "+new1", "+new2"]);
-  });
-
-  it("pads the shorter side with empty lines when + count differs from -", () => {
-    const docs = buildSplitDocs(
-      file([
-        {
-          header: "@@ -1,1 +1,3 @@",
-          lines: ["-only-del", "+new1", "+new2", "+new3"],
-        },
-      ]),
-    );
-    const left = docs.leftDoc.split("\n");
-    const right = docs.rightDoc.split("\n");
-    expect(left).toEqual(["@@ -1,1 +1,3 @@", "-only-del", "", ""]);
-    expect(right).toEqual(["@@ -1,1 +1,3 @@", "+new1", "+new2", "+new3"]);
-    expect(left.length).toBe(right.length);
-  });
-
-  it("handles mixed context and change blocks, keeping alignment", () => {
-    const docs = buildSplitDocs(
-      file([
-        {
-          header: "@@ -1,4 +1,4 @@",
-          lines: [" ctx-a", "-del-b", "+add-b", " ctx-c"],
-        },
-      ]),
-    );
-    const left = docs.leftDoc.split("\n");
-    const right = docs.rightDoc.split("\n");
-    expect(left).toEqual(["@@ -1,4 +1,4 @@", " ctx-a", "-del-b", " ctx-c"]);
-    expect(right).toEqual(["@@ -1,4 +1,4 @@", " ctx-a", "+add-b", " ctx-c"]);
-  });
-
+describe("buildStrippedSplitDocs", () => {
   it("returns empty docs for files with no hunks (binary)", () => {
-    const docs = buildSplitDocs(file([]));
+    const docs = buildStrippedSplitDocs(file([]));
     expect(docs.leftDoc).toBe("");
     expect(docs.rightDoc).toBe("");
     expect(docs.lineCount).toBe(0);
+    expect(docs.leftSignals).toEqual([]);
+    expect(docs.rightSignals).toEqual([]);
   });
 
-  it("preserves +++/--- content inside hunk bodies (real deletions/additions)", () => {
-    // parseFileSection only emits @@-delimited bodies into hunk.lines, so
-    // `--- a/x` / `+++ b/x` never appear here — but legitimate patches can
-    // delete or add lines whose own content starts with "---" or "+++"
-    // (e.g. removing a YAML document separator). Those must be kept.
-    const docs = buildSplitDocs(
-      file([
-        {
-          header: "@@ -1,2 +1,2 @@",
-          lines: ["---old yaml marker", "+++new yaml marker"],
-        },
-      ]),
-    );
-    expect(docs.leftDoc).toBe("@@ -1,2 +1,2 @@\n---old yaml marker");
-    expect(docs.rightDoc).toBe("@@ -1,2 +1,2 @@\n+++new yaml marker");
-  });
-});
 
-describe("buildStrippedSplitDocs", () => {
   it("strips +/-/space prefix so content is valid source", () => {
     const docs = buildStrippedSplitDocs(
       file([

--- a/packages/diff-parser/src/split-view.ts
+++ b/packages/diff-parser/src/split-view.ts
@@ -7,12 +7,6 @@ export type SplitLineSignal =
   | "empty"
   | "header";
 
-type SplitDocs = {
-  leftDoc: string;
-  rightDoc: string;
-  lineCount: number;
-};
-
 type StrippedSplitDocs = {
   leftDoc: string;
   rightDoc: string;
@@ -91,46 +85,6 @@ export function buildStrippedSplitDocs(file: ParsedFile): StrippedSplitDocs {
   };
 }
 
-export function buildSplitDocs(file: ParsedFile): SplitDocs {
-  const left: string[] = [];
-  const right: string[] = [];
-  let dels: string[] = [];
-  let adds: string[] = [];
-
-  const flush = () => {
-    const n = Math.max(dels.length, adds.length);
-    for (let i = 0; i < n; i += 1) {
-      left.push(i < dels.length ? dels[i]! : "");
-      right.push(i < adds.length ? adds[i]! : "");
-    }
-    dels = [];
-    adds = [];
-  };
-
-  for (const hunk of file.hunks) {
-    flush();
-    left.push(hunk.header);
-    right.push(hunk.header);
-    for (const line of hunk.lines) {
-      if (line.startsWith("-")) {
-        dels.push(line);
-      } else if (line.startsWith("+")) {
-        adds.push(line);
-      } else {
-        flush();
-        left.push(line);
-        right.push(line);
-      }
-    }
-    flush();
-  }
-
-  return {
-    leftDoc: left.join("\n"),
-    rightDoc: right.join("\n"),
-    lineCount: left.length,
-  };
-}
 
 export type ScrollSyncTarget = {
   scrollTop: number;

--- a/packages/diff-parser/src/split-view.ts
+++ b/packages/diff-parser/src/split-view.ts
@@ -1,10 +1,95 @@
 import type { ParsedFile } from "./index.js";
 
+export type SplitLineSignal =
+  | "context"
+  | "add"
+  | "del"
+  | "empty"
+  | "header";
+
 type SplitDocs = {
   leftDoc: string;
   rightDoc: string;
   lineCount: number;
 };
+
+type StrippedSplitDocs = {
+  leftDoc: string;
+  rightDoc: string;
+  lineCount: number;
+  leftSignals: SplitLineSignal[];
+  rightSignals: SplitLineSignal[];
+};
+
+function stripPrefix(line: string): string {
+  const ch = line.charCodeAt(0);
+  if (ch === 0x2b /* + */ || ch === 0x2d /* - */ || ch === 0x20 /* space */) {
+    return line.slice(1);
+  }
+  return line;
+}
+
+export function buildStrippedSplitDocs(file: ParsedFile): StrippedSplitDocs {
+  const leftLines: string[] = [];
+  const rightLines: string[] = [];
+  const leftSignals: SplitLineSignal[] = [];
+  const rightSignals: SplitLineSignal[] = [];
+  let dels: string[] = [];
+  let adds: string[] = [];
+
+  const flush = () => {
+    const n = Math.max(dels.length, adds.length);
+    for (let i = 0; i < n; i += 1) {
+      if (i < dels.length) {
+        leftLines.push(stripPrefix(dels[i]!));
+        leftSignals.push("del");
+      } else {
+        leftLines.push("");
+        leftSignals.push("empty");
+      }
+      if (i < adds.length) {
+        rightLines.push(stripPrefix(adds[i]!));
+        rightSignals.push("add");
+      } else {
+        rightLines.push("");
+        rightSignals.push("empty");
+      }
+    }
+    dels = [];
+    adds = [];
+  };
+
+  for (const hunk of file.hunks) {
+    flush();
+    leftLines.push(hunk.header);
+    rightLines.push(hunk.header);
+    leftSignals.push("header");
+    rightSignals.push("header");
+    for (const line of hunk.lines) {
+      if (line.startsWith("-")) {
+        dels.push(line);
+      } else if (line.startsWith("+")) {
+        adds.push(line);
+      } else {
+        flush();
+        const stripped = stripPrefix(line);
+        leftLines.push(stripped);
+        rightLines.push(stripped);
+        leftSignals.push("context");
+        rightSignals.push("context");
+      }
+    }
+    flush();
+  }
+
+  return {
+    leftDoc: leftLines.join("\n"),
+    rightDoc: rightLines.join("\n"),
+    lineCount: leftLines.length,
+    leftSignals,
+    rightSignals,
+  };
+}
 
 export function buildSplitDocs(file: ParsedFile): SplitDocs {
   const left: string[] = [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,27 @@ importers:
       '@codemirror/commands':
         specifier: ^6
         version: 6.10.3
+      '@codemirror/lang-css':
+        specifier: ^6
+        version: 6.3.1
+      '@codemirror/lang-html':
+        specifier: ^6
+        version: 6.4.11
+      '@codemirror/lang-javascript':
+        specifier: ^6
+        version: 6.2.5
+      '@codemirror/lang-json':
+        specifier: ^6
+        version: 6.0.2
+      '@codemirror/lang-markdown':
+        specifier: ^6
+        version: 6.5.0
+      '@codemirror/lang-python':
+        specifier: ^6
+        version: 6.2.1
+      '@codemirror/lang-yaml':
+        specifier: ^6
+        version: 6.1.3
       '@codemirror/language':
         specifier: ^6
         version: 6.12.3
@@ -577,14 +598,41 @@ packages:
     resolution: {integrity: sha512-sAWO3D8PFP6pBXdxxW93SQi/KQqqhE2AAHo3AgWfdtJXwO6bfK6/wUN81XnOZk0qRC6vHzUEKhjwVD9dtDWvxg==}
     engines: {node: '>=18.18'}
 
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
+
   '@codemirror/commands@6.10.3':
     resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
+
+  '@codemirror/lang-python@6.2.1':
+    resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
+
+  '@codemirror/lang-yaml@6.1.3':
+    resolution: {integrity: sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==}
 
   '@codemirror/language@6.12.3':
     resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
 
   '@codemirror/legacy-modes@6.5.2':
     resolution: {integrity: sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==}
+
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
 
   '@codemirror/state@6.6.0':
     resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
@@ -1175,11 +1223,32 @@ packages:
   '@lezer/common@1.5.2':
     resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
 
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
 
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
   '@lezer/lr@1.4.10':
     resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/markdown@1.6.3':
+    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
+
+  '@lezer/python@1.1.18':
+    resolution: {integrity: sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==}
+
+  '@lezer/yaml@1.0.4':
+    resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -6066,12 +6135,82 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  '@codemirror/autocomplete@6.20.1':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
   '@codemirror/commands@6.10.3':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-markdown@6.5.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.6.3
+
+  '@codemirror/lang-python@6.2.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/python': 1.1.18
+
+  '@codemirror/lang-yaml@6.1.3':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      '@lezer/yaml': 1.0.4
 
   '@codemirror/language@6.12.3':
     dependencies:
@@ -6085,6 +6224,12 @@ snapshots:
   '@codemirror/legacy-modes@6.5.2':
     dependencies:
       '@codemirror/language': 6.12.3
+
+  '@codemirror/lint@6.9.5':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      crelt: 1.0.6
 
   '@codemirror/state@6.6.0':
     dependencies:
@@ -6524,13 +6669,54 @@ snapshots:
 
   '@lezer/common@1.5.2': {}
 
+  '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lezer/highlight@1.2.3':
     dependencies:
       '@lezer/common': 1.5.2
 
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lezer/lr@1.4.10':
     dependencies:
       '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.6.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+
+  '@lezer/python@1.1.18':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/yaml@1.0.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lukeed/csprng@1.1.0': {}
 


### PR DESCRIPTION
## Summary
- tabs no longer cramp past ~6 files — buttons get `shrink-0`, container scrolls horizontally, fade masks appear on overflowing edges.
- split-mode panes now get language-aware syntax highlighting: `+`/`-`/context prefix stripped, extension → CM lang pack loaded via dynamic `import()` (cached). Add/del/context/empty/header line signal moved to per-line background tint via `Decoration.line`.
- unified mode is untouched (still editable, still uses the diff `StreamLanguage`).
- langs covered: ts, tsx, js, jsx, json, python, markdown, css, html, yaml. Unknown extensions fall back to today's diff stream language.
- `classHighlighter` is layered alongside `defaultHighlightStyle` / `oneDark` so tokens carry stable `tok-*` classes for e2e.

## Tests
- `split-view.spec.ts` — new `buildStrippedSplitDocs` block covers: prefix strip (context/add/del), empty padding alignment, left/right symmetry, `\ No newline` passthrough, `+++`/`---` content preservation.
- `language-key.spec.ts` — extension → language-key resolver (positive cases, case-insensitivity, unknown, dotfile, path with no extension, nested paths).
- `generate.spec.ts` — new split-mode test pastes a TS+JSON fixture, switches to split, asserts `span.tok-keyword` on `export` (TS pane) and a property/string span on the JSON pane.

Closes #225