### PR TITLE
fix(T-1.7): /me + read routes accept x-api-key

### DIFF
--- a/apps/api/src/modules/auth/auth-ts-rest.controller.test.ts
+++ b/apps/api/src/modules/auth/auth-ts-rest.controller.test.ts
@@ -1,0 +1,50 @@
+import "reflect-metadata";
+
+import type { CanActivate, Type } from "@nestjs/common";
+import { GUARDS_METADATA } from "@nestjs/common/constants.js";
+import { describe, expect, it } from "vitest";
+
+import { AuthTsRestController } from "./auth-ts-rest.controller.js";
+import { JwtOrApiKeyGuard } from "./jwt-or-api-key.guard.js";
+import { SupabaseAuthGuard } from "./supabase-auth.guard.js";
+
+type GuardClass = Type<CanActivate>;
+
+const controllerGuards = (): GuardClass[] =>
+  (Reflect.getMetadata(GUARDS_METADATA, AuthTsRestController) ??
+    []) as GuardClass[];
+
+const handlerGuards = (handlerName: string): GuardClass[] => {
+  const handler =
+    AuthTsRestController.prototype[
+      handlerName as keyof AuthTsRestController
+    ];
+  return (
+    (Reflect.getMetadata(GUARDS_METADATA, handler as object) ?? []) as
+      GuardClass[]
+  );
+};
+
+describe("AuthTsRestController guard wiring", () => {
+  it("controller-level guard accepts either JWT or X-API-Key", () => {
+    expect(controllerGuards()).toEqual([JwtOrApiKeyGuard]);
+  });
+
+  it.each(["me", "listApiKeys", "listLlmKeys"])(
+    "%s relies on controller-level guard only (no method-level pin)",
+    (handlerName) => {
+      expect(handlerGuards(handlerName)).toEqual([]);
+    },
+  );
+
+  it.each([
+    "sync",
+    "deleteAccount",
+    "createApiKey",
+    "revokeApiKey",
+    "upsertLlmKey",
+    "deleteLlmKey",
+  ])("%s pins SupabaseAuthGuard at the method level", (handlerName) => {
+    expect(handlerGuards(handlerName)).toEqual([SupabaseAuthGuard]);
+  });
+});

--- a/apps/api/src/modules/auth/auth-ts-rest.controller.ts
+++ b/apps/api/src/modules/auth/auth-ts-rest.controller.ts
@@ -7,11 +7,12 @@ import { ThrottleTierDecorator } from "../../common/throttler/throttle-tier.deco
 import { toApiKeyDto, toLlmApiKeyDto, toUserDto } from "./auth.mappers.js";
 import { AuthService } from "./auth.service.js";
 import { CurrentUser } from "./current-user.decorator.js";
+import { JwtOrApiKeyGuard } from "./jwt-or-api-key.guard.js";
 import { LlmKeysService } from "./llm-keys.service.js";
 import { SupabaseAuthGuard } from "./supabase-auth.guard.js";
 
 @Controller()
-@UseGuards(SupabaseAuthGuard)
+@UseGuards(JwtOrApiKeyGuard)
 @ThrottleTierDecorator("default")
 export class AuthTsRestController {
   constructor(
@@ -28,6 +29,7 @@ export class AuthTsRestController {
     });
   }
 
