### PR TITLE
feat(T-5.3): ts-rest client + sse consumer

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -31,7 +31,11 @@
     "vitest": "^2"
   },
   "dependencies": {
+    "@commit-analyzer/contracts": "workspace:*",
     "@commit-analyzer/diff-parser": "workspace:*",
-    "commander": "^12.1.0"
+    "@ts-rest/core": "^3.51.0",
+    "commander": "^12.1.0",
+    "eventsource-parser": "^3.0.8",
+    "zod": "^3.23.8"
   }
 }

--- a/apps/cli/src/lib/api-client.spec.ts
+++ b/apps/cli/src/lib/api-client.spec.ts
@@ -1,0 +1,379 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createApiClient, listPolicies, streamGenerate, whoami } from "./api-client.js";
+import {
+  AbortError,
+  ApiResponseError,
+  AuthError,
+  NetworkError,
+  StreamError,
+  TimeoutError,
+} from "./api-errors.js";
+
+type FetchFn = typeof globalThis.fetch;
+
+const VALID_DIFF = [
+  "diff --git a/a.ts b/a.ts",
+  "index 1..2 100644",
+  "--- a/a.ts",
+  "+++ b/a.ts",
+  "@@ -1 +1 @@",
+  "-a",
+  "+b",
+  "",
+].join("\n");
+
+const REQUEST = {
+  diff: VALID_DIFF,
+  provider: "openai" as const,
+  model: "gpt-4o-mini",
+};
+
+const SUGGESTION_PAYLOAD = {
+  index: 0,
+  type: "feat",
+  scope: null,
+  subject: "add a",
+  body: null,
+  footer: null,
+  compliant: true,
+  validation: null,
+};
+
+const DONE_PAYLOAD = { historyId: null, tokensUsed: 42 };
+
+function sseFrame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+interface StreamHandle {
+  response: Response;
+  close: () => void;
+  error: (err: Error) => void;
+}
+
+function makeStreamResponse(chunks: string[]): StreamHandle {
+  let close!: () => void;
+  let error!: (err: Error) => void;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const c of chunks) controller.enqueue(encoder.encode(c));
+      close = () => controller.close();
+      error = (err: Error) => controller.error(err);
+    },
+  });
+  const response = new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+  return { response, close, error };
+}
+
+function makeJsonErrorResponse(status: number, code: string, message: string): Response {
+  return new Response(JSON.stringify({ error: { code, message } }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function userResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      id: "00000000-0000-0000-0000-000000000000",
+      email: null,
+      name: null,
+      avatarUrl: null,
+      createdAt: new Date().toISOString(),
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+type FetchInput = Parameters<FetchFn>[0];
+type FetchInit = Parameters<FetchFn>[1];
+type FetchImpl = (input: FetchInput, init: FetchInit) => Promise<Response> | Response;
+
+function fakeFetch(impl: FetchImpl): FetchFn {
+  return vi.fn((input: FetchInput, init: FetchInit) => Promise.resolve(impl(input, init)));
+}
+
+function inputUrl(input: FetchInput): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return (input as { url: string }).url;
+}
+
+function pendingFetchUntilAbort(): FetchFn {
+  return fakeFetch(
+    (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      }),
+  );
+}
+
+describe("createApiClient", () => {
+  let originalFetch: FetchFn;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it("returns a ts-rest client that whoami can drive", async () => {
+    let captured: { url: string; headers: Headers } | null = null;
+    globalThis.fetch = fakeFetch((input, init) => {
+      captured = { url: inputUrl(input), headers: new Headers(init?.headers) };
+      return userResponse();
+    });
+    const client = createApiClient({
+      apiUrl: "https://example.test",
+      apiKey: "git_secret",
+    });
+    const user = await whoami(client);
+    expect(user.id).toBe("00000000-0000-0000-0000-000000000000");
+    expect(captured!.url).toContain("/me");
+    expect(captured!.headers.get("x-api-key")).toBe("git_secret");
+  });
+
+  it("listPolicies hits the /repos/:repoId/policies route", async () => {
+    let url: string | null = null;
+    globalThis.fetch = fakeFetch((input) => {
+      url = inputUrl(input);
+      return new Response(JSON.stringify({ items: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const client = createApiClient({
+      apiUrl: "https://example.test",
+      apiKey: "git_x",
+    });
+    const items = await listPolicies(client, "11111111-1111-1111-1111-111111111111");
+    expect(items).toEqual([]);
+    expect(url).toContain("/repos/11111111-1111-1111-1111-111111111111/policies");
+  });
+
+  it("translates fetch TypeError into NetworkError", async () => {
+    globalThis.fetch = fakeFetch(() => {
+      throw new TypeError("connect ECONNREFUSED");
+    });
+    const client = createApiClient({
+      apiUrl: "https://example.test",
+      apiKey: "git_x",
+    });
+    await expect(whoami(client)).rejects.toBeInstanceOf(NetworkError);
+  });
+
+  it("translates request timeout into TimeoutError", async () => {
+    globalThis.fetch = pendingFetchUntilAbort();
+    const client = createApiClient({
+      apiUrl: "https://example.test",
+      apiKey: "git_x",
+      requestTimeoutMs: 25,
+    });
+    await expect(whoami(client)).rejects.toBeInstanceOf(TimeoutError);
+  });
+
+  it("translates external abort into AbortError", async () => {
+    globalThis.fetch = pendingFetchUntilAbort();
+    const ctrl = new AbortController();
+    const client = createApiClient({
+      apiUrl: "https://example.test",
+      apiKey: "git_x",
+    });
+    const promise = whoami(client, { signal: ctrl.signal });
+    ctrl.abort();
+    await expect(promise).rejects.toBeInstanceOf(AbortError);
+  });
+
+  it("maps 401 on /me to AuthError", async () => {
+    globalThis.fetch = fakeFetch(
+      () =>
+        new Response(JSON.stringify({ error: { code: "UNAUTHORIZED", message: "no key" } }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const client = createApiClient({
+      apiUrl: "https://example.test",
+      apiKey: "git_bad",
+    });
+    const err = await whoami(client).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AuthError);
+    expect((err as AuthError).status).toBe(401);
+  });
+
+  it("maps non-2xx on /policies to ApiResponseError", async () => {
+    globalThis.fetch = fakeFetch(
+      () =>
+        new Response(JSON.stringify({ error: { code: "NOT_FOUND", message: "no repo" } }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const client = createApiClient({
+      apiUrl: "https://example.test",
+      apiKey: "git_x",
+    });
+    const err = await listPolicies(client, "22222222-2222-2222-2222-222222222222").catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ApiResponseError);
+    expect((err as ApiResponseError).status).toBe(404);
+  });
+});
+
+describe("streamGenerate", () => {
+  let originalFetch: FetchFn;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it("parses suggestion and done frames", async () => {
+    const onSuggestion = vi.fn();
+    globalThis.fetch = fakeFetch(() => {
+      const fresh = makeStreamResponse([
+        ": ping\n\n",
+        sseFrame("suggestion", SUGGESTION_PAYLOAD),
+        sseFrame("done", DONE_PAYLOAD),
+      ]);
+      fresh.close();
+      return fresh.response;
+    });
+
+    const result = await streamGenerate(
+      { apiUrl: "https://example.test", apiKey: "git_x" },
+      REQUEST,
+      { onSuggestion },
+    );
+    expect(result.done).toEqual(DONE_PAYLOAD);
+    expect(result.suggestions).toHaveLength(1);
+    expect(onSuggestion).toHaveBeenCalledOnce();
+  });
+
+  it("sends x-api-key + accept: text/event-stream", async () => {
+    let url: string | null = null;
+    let headers: Headers | null = null;
+    globalThis.fetch = fakeFetch((input, init) => {
+      url = inputUrl(input);
+      headers = new Headers(init?.headers);
+      const fresh = makeStreamResponse([sseFrame("done", DONE_PAYLOAD)]);
+      fresh.close();
+      return fresh.response;
+    });
+
+    await streamGenerate({ apiUrl: "https://example.test/", apiKey: "git_secret" }, REQUEST);
+    expect(url).toBe("https://example.test/generate");
+    expect(headers!.get("x-api-key")).toBe("git_secret");
+    expect(headers!.get("accept")).toBe("text/event-stream");
+  });
+
+  it("surfaces error frames as StreamError", async () => {
+    globalThis.fetch = fakeFetch(() => {
+      const fresh = makeStreamResponse([
+        sseFrame("error", { code: "LLM_RATE_LIMITED", message: "slow down" }),
+      ]);
+      fresh.close();
+      return fresh.response;
+    });
+
+    await expect(
+      streamGenerate({ apiUrl: "https://example.test", apiKey: "git_x" }, REQUEST),
+    ).rejects.toMatchObject({
+      name: "StreamError",
+      code: "STREAM",
+      message: "slow down",
+    });
+  });
+
+  it("throws StreamError when the connection closes before done", async () => {
+    globalThis.fetch = fakeFetch(() => {
+      const fresh = makeStreamResponse([sseFrame("suggestion", SUGGESTION_PAYLOAD)]);
+      fresh.close();
+      return fresh.response;
+    });
+
+    await expect(
+      streamGenerate({ apiUrl: "https://example.test", apiKey: "git_x" }, REQUEST),
+    ).rejects.toBeInstanceOf(StreamError);
+  });
+
+  it("throws StreamError when the stream errors mid-flight", async () => {
+    globalThis.fetch = fakeFetch(() => {
+      const fresh = makeStreamResponse([sseFrame("suggestion", SUGGESTION_PAYLOAD)]);
+      queueMicrotask(() => fresh.error(new Error("ECONNRESET")));
+      return fresh.response;
+    });
+
+    const err = await streamGenerate(
+      { apiUrl: "https://example.test", apiKey: "git_x" },
+      REQUEST,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StreamError);
+  });
+
+  it("maps 401 to AuthError with envelope details", async () => {
+    globalThis.fetch = fakeFetch(() =>
+      makeJsonErrorResponse(401, "INVALID_API_KEY", "key not recognized"),
+    );
+
+    const err = await streamGenerate(
+      { apiUrl: "https://example.test", apiKey: "git_bad" },
+      REQUEST,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AuthError);
+    const auth = err as AuthError;
+    expect(auth.status).toBe(401);
+    expect(auth.envelope?.error.code).toBe("INVALID_API_KEY");
+  });
+
+  it("maps non-401 error responses to ApiResponseError", async () => {
+    globalThis.fetch = fakeFetch(() => makeJsonErrorResponse(500, "INTERNAL", "boom"));
+
+    const err = await streamGenerate(
+      { apiUrl: "https://example.test", apiKey: "git_x" },
+      REQUEST,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiResponseError);
+    expect((err as ApiResponseError).status).toBe(500);
+  });
+
+  it("translates external abort to AbortError", async () => {
+    globalThis.fetch = pendingFetchUntilAbort();
+
+    const ctrl = new AbortController();
+    const promise = streamGenerate({ apiUrl: "https://example.test", apiKey: "git_x" }, REQUEST, {
+      signal: ctrl.signal,
+    });
+    ctrl.abort();
+    await expect(promise).rejects.toBeInstanceOf(AbortError);
+  });
+
+  it("translates idle stream timeout to TimeoutError", async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = pendingFetchUntilAbort();
+
+    const settled = streamGenerate({ apiUrl: "https://example.test", apiKey: "git_x" }, REQUEST, {
+      streamIdleTimeoutMs: 10,
+    }).catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(20);
+    const err = await settled;
+    expect(err).toBeInstanceOf(TimeoutError);
+  });
+});

--- a/apps/cli/src/lib/api-client.ts
+++ b/apps/cli/src/lib/api-client.ts
@@ -1,0 +1,382 @@
+import {
+  contracts,
+  doneFrameSchema,
+  errorEnvelopeSchema,
+  errorFrameSchema,
+  suggestionFrameSchema,
+  type DoneFrame,
+  type ErrorEnvelope,
+  type ErrorFrame,
+  type GenerateRequest,
+  type PolicyDto,
+  type SuggestionFrame,
+  type User,
+} from "@commit-analyzer/contracts";
+import { initClient, tsRestFetchApi, type ApiFetcher, type ApiFetcherArgs } from "@ts-rest/core";
+import { createParser } from "eventsource-parser";
+
+import {
+  AbortError,
+  ApiResponseError,
+  AuthError,
+  NetworkError,
+  ProtocolError,
+  StreamError,
+  TimeoutError,
+} from "./api-errors.js";
+
+const API_KEY_HEADER = "x-api-key";
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 30_000;
+
+type FetchLike = typeof globalThis.fetch;
+
+interface ApiClientConfig {
+  apiUrl: string;
+  apiKey: string;
+  /** Per-request timeout for ts-rest unary calls. Default 30s. */
+  requestTimeoutMs?: number;
+  /** Stream idle timeout — aborts when no bytes arrive for this many ms. */
+  streamIdleTimeoutMs?: number;
+  /** Inject for tests. */
+  fetch?: FetchLike;
+}
+
+export function createApiClient(cfg: ApiClientConfig) {
+  const baseHeaders: Record<string, string> = { [API_KEY_HEADER]: cfg.apiKey };
+  // `c.noBody()` in `apiKeys.revoke` / `llmKeys.delete` produces a unique
+  // symbol type. With NodeNext, the contracts package's @ts-rest/core copy
+  // is a different physical install from the cli's, so the symbols don't
+  // match and initClient refuses the router. Runtime shape is identical;
+  // mirror the api app's `as never` workaround in
+  // auth-ts-rest.controller.ts.
+  return initClient(contracts as never, {
+    baseUrl: stripTrailingSlash(cfg.apiUrl),
+    baseHeaders,
+    api: createTypedFetcher(cfg),
+  });
+}
+
+type ApiClient = ReturnType<typeof createApiClient>;
+
+interface RouteResponse {
+  status: number;
+  body: unknown;
+  headers: Headers;
+}
+
+type CallArg = { fetchOptions?: { signal?: AbortSignal } };
+type ListPoliciesArg = CallArg & { params: { repoId: string } };
+
+interface ProxyShape {
+  auth: { me: (args?: CallArg) => Promise<RouteResponse> };
+  policies: { list: (args: ListPoliciesArg) => Promise<RouteResponse> };
+}
+
+const asTyped = (client: ApiClient): ProxyShape => client as unknown as ProxyShape;
+
+interface CallOptions {
+  signal?: AbortSignal;
+}
+
+export async function whoami(client: ApiClient, options: CallOptions = {}): Promise<User> {
+  const res = await asTyped(client).auth.me({
+    fetchOptions: options.signal ? { signal: options.signal } : {},
+  });
+  if (res.status === 200) return res.body as User;
+  throwResponseError(res);
+}
+
+export async function listPolicies(
+  client: ApiClient,
+  repoId: string,
+  options: CallOptions = {},
+): Promise<PolicyDto[]> {
+  const res = await asTyped(client).policies.list({
+    params: { repoId },
+    fetchOptions: options.signal ? { signal: options.signal } : {},
+  });
+  if (res.status === 200) {
+    return (res.body as { items: PolicyDto[] }).items;
+  }
+  throwResponseError(res);
+}
+
+function throwResponseError(res: RouteResponse): never {
+  const envelope = ensureEnvelope(res.body);
+  if (res.status === 401 || res.status === 403) {
+    throw new AuthError(res.status, envelope);
+  }
+  throw new ApiResponseError(res.status, envelope);
+}
+
+function ensureEnvelope(body: unknown): ErrorEnvelope | null {
+  const parsed = errorEnvelopeSchema.safeParse(body);
+  return parsed.success ? parsed.data : null;
+}
+
+function createTypedFetcher(cfg: ApiClientConfig): ApiFetcher {
+  const timeoutMs = cfg.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  return async (args: ApiFetcherArgs) => {
+    const userSignal = args.fetchOptions?.signal ?? args.signal;
+    const { signal, cleanup } = withTimeout(userSignal, timeoutMs);
+    try {
+      return await tsRestFetchApi({
+        ...args,
+        fetchOptions: { ...args.fetchOptions, signal },
+        signal,
+      });
+    } catch (err) {
+      throw translateFetchError(err, userSignal, timeoutMs);
+    } finally {
+      cleanup();
+    }
+  };
+}
+
+interface StreamGenerateOptions {
+  signal?: AbortSignal;
+  /** Stream idle timeout override. */
+  streamIdleTimeoutMs?: number;
+  onSuggestion?: (frame: SuggestionFrame) => void;
+  onError?: (frame: ErrorFrame) => void;
+}
+
+interface StreamGenerateResult {
+  done: DoneFrame;
+  suggestions: SuggestionFrame[];
+}
+
+export async function streamGenerate(
+  cfg: ApiClientConfig,
+  body: GenerateRequest,
+  options: StreamGenerateOptions = {},
+): Promise<StreamGenerateResult> {
+  const fetchImpl: FetchLike = cfg.fetch ?? globalThis.fetch;
+  const url = `${stripTrailingSlash(cfg.apiUrl)}/generate`;
+  const idleMs =
+    options.streamIdleTimeoutMs ?? cfg.streamIdleTimeoutMs ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS;
+
+  const idle = createIdleAbort(idleMs, options.signal);
+
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "text/event-stream",
+        [API_KEY_HEADER]: cfg.apiKey,
+      },
+      body: JSON.stringify(body),
+      signal: idle.signal,
+    });
+  } catch (err) {
+    idle.cleanup();
+    throw translateStreamFetchError(err, options.signal, idle, idleMs);
+  }
+
+  if (!res.ok) {
+    idle.cleanup();
+    const text = await res.text().catch(() => "");
+    const envelope = parseErrorEnvelope(text);
+    if (res.status === 401 || res.status === 403) {
+      throw new AuthError(res.status, envelope);
+    }
+    throw new ApiResponseError(res.status, envelope);
+  }
+
+  if (!res.body) {
+    idle.cleanup();
+    throw new ProtocolError("response has no body");
+  }
+
+  const suggestions: SuggestionFrame[] = [];
+  const sink: { done: DoneFrame | null; error: ErrorFrame | null } = {
+    done: null,
+    error: null,
+  };
+
+  const parser = createParser({
+    onEvent: (ev) => {
+      if (!ev.event) return;
+      const payload = safeParseJson(ev.data);
+      if (payload === undefined) return;
+      switch (ev.event) {
+        case "suggestion": {
+          const result = suggestionFrameSchema.safeParse(payload);
+          if (!result.success) return;
+          suggestions.push(result.data);
+          options.onSuggestion?.(result.data);
+          return;
+        }
+        case "done": {
+          const result = doneFrameSchema.safeParse(payload);
+          if (result.success) sink.done = result.data;
+          return;
+        }
+        case "error": {
+          const result = errorFrameSchema.safeParse(payload);
+          if (result.success) {
+            sink.error = result.data;
+            options.onError?.(result.data);
+          }
+        }
+      }
+    },
+  });
+
+  const decoder = new TextDecoder("utf-8");
+  const reader: ReadableStreamDefaultReader<Uint8Array> = res.body.getReader();
+
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      idle.refresh();
+      parser.feed(decoder.decode(value, { stream: true }));
+    }
+  } catch (err) {
+    await reader.cancel().catch(() => {});
+    throw translateStreamFetchError(err, options.signal, idle, idleMs, true);
+  } finally {
+    idle.cleanup();
+  }
+
+  if (sink.error) {
+    throw new StreamError(sink.error.message);
+  }
+  if (!sink.done) {
+    throw new StreamError("connection closed before done frame");
+  }
+  return { done: sink.done, suggestions };
+}
+
+function withTimeout(
+  external: AbortSignal | null | undefined,
+  timeoutMs: number,
+): { signal: AbortSignal; cleanup: () => void } {
+  const ctrl = new AbortController();
+  let cleared = false;
+  const onExternalAbort = () => ctrl.abort(external?.reason);
+  if (external) {
+    if (external.aborted) ctrl.abort(external.reason);
+    else external.addEventListener("abort", onExternalAbort, { once: true });
+  }
+  const timer = setTimeout(() => ctrl.abort(new TimeoutError(timeoutMs)), timeoutMs);
+  return {
+    signal: ctrl.signal,
+    cleanup: () => {
+      if (cleared) return;
+      cleared = true;
+      clearTimeout(timer);
+      external?.removeEventListener("abort", onExternalAbort);
+    },
+  };
+}
+
+interface IdleAbort {
+  signal: AbortSignal;
+  refresh: () => void;
+  cleanup: () => void;
+  fired: () => boolean;
+}
+
+function createIdleAbort(idleMs: number, external: AbortSignal | null | undefined): IdleAbort {
+  const ctrl = new AbortController();
+  let timeoutFired = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const arm = () => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timeoutFired = true;
+      ctrl.abort(new TimeoutError(idleMs));
+    }, idleMs);
+  };
+  arm();
+
+  const onExternalAbort = () => ctrl.abort(external?.reason);
+  if (external) {
+    if (external.aborted) ctrl.abort(external.reason);
+    else external.addEventListener("abort", onExternalAbort, { once: true });
+  }
+
+  let cleared = false;
+  return {
+    signal: ctrl.signal,
+    refresh: arm,
+    cleanup: () => {
+      if (cleared) return;
+      cleared = true;
+      if (timer) clearTimeout(timer);
+      external?.removeEventListener("abort", onExternalAbort);
+    },
+    fired: () => timeoutFired,
+  };
+}
+
+function translateFetchError(
+  err: unknown,
+  external: AbortSignal | null | undefined,
+  timeoutMs: number,
+): unknown {
+  if (err instanceof TimeoutError) return err;
+  if (external?.aborted) return new AbortError();
+  if (isAbortDomError(err)) {
+    const reason = (err as { cause?: unknown }).cause;
+    if (reason instanceof TimeoutError) return reason;
+    return new TimeoutError(timeoutMs);
+  }
+  if (err instanceof TypeError) {
+    return new NetworkError(err.message, { cause: err });
+  }
+  return err;
+}
+
+function translateStreamFetchError(
+  err: unknown,
+  external: AbortSignal | null | undefined,
+  idle: IdleAbort,
+  idleMs: number,
+  midStream = false,
+): unknown {
+  if (err instanceof TimeoutError) return err;
+  if (external?.aborted) return new AbortError();
+  if (idle.fired()) return new TimeoutError(idleMs);
+  if (isAbortDomError(err)) {
+    if (external?.aborted) return new AbortError();
+    return new TimeoutError(idleMs);
+  }
+  if (midStream) {
+    const message = err instanceof Error ? err.message : "stream error";
+    return new StreamError(message, { cause: err });
+  }
+  if (err instanceof TypeError) {
+    return new NetworkError(err.message, { cause: err });
+  }
+  return err;
+}
+
+function isAbortDomError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+function parseErrorEnvelope(text: string): ReturnType<typeof errorEnvelopeSchema.parse> | null {
+  if (!text) return null;
+  const json = safeParseJson(text);
+  if (json === undefined) return null;
+  const parsed = errorEnvelopeSchema.safeParse(json);
+  return parsed.success ? parsed.data : null;
+}
+
+function safeParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}

