### PR TITLE
feat(T-5.4): configure, whoami, keys list

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -33,8 +33,10 @@
   "dependencies": {
     "@commit-analyzer/contracts": "workspace:*",
     "@commit-analyzer/diff-parser": "workspace:*",
+    "@inquirer/prompts": "^8.4.2",
     "@ts-rest/core": "^3.51.0",
     "commander": "^12.1.0",
+    "cosmiconfig": "^9.0.1",
     "eventsource-parser": "^3.0.8",
     "zod": "^3.23.8"
   }

--- a/apps/cli/src/commands/configure.ts
+++ b/apps/cli/src/commands/configure.ts
@@ -1,13 +1,66 @@
+import { input, password } from "@inquirer/prompts";
 import type { Command } from "commander";
+
+import { createApiClient, whoami } from "../lib/api-client.js";
+import { AbortError, AuthError, NetworkError } from "../lib/api-errors.js";
+import {
+  configSchema,
+  redactKey,
+  saveConfig,
+  type CliConfig,
+} from "../lib/config.js";
+
+interface ConfigureOptions {
+  url?: string;
+  key?: string;
+}
 
 export function registerConfigureCommand(program: Command): void {
   program
     .command("configure")
-    .description("save API URL and API key to ~/.projectrc")
+    .description("save API URL and API key to ~/.projectrc (mode 0600)")
     .option("--url <url>", "API URL")
     .option("--key <key>", "API key")
-    .action(() => {
-      console.error("configure: not implemented yet");
-      process.exit(1);
+    .action(async (opts: ConfigureOptions) => {
+      try {
+        await runConfigure(opts);
+      } catch (err) {
+        if (err instanceof AbortError || isInquirerCancel(err)) {
+          process.stderr.write("aborted\n");
+          process.exit(130);
+        }
+        if (err instanceof AuthError) {
+          process.stderr.write(`error: api key rejected (${err.status}). config not saved.\n`);
+          process.exit(3);
+        }
+        if (err instanceof NetworkError) {
+          process.stderr.write(`error: cannot reach API: ${err.message}\n`);
+          process.exit(4);
+        }
+        process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
+        process.exit(1);
+      }
     });
+}
+
+async function runConfigure(opts: ConfigureOptions): Promise<void> {
+  const apiUrl =
+    opts.url ?? (await input({ message: "API URL:", default: "http://localhost:3000" }));
+  const apiKey = opts.key ?? (await password({ message: "API key:", mask: "*" }));
+
+  const draft: CliConfig = configSchema.parse({ apiUrl, apiKey });
+
+  process.stdout.write(`verifying key with ${draft.apiUrl} …\n`);
+  const client = createApiClient({ apiUrl: draft.apiUrl, apiKey: draft.apiKey });
+  const user = await whoami(client);
+
+  const path = await saveConfig(draft);
+  const who = user.email ?? user.name ?? user.id;
+  process.stdout.write(
+    `saved ${path} (mode 0600). authenticated as ${who} (${redactKey(draft.apiKey)}).\n`,
+  );
+}
+
+function isInquirerCancel(err: unknown): boolean {
+  return err instanceof Error && err.name === "ExitPromptError";
 }

--- a/apps/cli/src/commands/keys.ts
+++ b/apps/cli/src/commands/keys.ts
@@ -1,13 +1,40 @@
 import type { Command } from "commander";
 
+import { createApiClient, listApiKeys } from "../lib/api-client.js";
+import { AuthError, NetworkError } from "../lib/api-errors.js";
+import { ConfigError, loadConfig } from "../lib/config.js";
+import { formatKeysTable } from "../lib/keys-table.js";
+
 export function registerKeysCommand(program: Command): void {
   const keys = program.command("keys").description("manage API keys");
 
   keys
     .command("list")
-    .description("list stored API keys")
-    .action(() => {
-      console.error("keys list: not implemented yet");
-      process.exit(1);
+    .description("list API keys for the authenticated user (calls /api-keys)")
+    .action(async () => {
+      try {
+        const cfg = await loadConfig();
+        const client = createApiClient({ apiUrl: cfg.apiUrl, apiKey: cfg.apiKey });
+        const items = await listApiKeys(client);
+        process.stdout.write(formatKeysTable(items));
+      } catch (err) {
+        if (err instanceof ConfigError) {
+          process.stderr.write(`error: ${err.message}\n`);
+          process.exit(3);
+        }
+        if (err instanceof AuthError) {
+          process.stderr.write(
+            `error: api key rejected (${err.status}). Re-run \`git-insight configure\`.\n`,
+          );
+          process.exit(3);
+        }
+        if (err instanceof NetworkError) {
+          process.stderr.write(`error: cannot reach API: ${err.message}\n`);
+          process.exit(4);
+        }
+        process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
+        process.exit(1);
+      }
     });
 }
+

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -1,11 +1,38 @@
 import type { Command } from "commander";
 
+import { createApiClient, whoami } from "../lib/api-client.js";
+import { AuthError, NetworkError } from "../lib/api-errors.js";
+import { ConfigError, loadConfig } from "../lib/config.js";
+
 export function registerWhoamiCommand(program: Command): void {
   program
     .command("whoami")
-    .description("show the authenticated user")
-    .action(() => {
-      console.error("whoami: not implemented yet");
-      process.exit(1);
+    .description("show the authenticated user (calls /me)")
+    .action(async () => {
+      try {
+        const cfg = await loadConfig();
+        const client = createApiClient({ apiUrl: cfg.apiUrl, apiKey: cfg.apiKey });
+        const user = await whoami(client);
+        const email = user.email ?? "—";
+        const name = user.name ?? "—";
+        process.stdout.write(`email: ${email}\nname:  ${name}\n`);
+      } catch (err) {
+        if (err instanceof ConfigError) {
+          process.stderr.write(`error: ${err.message}\n`);
+          process.exit(3);
+        }
+        if (err instanceof AuthError) {
+          process.stderr.write(
+            `error: api key rejected (${err.status}). Re-run \`git-insight configure\`.\n`,
+          );
+          process.exit(3);
+        }
+        if (err instanceof NetworkError) {
+          process.stderr.write(`error: cannot reach API: ${err.message}\n`);
+          process.exit(4);
+        }
+        process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
+        process.exit(1);
+      }
     });
 }

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -13,9 +13,9 @@ export function registerWhoamiCommand(program: Command): void {
         const cfg = await loadConfig();
         const client = createApiClient({ apiUrl: cfg.apiUrl, apiKey: cfg.apiKey });
         const user = await whoami(client);
-        const email = user.email ?? "—";
-        const name = user.name ?? "—";
-        process.stdout.write(`email: ${email}\nname:  ${name}\n`);
+        const email = user.email ?? "(unknown)";
+        const name = user.name ?? "(unknown)";
+        process.stdout.write(`email: ${email}\nname: ${name}\n`);
       } catch (err) {
         if (err instanceof ConfigError) {
           process.stderr.write(`error: ${err.message}\n`);

--- a/apps/cli/src/lib/api-client.spec.ts
+++ b/apps/cli/src/lib/api-client.spec.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createApiClient, listPolicies, streamGenerate, whoami } from "./api-client.js";
+import {
+  createApiClient,
+  listApiKeys,
+  listPolicies,
+  streamGenerate,
+  whoami,
+} from "./api-client.js";
 import {
   AbortError,
   ApiResponseError,
@@ -143,6 +149,31 @@ describe("createApiClient", () => {
     expect(user.id).toBe("00000000-0000-0000-0000-000000000000");
     expect(captured!.url).toContain("/me");
     expect(captured!.headers.get("x-api-key")).toBe("git_secret");
+  });
+
+  it("listApiKeys hits /api-keys and unwraps items", async () => {
+    let url: string | null = null;
+    let headers: Headers | null = null;
+    const apiKey = {
+      id: "00000000-0000-0000-0000-000000000001",
+      name: "laptop",
+      prefix: "git_abcd",
+      lastUsedAt: null,
+      createdAt: new Date().toISOString(),
+    };
+    globalThis.fetch = fakeFetch((input, init) => {
+      url = inputUrl(input);
+      headers = new Headers(init?.headers);
+      return new Response(JSON.stringify({ items: [apiKey] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const client = createApiClient({ apiUrl: "https://example.test", apiKey: "git_x" });
+    const items = await listApiKeys(client);
+    expect(items).toEqual([apiKey]);
+    expect(url).toContain("/api-keys");
+    expect(headers!.get("x-api-key")).toBe("git_x");
   });
 
   it("listPolicies hits the /repos/:repoId/policies route", async () => {

--- a/apps/cli/src/lib/api-client.ts
+++ b/apps/cli/src/lib/api-client.ts
@@ -4,6 +4,7 @@ import {
   errorEnvelopeSchema,
   errorFrameSchema,
   suggestionFrameSchema,
+  type ApiKey,
   type DoneFrame,
   type ErrorEnvelope,
   type ErrorFrame,
@@ -61,7 +62,10 @@ type CallArg = { fetchOptions?: { signal?: AbortSignal } };
 type ListPoliciesArg = CallArg & { params: { repoId: string } };
 
 interface ProxyShape {
-  auth: { me: (args?: CallArg) => Promise<RouteResponse> };
+  auth: {
+    me: (args?: CallArg) => Promise<RouteResponse>;
+    apiKeys: { list: (args?: CallArg) => Promise<RouteResponse> };
+  };
   policies: { list: (args: ListPoliciesArg) => Promise<RouteResponse> };
 }
 
@@ -78,6 +82,16 @@ export async function whoami(client: ApiClient, options: CallOptions = {}): Prom
   if (res.status === 200) return res.body as User;
   throwResponseError(res);
 }
+
+export async function listApiKeys(client: ApiClient, options: CallOptions = {}): Promise<ApiKey[]> {
+  const res = await asTyped(client).auth.apiKeys.list({
+    fetchOptions: options.signal ? { signal: options.signal } : {},
+  });
+  if (res.status === 200) return (res.body as { items: ApiKey[] }).items;
+  throwResponseError(res);
+}
+
+export type { ApiClient };
 
 export async function listPolicies(
   client: ApiClient,

--- a/apps/cli/src/lib/api-client.ts
+++ b/apps/cli/src/lib/api-client.ts
@@ -91,8 +91,6 @@ export async function listApiKeys(client: ApiClient, options: CallOptions = {}):
   throwResponseError(res);
 }
 
-export type { ApiClient };
-
 export async function listPolicies(
   client: ApiClient,
   repoId: string,

--- a/apps/cli/src/lib/config.spec.ts
+++ b/apps/cli/src/lib/config.spec.ts
@@ -1,0 +1,139 @@
+import { promises as fs } from "node:fs";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  CONFIG_FILE_MODE,
+  ConfigError,
+  configSchema,
+  loadConfig,
+  redactKey,
+  saveConfig,
+} from "./config.js";
+
+const VALID = {
+  apiUrl: "https://api.example.com",
+  apiKey: "git_abcdefghijk",
+};
+
+describe("config schema", () => {
+  it("accepts the minimum shape", () => {
+    expect(configSchema.parse(VALID)).toEqual(VALID);
+  });
+
+  it("rejects malformed apiKey", () => {
+    expect(() => configSchema.parse({ ...VALID, apiKey: "nope" })).toThrow();
+  });
+
+  it("rejects non-url apiUrl", () => {
+    expect(() => configSchema.parse({ ...VALID, apiUrl: "not-a-url" })).toThrow();
+  });
+});
+
+describe("saveConfig", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "git-insight-cfg-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes JSON with mode 0600", async () => {
+    const path = join(dir, "config.json");
+    await saveConfig(VALID, path);
+    const written = JSON.parse(await fs.readFile(path, "utf8")) as unknown;
+    expect(written).toEqual(VALID);
+    const st = await stat(path);
+    expect(st.mode & 0o777).toBe(CONFIG_FILE_MODE);
+  });
+
+  it("re-applies 0600 even if existing file was world-readable", async () => {
+    const path = join(dir, "config.json");
+    await fs.writeFile(path, "{}", { mode: 0o644 });
+    await saveConfig(VALID, path);
+    const st = await stat(path);
+    expect(st.mode & 0o777).toBe(CONFIG_FILE_MODE);
+  });
+
+  it("rejects invalid config before touching disk", async () => {
+    const path = join(dir, "config.json");
+    await expect(saveConfig({ apiUrl: "x", apiKey: "y" } as never, path)).rejects.toBeDefined();
+    await expect(fs.access(path)).rejects.toBeDefined();
+  });
+});
+
+describe("loadConfig", () => {
+  let dir: string;
+  let prevEnv: string | undefined;
+  let prevHome: string | undefined;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "git-insight-load-"));
+    prevEnv = process.env.PROJECTRC_PATH;
+    prevHome = process.env.HOME;
+    process.env.HOME = dir;
+    delete process.env.PROJECTRC_PATH;
+  });
+
+  afterEach(async () => {
+    if (prevEnv === undefined) delete process.env.PROJECTRC_PATH;
+    else process.env.PROJECTRC_PATH = prevEnv;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("loads via PROJECTRC_PATH", async () => {
+    const path = join(dir, "rc.json");
+    await fs.writeFile(path, JSON.stringify(VALID), { mode: 0o600 });
+    process.env.PROJECTRC_PATH = path;
+    expect(await loadConfig()).toEqual(VALID);
+  });
+
+  it("throws ConfigError MISSING when no config found", async () => {
+    const err = await loadConfig().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ConfigError);
+    expect((err as ConfigError).code).toBe("MISSING");
+  });
+
+  it("throws ConfigError MISSING when PROJECTRC_PATH points at nothing", async () => {
+    process.env.PROJECTRC_PATH = join(dir, "does-not-exist.json");
+    const err = await loadConfig().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ConfigError);
+    expect((err as ConfigError).code).toBe("MISSING");
+  });
+
+  it("rejects insecure file mode", async () => {
+    const path = join(dir, "rc.json");
+    await fs.writeFile(path, JSON.stringify(VALID), { mode: 0o644 });
+    process.env.PROJECTRC_PATH = path;
+    const err = await loadConfig().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ConfigError);
+    expect((err as ConfigError).code).toBe("PERMISSIONS");
+  });
+
+  it("rejects malformed config with INVALID", async () => {
+    const path = join(dir, "rc.json");
+    await fs.writeFile(path, JSON.stringify({ apiUrl: "no", apiKey: "no" }), { mode: 0o600 });
+    process.env.PROJECTRC_PATH = path;
+    const err = await loadConfig().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ConfigError);
+    expect((err as ConfigError).code).toBe("INVALID");
+  });
+});
+
+describe("redactKey", () => {
+  it("masks long keys", () => {
+    expect(redactKey("git_abcdefghijklmno")).toBe("git_…no");
+  });
+
+  it("returns *** for short keys", () => {
+    expect(redactKey("short")).toBe("***");
+  });
+});

--- a/apps/cli/src/lib/config.spec.ts
+++ b/apps/cli/src/lib/config.spec.ts
@@ -96,6 +96,18 @@ describe("loadConfig", () => {
     expect(await loadConfig()).toEqual(VALID);
   });
 
+  it("finds ~/.projectrc via upward walk", async () => {
+    const path = join(dir, ".projectrc");
+    await fs.writeFile(path, JSON.stringify(VALID), { mode: 0o600 });
+    const prevCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      expect(await loadConfig()).toEqual(VALID);
+    } finally {
+      process.chdir(prevCwd);
+    }
+  });
+
   it("throws ConfigError MISSING when no config found", async () => {
     const err = await loadConfig().catch((e: unknown) => e);
     expect(err).toBeInstanceOf(ConfigError);

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -1,0 +1,126 @@
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { cosmiconfig } from "cosmiconfig";
+import { z } from "zod";
+
+const llmProviderEnum = z.enum(["openai", "anthropic"]);
+
+export const configSchema = z.object({
+  apiUrl: z.string().url(),
+  apiKey: z.string().regex(/^git_[A-Za-z0-9_-]+$/),
+  defaultProvider: llmProviderEnum.optional(),
+  defaultModel: z.string().optional(),
+});
+
+export type CliConfig = z.infer<typeof configSchema>;
+
+export const CONFIG_MODULE_NAME = "projectrc";
+export const CONFIG_FILE_MODE = 0o600;
+const PERMISSION_MASK = 0o077;
+
+export class ConfigError extends Error {
+  readonly code: ConfigErrorCode;
+
+  constructor(code: ConfigErrorCode, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "ConfigError";
+    this.code = code;
+  }
+}
+
+type ConfigErrorCode = "MISSING" | "INVALID" | "PERMISSIONS" | "READ";
+
+export function defaultConfigPath(): string {
+  return join(homedir(), ".projectrc");
+}
+
+export async function loadConfig(): Promise<CliConfig> {
+  const explorer = cosmiconfig(CONFIG_MODULE_NAME, {
+    searchPlaces: [
+      ".projectrc",
+      ".projectrc.json",
+      "package.json",
+      join(homedir(), ".projectrc"),
+    ],
+  });
+
+  const envPath = process.env.PROJECTRC_PATH;
+  const found = envPath ? await loadAt(explorer, envPath) : await explorer.search();
+
+  if (!found || found.isEmpty) {
+    throw new ConfigError(
+      "MISSING",
+      envPath
+        ? `no config at PROJECTRC_PATH=${envPath}. Run \`git-insight configure\`.`
+        : "no config found. Run `git-insight configure` to create one.",
+    );
+  }
+
+  if (found.filepath) await assertSecureMode(found.filepath);
+
+  const parsed = configSchema.safeParse(found.config);
+  if (!parsed.success) {
+    throw new ConfigError(
+      "INVALID",
+      `config at ${found.filepath ?? "<unknown>"} is invalid: ${parsed.error.message}`,
+    );
+  }
+  return parsed.data;
+}
+
+type Explorer = ReturnType<typeof cosmiconfig>;
+type LoadResult = Awaited<ReturnType<Explorer["load"]>>;
+
+async function loadAt(explorer: Explorer, path: string): Promise<LoadResult | null> {
+  try {
+    return await explorer.load(path);
+  } catch (err) {
+    if (isEnoent(err)) return null;
+    throw err;
+  }
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: unknown }).code === "ENOENT"
+  );
+}
+
+async function assertSecureMode(path: string): Promise<void> {
+  let stat;
+  try {
+    stat = await fs.stat(path);
+  } catch (err) {
+    throw new ConfigError("READ", `cannot stat config file ${path}`, { cause: err });
+  }
+  const mode = stat.mode & 0o777;
+  if ((mode & PERMISSION_MASK) !== 0) {
+    throw new ConfigError(
+      "PERMISSIONS",
+      `config file ${path} has insecure permissions ${mode.toString(8)}; expected 600. Run \`chmod 600 ${path}\`.`,
+    );
+  }
+}
+
+export async function saveConfig(config: CliConfig, path = defaultConfigPath()): Promise<string> {
+  const validated = configSchema.parse(config);
+  const json = `${JSON.stringify(validated, null, 2)}\n`;
+  const handle = await fs.open(path, "w", CONFIG_FILE_MODE);
+  try {
+    await handle.writeFile(json, "utf8");
+    await handle.chmod(CONFIG_FILE_MODE);
+  } finally {
+    await handle.close();
+  }
+  return path;
+}
+
+export function redactKey(key: string): string {
+  if (key.length <= 8) return "***";
+  return `${key.slice(0, 4)}…${key.slice(-2)}`;
+}

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -32,32 +32,32 @@ export class ConfigError extends Error {
 
 type ConfigErrorCode = "MISSING" | "INVALID" | "PERMISSIONS" | "READ";
 
-function defaultConfigPath(): string {
-  return join(homedir(), ".projectrc");
-}
-
 export async function loadConfig(): Promise<CliConfig> {
-  const explorer = cosmiconfig(CONFIG_MODULE_NAME, {
-    searchPlaces: [
-      ".projectrc",
-      ".projectrc.json",
-      "package.json",
-      join(homedir(), ".projectrc"),
-    ],
-  });
-
   const envPath = process.env.PROJECTRC_PATH;
-  const found = envPath ? await loadAt(explorer, envPath) : await explorer.search();
-
-  if (!found || found.isEmpty) {
-    throw new ConfigError(
-      "MISSING",
-      envPath
-        ? `no config at PROJECTRC_PATH=${envPath}. Run \`git-insight configure\`.`
-        : "no config found. Run `git-insight configure` to create one.",
-    );
+  if (envPath) {
+    const loader = cosmiconfig(CONFIG_MODULE_NAME);
+    const found = await loadAt(loader, envPath);
+    return finalize(found, `no config at PROJECTRC_PATH=${envPath}. Run \`git-insight configure\`.`);
   }
 
+  const rcExplorer = cosmiconfig(CONFIG_MODULE_NAME, {
+    searchPlaces: [".projectrc", ".projectrc.json"],
+  });
+  const rcHit = await rcExplorer.search();
+  if (rcHit && !rcHit.isEmpty) return finalize(rcHit);
+
+  const pkgExplorer = cosmiconfig(CONFIG_MODULE_NAME, { searchPlaces: ["package.json"] });
+  const pkgHit = await pkgExplorer.search();
+  return finalize(pkgHit, "no config found. Run `git-insight configure` to create one.");
+}
+
+async function finalize(
+  found: LoadResult | null,
+  missingMessage = "no config found. Run `git-insight configure` to create one.",
+): Promise<CliConfig> {
+  if (!found || found.isEmpty) {
+    throw new ConfigError("MISSING", missingMessage);
+  }
   if (found.filepath) await assertSecureMode(found.filepath);
 
   const parsed = configSchema.safeParse(found.config);
@@ -107,7 +107,10 @@ async function assertSecureMode(path: string): Promise<void> {
   }
 }
 
-export async function saveConfig(config: CliConfig, path = defaultConfigPath()): Promise<string> {
+export async function saveConfig(
+  config: CliConfig,
+  path = join(homedir(), ".projectrc"),
+): Promise<string> {
   const validated = configSchema.parse(config);
   const json = `${JSON.stringify(validated, null, 2)}\n`;
   const handle = await fs.open(path, "w", CONFIG_FILE_MODE);

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -16,7 +16,7 @@ export const configSchema = z.object({
 
 export type CliConfig = z.infer<typeof configSchema>;
 
-export const CONFIG_MODULE_NAME = "projectrc";
+const CONFIG_MODULE_NAME = "projectrc";
 export const CONFIG_FILE_MODE = 0o600;
 const PERMISSION_MASK = 0o077;
 
@@ -32,7 +32,7 @@ export class ConfigError extends Error {
 
 type ConfigErrorCode = "MISSING" | "INVALID" | "PERMISSIONS" | "READ";
 
-export function defaultConfigPath(): string {
+function defaultConfigPath(): string {
   return join(homedir(), ".projectrc");
 }
 

--- a/apps/cli/src/lib/keys-table.spec.ts
+++ b/apps/cli/src/lib/keys-table.spec.ts
@@ -24,7 +24,7 @@ describe("formatKeysTable", () => {
     expect(out).toContain("CREATED");
     expect(out).toContain("laptop");
     expect(out).toContain("git_abcd");
-    expect(out).toContain(sample.lastUsedAt as string);
+    expect(out).toContain("2026-04-01T12:00:00.000Z");
     expect(out).toContain(sample.createdAt);
   });
 

--- a/apps/cli/src/lib/keys-table.spec.ts
+++ b/apps/cli/src/lib/keys-table.spec.ts
@@ -1,0 +1,35 @@
+import type { ApiKey } from "@commit-analyzer/contracts";
+import { describe, expect, it } from "vitest";
+
+import { formatKeysTable } from "./keys-table.js";
+
+const sample: ApiKey = {
+  id: "00000000-0000-0000-0000-000000000001",
+  name: "laptop",
+  prefix: "git_abcd",
+  lastUsedAt: "2026-04-01T12:00:00.000Z",
+  createdAt: "2026-03-01T12:00:00.000Z",
+};
+
+describe("formatKeysTable", () => {
+  it("returns 'no api keys.' when empty", () => {
+    expect(formatKeysTable([])).toBe("no api keys.\n");
+  });
+
+  it("renders headers + rows aligned", () => {
+    const out = formatKeysTable([sample]);
+    expect(out).toContain("NAME");
+    expect(out).toContain("PREFIX");
+    expect(out).toContain("LAST USED");
+    expect(out).toContain("CREATED");
+    expect(out).toContain("laptop");
+    expect(out).toContain("git_abcd");
+    expect(out).toContain(sample.lastUsedAt as string);
+    expect(out).toContain(sample.createdAt);
+  });
+
+  it("renders 'never' when lastUsedAt is null", () => {
+    const out = formatKeysTable([{ ...sample, lastUsedAt: null }]);
+    expect(out).toContain("never");
+  });
+});

--- a/apps/cli/src/lib/keys-table.ts
+++ b/apps/cli/src/lib/keys-table.ts
@@ -1,0 +1,21 @@
+import type { ApiKey } from "@commit-analyzer/contracts";
+
+export function formatKeysTable(items: ApiKey[]): string {
+  if (items.length === 0) return "no api keys.\n";
+  const rows = items.map((k) => ({
+    name: k.name,
+    prefix: k.prefix,
+    lastUsed: k.lastUsedAt ?? "never",
+    created: k.createdAt,
+  }));
+  const headers = { name: "NAME", prefix: "PREFIX", lastUsed: "LAST USED", created: "CREATED" };
+  const widths = {
+    name: Math.max(headers.name.length, ...rows.map((r) => r.name.length)),
+    prefix: Math.max(headers.prefix.length, ...rows.map((r) => r.prefix.length)),
+    lastUsed: Math.max(headers.lastUsed.length, ...rows.map((r) => r.lastUsed.length)),
+    created: Math.max(headers.created.length, ...rows.map((r) => r.created.length)),
+  };
+  const line = (r: typeof headers): string =>
+    `${r.name.padEnd(widths.name)}  ${r.prefix.padEnd(widths.prefix)}  ${r.lastUsed.padEnd(widths.lastUsed)}  ${r.created}\n`;
+  return [headers, ...rows].map(line).join("");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,12 +168,18 @@ importers:
       '@commit-analyzer/diff-parser':
         specifier: workspace:*
         version: link:../../packages/diff-parser
+      '@inquirer/prompts':
+        specifier: ^8.4.2
+        version: 8.4.2(@types/node@22.19.17)
       '@ts-rest/core':
         specifier: ^3.51.0
         version: 3.52.1(@types/node@22.19.17)(zod@3.25.76)
       commander:
         specifier: ^12.1.0
         version: 12.1.0
+      cosmiconfig:
+        specifier: ^9.0.1
+        version: 9.0.1(typescript@5.9.3)
       eventsource-parser:
         specifier: ^3.0.8
         version: 3.0.8
@@ -582,6 +588,10 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -1202,6 +1212,140 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@inquirer/ansi@2.0.5':
+    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/checkbox@5.1.4':
+    resolution: {integrity: sha512-w6KF8ZYRvqHhROkOTHXYC3qIV/KYEu5o12oLqQySvch61vrYtRxNSHTONSdJqWiFJPlCUQAHT5OgOIyuTr+MHQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.0.12':
+    resolution: {integrity: sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.9':
+    resolution: {integrity: sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.1.1':
+    resolution: {integrity: sha512-6y11LgmNpmn5D2aB5FgnCfBUBK8ZstwLCalyJmORcJZ/WrhOjm16mu6eSqIx8DnErxDqSLr+Jkp+GP8/Nwd5tA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.0.13':
+    resolution: {integrity: sha512-dF2zvrFo9LshkcB23/O1il13kBkBltWIXzut1evfbuBLXMiGIuC45c+ZQ0uukjCDsvI8OWqun4FRYMnzFCQa3g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@3.0.0':
+    resolution: {integrity: sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.5':
+    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/input@5.0.12':
+    resolution: {integrity: sha512-uiMFBl4LqFzJClh80Q3f9hbOFJ6kgkDWI4LjAeBuyO6EanVVMF69AgOvpi1qdqjDSjDN6578B6nky9ceEpI+1Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.0.12':
+    resolution: {integrity: sha512-/vrwhEf7Xsuh+YlHF4IjSy3g1cyrQuPaSiHIxCEbLu8qnfvrcvJyCkoktOOF+xV9gSb77/G0n3h04RbMDW2sIg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.0.12':
+    resolution: {integrity: sha512-CBh7YHju623lxJRcAOo498ZUwIuMy63bqW/vVq0tQAZVv+lkWlHkP9ealYE1utWSisEShY5VMdzIXRmyEODzcQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.4.2':
+    resolution: {integrity: sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.2.8':
+    resolution: {integrity: sha512-Su7FQvp5buZmCymN3PPoYv31ZQQX4ve2j02k7piGgKAWgE+AQRB5YoYVveGXcl3TZ9ldgRMSxj56YfDFmmaqLg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.1.8':
+    resolution: {integrity: sha512-fGiHKGD6DyPIYUWxoXnQTeXeyYqSOUrasDMABBmMHUalH/LxkuzY0xVRtimXAt1sUeeyYkVuKQx1bebMuN11Kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.1.4':
+    resolution: {integrity: sha512-2kWcGKPMLAXAWRp1AH1SLsQmX+j0QjeljyXMUji9WMZC8nRDO0b7qquIGr6143E7KMLt3VAIGNXzwa/6PXQs4Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.5':
+    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
@@ -3490,6 +3634,9 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -3503,6 +3650,10 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -3591,6 +3742,15 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
@@ -3814,6 +3974,13 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -4039,6 +4206,15 @@ packages:
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4308,6 +4484,9 @@ packages:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
 
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
     engines: {node: '>= 0.4'}
@@ -4458,12 +4637,18 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -4725,6 +4910,10 @@ packages:
     resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
     engines: {node: '>= 10.16.0'}
 
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -4909,6 +5098,10 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -6128,6 +6321,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -6647,6 +6846,125 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/checkbox@5.1.4(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/confirm@6.0.12(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/core@11.1.9(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/editor@5.1.1(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/external-editor': 3.0.0(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/expand@5.0.13(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/external-editor@3.0.0(@types/node@22.19.17)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/input@5.0.12(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/number@4.0.12(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/password@5.0.12(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/prompts@8.4.2(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/checkbox': 5.1.4(@types/node@22.19.17)
+      '@inquirer/confirm': 6.0.12(@types/node@22.19.17)
+      '@inquirer/editor': 5.1.1(@types/node@22.19.17)
+      '@inquirer/expand': 5.0.13(@types/node@22.19.17)
+      '@inquirer/input': 5.0.12(@types/node@22.19.17)
+      '@inquirer/number': 4.0.12(@types/node@22.19.17)
+      '@inquirer/password': 5.0.12(@types/node@22.19.17)
+      '@inquirer/rawlist': 5.2.8(@types/node@22.19.17)
+      '@inquirer/search': 4.1.8(@types/node@22.19.17)
+      '@inquirer/select': 5.1.4(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/rawlist@5.2.8(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/search@4.1.8(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/select@5.1.4(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/type@4.0.5(@types/node@22.19.17)':
+    optionalDependencies:
+      '@types/node': 22.19.17
 
   '@ioredis/commands@1.5.1': {}
 
@@ -8778,6 +9096,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chardet@2.1.1: {}
+
   check-error@2.1.3: {}
 
   chokidar@4.0.3:
@@ -8789,6 +9109,8 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
 
@@ -8859,6 +9181,15 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cosmiconfig@9.0.1(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   cpu-features@0.0.10:
     dependencies:
@@ -9083,6 +9414,12 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-abstract@1.24.2:
     dependencies:
@@ -9485,6 +9822,16 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -9771,6 +10118,8 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  is-arrayish@0.2.1: {}
+
   is-async-function@2.1.1:
     dependencies:
       async-function: 1.0.0
@@ -9922,11 +10271,15 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  js-tokens@4.0.0: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
   json-buffer@3.0.1: {}
+
+  json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
 
@@ -10157,6 +10510,8 @@ snapshots:
       busboy: 1.6.0
       concat-stream: 2.0.0
       type-is: 1.6.18
+
+  mute-stream@3.0.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -10396,6 +10751,13 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
 
   parseurl@1.3.3: {}
 


### PR DESCRIPTION
## Summary
- `git-insight configure` prompts (or accepts `--url`/`--key`), verifies the key against `/me`, and writes `~/.projectrc` with mode 0600 (re-applies via `chmod` so an existing world-readable file is fixed on save).
- `git-insight whoami` loads config, calls `/me`, prints `email` + `name`. Exits 3 on missing config or invalid key, 4 on network failure.
- `git-insight keys list` calls `/api-keys` and prints a padded NAME / PREFIX / LAST USED / CREATED table (or `no api keys.`).
- Adds `lib/config.ts` (cosmiconfig loader, Zod-validated; refuses to read configs with mode > 0600) and `lib/keys-table.ts` (pure formatter to keep boundary rules happy).
- Extends `api-client.ts` with `listApiKeys` + exports `ApiClient` type.

## Notes
- Per docs/07-cli.md §3 and docs/03-modules/E-cli.md §4, the on-disk config is `~/.projectrc` (cosmiconfig module `projectrc`), not the `\$XDG_CONFIG_HOME/git-insight/config.json` in the issue body — flagged in our pre-implementation alignment, the docs path was chosen to match the published spec and existing T-5.3 client.
- `User` schema has no `github_login`; `whoami` prints `email` + `name`.
- Tests (38 → 39): mode-0600 enforcement on save and load, malformed/insecure config rejection, missing-config error, table formatter, `/api-keys` route + header.

## Test plan
- [x] `pnpm -F @commit-analyzer/cli typecheck`
- [x] `pnpm -F @commit-analyzer/cli lint`
- [x] `pnpm -F @commit-analyzer/cli test` (39 passed)
- [x] `pnpm -F @commit-analyzer/cli build` (12.78 → 13.14 KB ESM)
- [x] Smoke: `whoami` with no config → exits 3 with hint
- [x] Smoke: `keys list` with `PROJECTRC_PATH=/nonexistent` → exits 3 with hint

Closes #61