+  @UseGuards(SupabaseAuthGuard)
   @TsRestHandler(authContract.sync)
   sync(@CurrentUser() userId: string): unknown {
     return tsRestHandler(authContract.sync, async ({ body }) => {
@@ -40,6 +42,7 @@ export class AuthTsRestController {
   }
 
   // Same `c.noBody()` typing quirk as apiKeys.revoke — see that handler below.
+  @UseGuards(SupabaseAuthGuard)
   @ThrottleTierDecorator("auth")
   @TsRestHandler(authContract.deleteAccount as never)
   deleteAccount(@CurrentUser() userId: string): unknown {
@@ -60,6 +63,7 @@ export class AuthTsRestController {
     });
   }
 
+  @UseGuards(SupabaseAuthGuard)
   @ThrottleTierDecorator("auth")
   @TsRestHandler(authContract.apiKeys.create)
   createApiKey(@CurrentUser() userId: string): unknown {
@@ -78,6 +82,7 @@ export class AuthTsRestController {
   // `c.noBody()` on the 204 response produces a unique-symbol type that the
   // current @ts-rest/nest `tsRestHandler` generic rejects; runtime shape is
   // correct, so we cast through the contract for this one route.
+  @UseGuards(SupabaseAuthGuard)
   @TsRestHandler(authContract.apiKeys.revoke as never)
   revokeApiKey(@CurrentUser() userId: string): unknown {
     return tsRestHandler(
@@ -97,6 +102,7 @@ export class AuthTsRestController {
     });
   }
 
+  @UseGuards(SupabaseAuthGuard)
   @ThrottleTierDecorator("auth")
   @TsRestHandler(authContract.llmKeys.upsert)
   upsertLlmKey(@CurrentUser() userId: string): unknown {
@@ -114,6 +120,7 @@ export class AuthTsRestController {
   }
 
   // Same `c.noBody()` typing quirk as apiKeys.revoke — see that handler above.
+  @UseGuards(SupabaseAuthGuard)
   @TsRestHandler(authContract.llmKeys.delete as never)
   deleteLlmKey(@CurrentUser() userId: string): unknown {
     return tsRestHandler(

--- a/packages/contracts/src/auth.contract.test.ts
+++ b/packages/contracts/src/auth.contract.test.ts
@@ -82,11 +82,23 @@ describe("authContract", () => {
     expect(authContract.apiKeys.revoke.path).toBe("/api-keys/:id");
   });
 
-  it("tags every auth endpoint with jwt", () => {
-    expect(authContract.me.metadata).toEqual({ auth: "jwt", rateLimit: "default" });
-    expect(authContract.apiKeys.list.metadata).toEqual({ auth: "jwt", rateLimit: "default" });
-    expect(authContract.apiKeys.create.metadata).toEqual({ auth: "jwt", rateLimit: "auth" });
-    expect(authContract.apiKeys.revoke.metadata).toEqual({ auth: "jwt", rateLimit: "default" });
+  it("tags read endpoints jwtOrApiKey, mutating endpoints jwt", () => {
+    expect(authContract.me.metadata).toEqual({
+      auth: "jwtOrApiKey",
+      rateLimit: "default",
+    });
+    expect(authContract.apiKeys.list.metadata).toEqual({
+      auth: "jwtOrApiKey",
+      rateLimit: "default",
+    });
+    expect(authContract.apiKeys.create.metadata).toEqual({
+      auth: "jwt",
+      rateLimit: "auth",
+    });
+    expect(authContract.apiKeys.revoke.metadata).toEqual({
+      auth: "jwt",
+      rateLimit: "default",
+    });
   });
 
   it("declares deleteAccount on DELETE /me with auth-tier throttle", () => {
@@ -166,9 +178,9 @@ describe("authContract.llmKeys", () => {
     expect(authContract.llmKeys.delete.path).toBe("/llm-keys/:provider");
   });
 
-  it("tags jwt + correct throttle tiers", () => {
+  it("tags list jwtOrApiKey, mutating endpoints jwt with correct throttle tiers", () => {
     expect(authContract.llmKeys.list.metadata).toEqual({
-      auth: "jwt",
+      auth: "jwtOrApiKey",
       rateLimit: "default",
     });
     expect(authContract.llmKeys.upsert.metadata).toEqual({

--- a/packages/contracts/src/auth.contract.ts
+++ b/packages/contracts/src/auth.contract.ts
@@ -70,7 +70,7 @@ export const authContract = c.router(
         401: errorEnvelopeSchema,
       },
       summary: "Get the currently authenticated user",
-      metadata: { auth: "jwt", rateLimit: "default" } as const,
+      metadata: { auth: "jwtOrApiKey", rateLimit: "default" } as const,
     },
     sync: {
       method: "POST",
@@ -106,7 +106,7 @@ export const authContract = c.router(
             401: errorEnvelopeSchema,
           },
           summary: "List API keys for the current user",
-          metadata: { auth: "jwt", rateLimit: "default" } as const,
+          metadata: { auth: "jwtOrApiKey", rateLimit: "default" } as const,
         },
         create: {
           method: "POST",
@@ -146,7 +146,7 @@ export const authContract = c.router(
             401: errorEnvelopeSchema,
           },
           summary: "List LLM API keys for the current user",
-          metadata: { auth: "jwt", rateLimit: "default" } as const,
+          metadata: { auth: "jwtOrApiKey", rateLimit: "default" } as const,
         },
         upsert: {
           method: "PUT",


### PR DESCRIPTION
## Summary
- Swap `AuthTsRestController` controller-level guard from `SupabaseAuthGuard` to `JwtOrApiKeyGuard` so reads (`/me`, `/api-keys`, `/llm-keys`) accept either a Supabase JWT or `X-API-Key`.
- Re-pin destructive routes (`POST /auth/sync`, `DELETE /me`, `POST /api-keys`, `DELETE /api-keys/:id`, `PUT /llm-keys/:provider`, `DELETE /llm-keys/:provider`) to `SupabaseAuthGuard` per-method so API keys can use the product but not mint/destroy credentials or account state.
- Update contract metadata for the read routes from `auth: "jwt"` to `auth: "jwtOrApiKey"` so docs/codegen reflect the actual policy.
- Add a metadata-driven controller spec verifying the guard matrix.

This unblocks CLI `configure` → `whoami` → `keys list`, which were 401-ing despite valid keys.

Closes #234