--- a/apps/cli/src/lib/api-client.ts
+++ b/apps/cli/src/lib/api-client.ts
@@ -34,22 +34,14 @@ type FetchLike = typeof globalThis.fetch;
 interface ApiClientConfig {
   apiUrl: string;
   apiKey: string;
-  /** Per-request timeout for ts-rest unary calls. Default 30s. */
   requestTimeoutMs?: number;
-  /** Stream idle timeout — aborts when no bytes arrive for this many ms. */
   streamIdleTimeoutMs?: number;
-  /** Inject for tests. */
   fetch?: FetchLike;
 }
 
 export function createApiClient(cfg: ApiClientConfig) {
   const baseHeaders: Record<string, string> = { [API_KEY_HEADER]: cfg.apiKey };
-  // `c.noBody()` in `apiKeys.revoke` / `llmKeys.delete` produces a unique
-  // symbol type. With NodeNext, the contracts package's @ts-rest/core copy
-  // is a different physical install from the cli's, so the symbols don't
-  // match and initClient refuses the router. Runtime shape is identical;
-  // mirror the api app's `as never` workaround in
-  // auth-ts-rest.controller.ts.
+  // `c.noBody()` unique-symbol from contracts' ts-rest install does not match the cli's; runtime shape is identical.
   return initClient(contracts as never, {
     baseUrl: stripTrailingSlash(cfg.apiUrl),
     baseHeaders,

--- a/apps/cli/src/lib/api-errors.ts
+++ b/apps/cli/src/lib/api-errors.ts
@@ -1,0 +1,68 @@
+import type { ErrorEnvelope } from "@commit-analyzer/contracts";
+
+type ApiErrorCode = "NETWORK" | "TIMEOUT" | "ABORTED" | "AUTH" | "API" | "STREAM" | "PROTOCOL";
+
+class CliApiError extends Error {
+  readonly code: ApiErrorCode;
+
+  constructor(code: ApiErrorCode, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = new.target.name;
+    this.code = code;
+  }
+}
+
+export class NetworkError extends CliApiError {
+  constructor(message = "network error", options?: { cause?: unknown }) {
+    super("NETWORK", message, options);
+  }
+}
+
+export class TimeoutError extends CliApiError {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number, message = `request timed out after ${timeoutMs}ms`) {
+    super("TIMEOUT", message);
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export class AbortError extends CliApiError {
+  constructor(message = "request aborted") {
+    super("ABORTED", message);
+  }
+}
+
+export class AuthError extends CliApiError {
+  readonly status: number;
+  readonly envelope: ErrorEnvelope | null;
+
+  constructor(status: number, envelope: ErrorEnvelope | null, message?: string) {
+    super("AUTH", message ?? envelope?.error.message ?? "authentication failed");
+    this.status = status;
+    this.envelope = envelope;
+  }
+}
+
+export class ApiResponseError extends CliApiError {
+  readonly status: number;
+  readonly envelope: ErrorEnvelope | null;
+
+  constructor(status: number, envelope: ErrorEnvelope | null, message?: string) {
+    super("API", message ?? envelope?.error.message ?? `request failed with status ${status}`);
+    this.status = status;
+    this.envelope = envelope;
+  }
+}
+
+export class StreamError extends CliApiError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super("STREAM", message, options);
+  }
+}
+
+export class ProtocolError extends CliApiError {
+  constructor(message: string) {
+    super("PROTOCOL", message);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,12 +162,24 @@ importers:
 
   apps/cli:
     dependencies:
+      '@commit-analyzer/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       '@commit-analyzer/diff-parser':
         specifier: workspace:*
         version: link:../../packages/diff-parser
+      '@ts-rest/core':
+        specifier: ^3.51.0
+        version: 3.52.1(@types/node@22.19.17)(zod@3.25.76)
       commander:
         specifier: ^12.1.0
         version: 12.1.0
+      eventsource-parser:
+        specifier: ^3.0.8
+        version: 3.0.8
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@commit-analyzer/eslint-config':
         specifier: workspace:*
@@ -8149,7 +8161,7 @@ snapshots:
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 


### PR DESCRIPTION
## Summary
- Adds `apps/cli/src/lib/api-client.ts`: ts-rest client built from `@commit-analyzer/contracts` with an `x-api-key` header, plus `streamGenerate` — a raw-fetch SSE consumer that uses `eventsource-parser` to parse `suggestion`/`done`/`error` frames (the actual server output; per `apps/api/.../generate.controller.ts`, `token` and `policy_result` from the spec text don't exist — validation/policy results ride on the `suggestion` frame's `validation` field).
- Typed wrappers `whoami` / `listPolicies` over the proxy and a typed error hierarchy in `apps/cli/src/lib/api-errors.ts` (`NetworkError`, `TimeoutError`, `AbortError`, `AuthError`, `ApiResponseError`, `StreamError`, `ProtocolError`).
- Both ts-rest unary calls and the SSE stream surface typed errors for connection drop, request timeout, idle-stream timeout, and external `AbortSignal` cancellation (Ctrl-C path).
- 16 vitest cases cover happy path, error frames, auth/HTTP errors, abort, and idle timeout.
- The `as never` cast at `initClient` mirrors the api app's existing workaround for the `c.noBody()` unique-symbol mismatch between the cli's and contracts' physical `@ts-rest/core` installs (NodeNext resolution).
- Existing `generate` / `whoami` / `keys` command stubs are intentionally left untouched; wiring is later tasks (T-5.4+).

Closes #60

## Test plan
- [x] `pnpm -F @commit-analyzer/cli typecheck` / `lint` / `test` / `build`
- [x] `pnpm -r typecheck` / `lint` (repo-wide)
- [x] `pnpm knip`
- [ ] CI: `branch-name`, `commitlint`, full pipeline