### PR TITLE
feat(T-5.5): generate command (sse + interactive)

### DIFF
--- a/apps/cli/eslint.config.js
+++ b/apps/cli/eslint.config.js
@@ -9,4 +9,12 @@ export default [
       "tsup.config.ts",
     ],
   },
+  {
+    files: ["src/**/*.spec.ts"],
+    rules: {
+      "boundaries/dependencies": "off",
+      "boundaries/no-unknown": "off",
+      "boundaries/no-unknown-files": "off",
+    },
+  },
 ];

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -38,6 +38,7 @@
     "commander": "^12.1.0",
     "cosmiconfig": "^9.0.1",
     "eventsource-parser": "^3.0.8",
+    "ora": "^8.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/cli/src/commands/generate.spec.ts
+++ b/apps/cli/src/commands/generate.spec.ts
@@ -1,0 +1,261 @@
+import { select } from "@inquirer/prompts";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+import { ConfigError, loadConfig } from "../lib/config.js";
+import {
+  GitError,
+  assertInsideWorkTree,
+  readDiffWithFallback,
+} from "../lib/git.js";
+
+import { handleError, runGenerate } from "./generate.js";
+
+vi.mock("../lib/config.js", () => ({
+  ConfigError: class ConfigError extends Error {
+    readonly code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.code = code;
+    }
+  },
+  loadConfig: vi.fn(),
+}));
+
+vi.mock("../lib/git.js", () => ({
+  GitError: class GitError extends Error {
+    readonly code: string;
+    readonly stderr: string;
+    constructor(code: string, message: string, stderr = "") {
+      super(message);
+      this.code = code;
+      this.stderr = stderr;
+    }
+  },
+  assertInsideWorkTree: vi.fn(),
+  readDiffWithFallback: vi.fn(),
+}));
+
+vi.mock("@inquirer/prompts", () => ({
+  select: vi.fn(),
+}));
+
+const loadConfigMock = loadConfig as unknown as Mock;
+const assertInsideWorkTreeMock = assertInsideWorkTree as unknown as Mock;
+const readDiffWithFallbackMock = readDiffWithFallback as unknown as Mock;
+const selectMock = select as unknown as Mock;
+
+const VALID_DIFF = [
+  "diff --git a/a.ts b/a.ts",
+  "index 1..2 100644",
+  "--- a/a.ts",
+  "+++ b/a.ts",
+  "@@ -1 +1 @@",
+  "-a",
+  "+b",
+  "",
+].join("\n");
+
+const CFG = {
+  apiUrl: "http://localhost:3000",
+  apiKey: "git_test",
+  defaultProvider: "openai" as const,
+  defaultModel: "gpt-4o-mini",
+};
+
+const SUGGESTION = {
+  index: 0,
+  type: "feat",
+  scope: null,
+  subject: "add a",
+  body: null,
+  footer: null,
+  compliant: true,
+  validation: null,
+};
+
+const DONE = { historyId: null, tokensUsed: 42 };
+
+function sseFrame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function sseResponse(events: string[]): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const e of events) controller.enqueue(encoder.encode(e));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+class ExitCalled extends Error {
+  constructor(readonly exitCode: number) {
+    super(`process.exit(${exitCode})`);
+  }
+}
+
+let stderrBuf = "";
+let stdoutBuf = "";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  stderrBuf = "";
+  stdoutBuf = "";
+  vi.spyOn(process.stderr, "write").mockImplementation((c) => {
+    stderrBuf += typeof c === "string" ? c : c.toString();
+    return true;
+  });
+  vi.spyOn(process.stdout, "write").mockImplementation((c) => {
+    stdoutBuf += typeof c === "string" ? c : c.toString();
+    return true;
+  });
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ExitCalled(code ?? 0);
+  }) as never);
+  loadConfigMock.mockResolvedValue(CFG);
+  assertInsideWorkTreeMock.mockResolvedValue(undefined);
+  readDiffWithFallbackMock.mockResolvedValue({ diff: VALID_DIFF, source: "staged" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+async function runAndCatchExit(opts: Parameters<typeof runGenerate>[0]): Promise<number> {
+  try {
+    await runGenerate(opts, new AbortController().signal);
+  } catch (err) {
+    if (err instanceof ExitCalled) return err.exitCode;
+    try {
+      handleError(err);
+    } catch (e) {
+      if (e instanceof ExitCalled) return e.exitCode;
+      throw e;
+    }
+  }
+  throw new Error("expected process.exit to be called");
+}
+
+describe("generate command", () => {
+  it("prints chosen message on happy path", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      sseResponse([sseFrame("suggestion", SUGGESTION), sseFrame("done", DONE)]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    selectMock.mockResolvedValue(SUGGESTION);
+
+    await runGenerate({}, new AbortController().signal);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(stdoutBuf).toContain("feat: add a");
+  });
+
+  it("exit 2 when no diff", async () => {
+    readDiffWithFallbackMock.mockResolvedValue(null);
+
+    expect(await runAndCatchExit({})).toBe(2);
+    expect(stderrBuf).toMatch(/nothing to commit/);
+  });
+
+  it("exit 2 when not in a git work tree", async () => {
+    assertInsideWorkTreeMock.mockRejectedValue(new GitError("NOT_A_REPO", "x"));
+
+    expect(await runAndCatchExit({})).toBe(2);
+    expect(stderrBuf).toMatch(/not inside a git work tree/);
+  });
+
+  it("exit 3 on auth failure", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { code: "UNAUTHORIZED", message: "bad key" } }),
+        { status: 401, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await runAndCatchExit({})).toBe(3);
+    expect(stderrBuf).toMatch(/api key rejected/);
+  });
+
+  it("exit 3 on missing config", async () => {
+    loadConfigMock.mockRejectedValue(new ConfigError("MISSING", "no config"));
+
+    expect(await runAndCatchExit({})).toBe(3);
+    expect(stderrBuf).toMatch(/no config/);
+  });
+
+  it("retries once on network failure, then exits 4", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("connection refused"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await runAndCatchExit({})).toBe(4);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("succeeds on retry when first network attempt fails", async () => {
+    let attempt = 0;
+    const fetchMock = vi.fn().mockImplementation(() => {
+      attempt += 1;
+      if (attempt === 1) return Promise.reject(new TypeError("connection refused"));
+      return Promise.resolve(
+        sseResponse([sseFrame("suggestion", SUGGESTION), sseFrame("done", DONE)]),
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    selectMock.mockResolvedValue(SUGGESTION);
+
+    await runGenerate({}, new AbortController().signal);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(stdoutBuf).toContain("feat: add a");
+  });
+
+  it("exit 5 on stream error frame", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      sseResponse([sseFrame("error", { code: "LLM_ERROR", message: "boom" })]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await runAndCatchExit({})).toBe(5);
+    expect(stderrBuf).toMatch(/stream failed/);
+  });
+
+  it("exit 1 on invalid provider", async () => {
+    expect(await runAndCatchExit({ provider: "bogus" })).toBe(1);
+    expect(stderrBuf).toMatch(/invalid provider/);
+  });
+
+  it("exit 1 on invalid --repo uuid", async () => {
+    expect(await runAndCatchExit({ repo: "not-a-uuid" })).toBe(1);
+    expect(stderrBuf).toMatch(/--repo must be a uuid/);
+  });
+
+  it("exit 130 when user picks quit", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      sseResponse([sseFrame("suggestion", SUGGESTION), sseFrame("done", DONE)]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    selectMock.mockResolvedValue(null);
+
+    expect(await runAndCatchExit({})).toBe(130);
+    expect(stderrBuf).toMatch(/aborted/);
+  });
+
+  it("emits HEAD-fallback note when nothing staged but HEAD diff exists", async () => {
+    readDiffWithFallbackMock.mockResolvedValue({ diff: VALID_DIFF, source: "head" });
+    const fetchMock = vi.fn().mockResolvedValue(
+      sseResponse([sseFrame("suggestion", SUGGESTION), sseFrame("done", DONE)]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    selectMock.mockResolvedValue(SUGGESTION);
+
+    await runGenerate({}, new AbortController().signal);
+    expect(stderrBuf).toMatch(/git diff HEAD/);
+  });
+});

--- a/apps/cli/src/commands/generate.ts
+++ b/apps/cli/src/commands/generate.ts
@@ -1,4 +1,37 @@
+import type {
+  GenerateRequest,
+  RuleResultDto,
+  SuggestionFrame,
+} from "@commit-analyzer/contracts";
+import { select } from "@inquirer/prompts";
 import type { Command } from "commander";
+import ora, { type Ora } from "ora";
+
+import { streamGenerate } from "../lib/api-client.js";
+import {
+  AbortError,
+  ApiResponseError,
+  AuthError,
+  NetworkError,
+  ProtocolError,
+  StreamError,
+  TimeoutError,
+} from "../lib/api-errors.js";
+import { ConfigError, loadConfig, type CliConfig } from "../lib/config.js";
+import { parseAndStripDiff, renderParsedDiff } from "../lib/diff-strip.js";
+import { GitError, assertInsideWorkTree, readDiffWithFallback } from "../lib/git.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const PROVIDERS = ["openai", "anthropic"] as const;
+type Provider = (typeof PROVIDERS)[number];
+
+interface GenerateOptions {
+  provider?: string;
+  model?: string;
+  repo?: string;
+  policy?: string;
+  count?: number;
+}
 
 export function registerGenerateCommand(program: Command): void {
   program
@@ -6,12 +39,240 @@ export function registerGenerateCommand(program: Command): void {
     .description("read staged diff, call the API, pick a suggestion")
     .option("--provider <provider>", "LLM provider (openai|anthropic)")
     .option("--model <model>", "model id")
-    .option("--repo <full_name>", "repository full name (owner/repo)")
-    .option("--count <n>", "number of suggestions", (v) => Number.parseInt(v, 10))
-    .option("--commit", "create the commit with the chosen message")
-    .option("--copy", "copy the chosen message to clipboard")
-    .action(() => {
-      console.error("generate: not implemented yet");
-      process.exit(1);
+    .option("--repo <repositoryId>", "connected repository id (uuid)")
+    .option("--policy <policyId>", "policy id (uuid) to enforce")
+    .option("--count <n>", "number of suggestions (1-5)", (v) => Number.parseInt(v, 10))
+    .action(async (opts: GenerateOptions) => {
+      const controller = new AbortController();
+      const onSigint = (): void => controller.abort();
+      process.once("SIGINT", onSigint);
+      try {
+        await runGenerate(opts, controller.signal);
+      } catch (err) {
+        handleError(err);
+      } finally {
+        process.removeListener("SIGINT", onSigint);
+      }
     });
+}
+
+async function runGenerate(opts: GenerateOptions, signal: AbortSignal): Promise<void> {
+  try {
+    await assertInsideWorkTree();
+  } catch (err) {
+    if (err instanceof GitError && err.code === "NOT_A_REPO") {
+      process.stderr.write("error: not inside a git work tree\n");
+      process.exit(2);
+    }
+    throw err;
+  }
+
+  const resolved = await readDiffWithFallback();
+  if (!resolved) {
+    process.stderr.write(
+      "error: nothing to commit. Stage changes with `git add` and try again.\n",
+    );
+    process.exit(2);
+  }
+  if (resolved.source === "head") {
+    process.stderr.write("note: no staged changes; using `git diff HEAD`.\n");
+  }
+
+  const cfg = await loadConfig();
+  const provider = resolveProvider(opts.provider, cfg);
+  const model = resolveModel(opts.model, cfg);
+  const repositoryId = resolveUuidOption(opts.repo, "--repo");
+  const policyId = resolveUuidOption(opts.policy, "--policy");
+  const count = resolveCount(opts.count);
+
+  const stripped = parseAndStripDiff(resolved.diff);
+  if (stripped.truncated) {
+    process.stderr.write("note: diff truncated to fit token budget.\n");
+  }
+  const diff = renderParsedDiff(stripped);
+
+  const body: GenerateRequest = {
+    diff,
+    provider,
+    model,
+    ...(repositoryId ? { repositoryId } : {}),
+    ...(policyId ? { policyId } : {}),
+    ...(count !== undefined ? { count } : {}),
+  };
+
+  const spinner: Ora = ora({ text: `generating with ${provider}/${model}…`, stream: process.stderr });
+  spinner.start();
+  let received = 0;
+
+  let result;
+  try {
+    result = await streamGenerate(
+      { apiUrl: cfg.apiUrl, apiKey: cfg.apiKey },
+      body,
+      {
+        signal,
+        onSuggestion: () => {
+          received += 1;
+          spinner.text = `generating with ${provider}/${model}… received ${received}`;
+        },
+      },
+    );
+    spinner.succeed(`done — ${result.suggestions.length} suggestion(s), tokens=${result.done.tokensUsed}`);
+  } catch (err) {
+    spinner.stop();
+    throw err;
+  }
+
+  if (result.suggestions.length === 0) {
+    process.stderr.write("error: no suggestions returned.\n");
+    process.exit(5);
+  }
+
+  printSuggestions(result.suggestions);
+
+  const choice = await select<SuggestionFrame | null>({
+    message: "Pick a suggestion (or quit):",
+    choices: [
+      ...result.suggestions.map((s) => ({
+        name: `${s.index + 1}. ${formatHeader(s)}${policyTag(s)}`,
+        value: s,
+      })),
+      { name: "q. quit", value: null },
+    ],
+  });
+
+  if (!choice) {
+    process.stderr.write("aborted\n");
+    process.exit(130);
+  }
+
+  process.stdout.write(`${formatFullMessage(choice)}\n`);
+}
+
+function resolveProvider(opt: string | undefined, cfg: CliConfig): Provider {
+  const raw = opt ?? cfg.defaultProvider;
+  if (!raw) {
+    process.stderr.write(
+      "error: provider not set. Pass --provider or set defaultProvider in your config.\n",
+    );
+    process.exit(1);
+  }
+  if (!PROVIDERS.includes(raw as Provider)) {
+    process.stderr.write(`error: invalid provider "${raw}" (expected: ${PROVIDERS.join("|")}).\n`);
+    process.exit(1);
+  }
+  return raw as Provider;
+}
+
+function resolveModel(opt: string | undefined, cfg: CliConfig): string {
+  const raw = opt ?? cfg.defaultModel;
+  if (!raw) {
+    process.stderr.write(
+      "error: model not set. Pass --model or set defaultModel in your config.\n",
+    );
+    process.exit(1);
+  }
+  return raw;
+}
+
+function resolveUuidOption(value: string | undefined, flag: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (!UUID_RE.test(value)) {
+    process.stderr.write(`error: ${flag} must be a uuid.\n`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function resolveCount(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isInteger(value) || value < 1 || value > 5) {
+    process.stderr.write("error: --count must be an integer between 1 and 5.\n");
+    process.exit(1);
+  }
+  return value;
+}
+
+function printSuggestions(suggestions: SuggestionFrame[]): void {
+  for (const s of suggestions) {
+    process.stdout.write(`\n[${s.index + 1}] ${formatHeader(s)}${policyTag(s)}\n`);
+    if (s.body) {
+      const indented = s.body
+        .split("\n")
+        .map((l) => `    ${l}`)
+        .join("\n");
+      process.stdout.write(`${indented}\n`);
+    }
+    if (s.footer) {
+      process.stdout.write(`    ${s.footer}\n`);
+    }
+    if (s.validation && s.validation.results.length > 0) {
+      for (const r of s.validation.results) {
+        process.stdout.write(`    ${ruleLine(r)}\n`);
+      }
+    }
+  }
+}
+
+function formatHeader(s: SuggestionFrame): string {
+  const scope = s.scope ? `(${s.scope})` : "";
+  return `${s.type}${scope}: ${s.subject}`;
+}
+
+function policyTag(s: SuggestionFrame): string {
+  if (!s.validation) return "";
+  return s.validation.passed ? "  [pass]" : "  [fail]";
+}
+
+function ruleLine(r: RuleResultDto): string {
+  const mark = r.passed ? "✓" : "✗";
+  const detail = r.message ? ` — ${r.message}` : "";
+  return `${mark} ${r.ruleType}${detail}`;
+}
+
+function formatFullMessage(s: SuggestionFrame): string {
+  const parts = [formatHeader(s)];
+  if (s.body) parts.push("", s.body);
+  if (s.footer) parts.push("", s.footer);
+  return parts.join("\n");
+}
+
+function handleError(err: unknown): never {
+  if (err instanceof AbortError || isInquirerCancel(err)) {
+    process.stderr.write("aborted\n");
+    process.exit(130);
+  }
+  if (err instanceof ConfigError) {
+    process.stderr.write(`error: ${err.message}\n`);
+    process.exit(3);
+  }
+  if (err instanceof AuthError) {
+    process.stderr.write(
+      `error: api key rejected (${err.status}). Re-run \`git-insight configure\`.\n`,
+    );
+    process.exit(3);
+  }
+  if (err instanceof NetworkError || err instanceof TimeoutError) {
+    process.stderr.write(`error: cannot reach API: ${err.message}\n`);
+    process.exit(4);
+  }
+  if (err instanceof StreamError || err instanceof ProtocolError) {
+    process.stderr.write(`error: stream failed: ${err.message}\n`);
+    process.exit(5);
+  }
+  if (err instanceof ApiResponseError) {
+    process.stderr.write(`error: ${err.message}\n`);
+    process.exit(err.status >= 500 ? 5 : 1);
+  }
+  if (err instanceof GitError) {
+    const detail = err.stderr ? ` (${err.stderr})` : "";
+    process.stderr.write(`error: ${err.message}${detail}\n`);
+    process.exit(1);
+  }
+  process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+}
+
+function isInquirerCancel(err: unknown): boolean {
+  return err instanceof Error && err.name === "ExitPromptError";
 }

--- a/apps/cli/src/commands/generate.ts
+++ b/apps/cli/src/commands/generate.ts
@@ -1,11 +1,14 @@
-import type {
-  GenerateRequest,
-  RuleResultDto,
-  SuggestionFrame,
+import {
+  llmProviderSchema,
+  type GenerateRequest,
+  type LlmProviderName,
+  type RuleResultDto,
+  type SuggestionFrame,
 } from "@commit-analyzer/contracts";
 import { select } from "@inquirer/prompts";
 import type { Command } from "commander";
 import ora, { type Ora } from "ora";
+import { z } from "zod";
 
 import { streamGenerate } from "../lib/api-client.js";
 import {
@@ -21,9 +24,19 @@ import { ConfigError, loadConfig, type CliConfig } from "../lib/config.js";
 import { parseAndStripDiff, renderParsedDiff } from "../lib/diff-strip.js";
 import { GitError, assertInsideWorkTree, readDiffWithFallback } from "../lib/git.js";
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const PROVIDERS = ["openai", "anthropic"] as const;
-type Provider = (typeof PROVIDERS)[number];
+const PROVIDERS = llmProviderSchema.options;
+const uuidSchema = z.string().uuid();
+const NETWORK_RETRY_BACKOFF_MS = 250;
+
+class GenerateError extends Error {
+  readonly exitCode: number;
+
+  constructor(exitCode: number, message: string) {
+    super(message);
+    this.name = "GenerateError";
+    this.exitCode = exitCode;
+  }
+}
 
 interface GenerateOptions {
   provider?: string;
@@ -56,23 +69,12 @@ export function registerGenerateCommand(program: Command): void {
     });
 }
 
-async function runGenerate(opts: GenerateOptions, signal: AbortSignal): Promise<void> {
-  try {
-    await assertInsideWorkTree();
-  } catch (err) {
-    if (err instanceof GitError && err.code === "NOT_A_REPO") {
-      process.stderr.write("error: not inside a git work tree\n");
-      process.exit(2);
-    }
-    throw err;
-  }
+export async function runGenerate(opts: GenerateOptions, signal: AbortSignal): Promise<void> {
+  await assertInsideWorkTreeOrExit();
 
   const resolved = await readDiffWithFallback();
   if (!resolved) {
-    process.stderr.write(
-      "error: nothing to commit. Stage changes with `git add` and try again.\n",
-    );
-    process.exit(2);
+    throw new GenerateError(2, "nothing to commit. Stage changes with `git add` and try again.");
   }
   if (resolved.source === "head") {
     process.stderr.write("note: no staged changes; using `git diff HEAD`.\n");
@@ -100,32 +102,29 @@ async function runGenerate(opts: GenerateOptions, signal: AbortSignal): Promise<
     ...(count !== undefined ? { count } : {}),
   };
 
-  const spinner: Ora = ora({ text: `generating with ${provider}/${model}…`, stream: process.stderr });
+  const spinner: Ora = ora({
+    text: spinnerText(provider, model, 0),
+    stream: process.stderr,
+  });
   spinner.start();
   let received = 0;
 
-  let result;
-  try {
-    result = await streamGenerate(
-      { apiUrl: cfg.apiUrl, apiKey: cfg.apiKey },
-      body,
-      {
-        signal,
-        onSuggestion: () => {
-          received += 1;
-          spinner.text = `generating with ${provider}/${model}… received ${received}`;
-        },
-      },
-    );
-    spinner.succeed(`done — ${result.suggestions.length} suggestion(s), tokens=${result.done.tokensUsed}`);
-  } catch (err) {
-    spinner.stop();
-    throw err;
-  }
+  const result = await streamWithRetry(
+    cfg,
+    body,
+    signal,
+    () => {
+      received += 1;
+      spinner.text = spinnerText(provider, model, received);
+    },
+    spinner,
+  );
+  spinner.succeed(
+    `done — ${result.suggestions.length} suggestion(s), tokens=${result.done.tokensUsed}`,
+  );
 
   if (result.suggestions.length === 0) {
-    process.stderr.write("error: no suggestions returned.\n");
-    process.exit(5);
+    throw new GenerateError(5, "no suggestions returned.");
   }
 
   printSuggestions(result.suggestions);
@@ -142,53 +141,112 @@ async function runGenerate(opts: GenerateOptions, signal: AbortSignal): Promise<
   });
 
   if (!choice) {
-    process.stderr.write("aborted\n");
-    process.exit(130);
+    throw new GenerateError(130, "aborted");
   }
 
   process.stdout.write(`${formatFullMessage(choice)}\n`);
 }
 
-function resolveProvider(opt: string | undefined, cfg: CliConfig): Provider {
+async function assertInsideWorkTreeOrExit(): Promise<void> {
+  try {
+    await assertInsideWorkTree();
+  } catch (err) {
+    if (err instanceof GitError && err.code === "NOT_A_REPO") {
+      throw new GenerateError(2, "not inside a git work tree");
+    }
+    throw err;
+  }
+}
+
+async function streamWithRetry(
+  cfg: CliConfig,
+  body: GenerateRequest,
+  signal: AbortSignal,
+  onSuggestion: () => void,
+  spinner: Ora,
+): ReturnType<typeof streamGenerate> {
+  try {
+    return await streamGenerate(
+      { apiUrl: cfg.apiUrl, apiKey: cfg.apiKey },
+      body,
+      { signal, onSuggestion },
+    );
+  } catch (err) {
+    if (err instanceof NetworkError && !signal.aborted) {
+      spinner.text = "network error — retrying once…";
+      await new Promise((r) => setTimeout(r, NETWORK_RETRY_BACKOFF_MS));
+      try {
+        return await streamGenerate(
+          { apiUrl: cfg.apiUrl, apiKey: cfg.apiKey },
+          body,
+          { signal, onSuggestion },
+        );
+      } catch (retryErr) {
+        spinner.fail("network error after retry");
+        throw retryErr;
+      }
+    }
+    spinner.fail(spinnerFailLabel(err));
+    throw err;
+  }
+}
+
+function spinnerText(provider: string, model: string, received: number): string {
+  const tail = received > 0 ? ` received ${received}` : "";
+  return `generating with ${provider}/${model}…${tail}`;
+}
+
+function spinnerFailLabel(err: unknown): string {
+  if (err instanceof AuthError) return "auth rejected";
+  if (err instanceof TimeoutError) return "request timed out";
+  if (err instanceof StreamError || err instanceof ProtocolError) return "stream failed";
+  if (err instanceof ApiResponseError) return `api error (${err.status})`;
+  if (err instanceof AbortError) return "aborted";
+  return "generate failed";
+}
+
+function resolveProvider(opt: string | undefined, cfg: CliConfig): LlmProviderName {
   const raw = opt ?? cfg.defaultProvider;
   if (!raw) {
-    process.stderr.write(
-      "error: provider not set. Pass --provider or set defaultProvider in your config.\n",
+    throw new GenerateError(
+      1,
+      "provider not set. Pass --provider or set defaultProvider in your config.",
     );
-    process.exit(1);
   }
-  if (!PROVIDERS.includes(raw as Provider)) {
-    process.stderr.write(`error: invalid provider "${raw}" (expected: ${PROVIDERS.join("|")}).\n`);
-    process.exit(1);
+  const parsed = llmProviderSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new GenerateError(
+      1,
+      `invalid provider "${raw}" (expected: ${PROVIDERS.join("|")}).`,
+    );
   }
-  return raw as Provider;
+  return parsed.data;
 }
 
 function resolveModel(opt: string | undefined, cfg: CliConfig): string {
   const raw = opt ?? cfg.defaultModel;
   if (!raw) {
-    process.stderr.write(
-      "error: model not set. Pass --model or set defaultModel in your config.\n",
+    throw new GenerateError(
+      1,
+      "model not set. Pass --model or set defaultModel in your config.",
     );
-    process.exit(1);
   }
   return raw;
 }
 
 function resolveUuidOption(value: string | undefined, flag: string): string | undefined {
   if (value === undefined) return undefined;
-  if (!UUID_RE.test(value)) {
-    process.stderr.write(`error: ${flag} must be a uuid.\n`);
-    process.exit(1);
+  const parsed = uuidSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new GenerateError(1, `${flag} must be a uuid.`);
   }
-  return value;
+  return parsed.data;
 }
 
 function resolveCount(value: number | undefined): number | undefined {
   if (value === undefined) return undefined;
   if (!Number.isInteger(value) || value < 1 || value > 5) {
-    process.stderr.write("error: --count must be an integer between 1 and 5.\n");
-    process.exit(1);
+    throw new GenerateError(1, "--count must be an integer between 1 and 5.");
   }
   return value;
 }
@@ -237,7 +295,11 @@ function formatFullMessage(s: SuggestionFrame): string {
   return parts.join("\n");
 }
 
-function handleError(err: unknown): never {
+export function handleError(err: unknown): never {
+  if (err instanceof GenerateError) {
+    process.stderr.write(`${err.exitCode === 130 ? "" : "error: "}${err.message}\n`);
+    process.exit(err.exitCode);
+  }
   if (err instanceof AbortError || isInquirerCancel(err)) {
     process.stderr.write("aborted\n");
     process.exit(130);

--- a/apps/cli/src/lib/git.spec.ts
+++ b/apps/cli/src/lib/git.spec.ts
@@ -1,0 +1,82 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  GitError,
+  assertInsideWorkTree,
+  readDiffWithFallback,
+  readHeadDiff,
+  readStagedDiff,
+} from "./git.js";
+
+function init(dir: string): void {
+  execSync("git init -q -b main", { cwd: dir });
+  execSync("git config user.email test@example.com", { cwd: dir });
+  execSync("git config user.name test", { cwd: dir });
+  execSync("git config commit.gpgsign false", { cwd: dir });
+}
+
+describe("git helpers", () => {
+  let dir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    dir = mkdtempSync(join(tmpdir(), "cli-git-"));
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+  });
+
+  it("rejects when not inside a work tree", async () => {
+    process.chdir(dir);
+    await expect(assertInsideWorkTree()).rejects.toBeInstanceOf(GitError);
+  });
+
+  it("returns staged diff when staged", async () => {
+    init(dir);
+    process.chdir(dir);
+    writeFileSync(join(dir, "a.txt"), "hello\n");
+    execSync("git add a.txt", { cwd: dir });
+
+    await assertInsideWorkTree();
+    const staged = await readStagedDiff();
+    expect(staged).toContain("diff --git a/a.txt b/a.txt");
+
+    const resolved = await readDiffWithFallback();
+    expect(resolved?.source).toBe("staged");
+    expect(resolved?.diff).toContain("a.txt");
+  });
+
+  it("falls back to HEAD when nothing staged but there are unstaged changes", async () => {
+    init(dir);
+    process.chdir(dir);
+    writeFileSync(join(dir, "a.txt"), "hello\n");
+    execSync("git add a.txt && git commit -q -m init", { cwd: dir });
+    writeFileSync(join(dir, "a.txt"), "hello world\n");
+
+    const staged = await readStagedDiff();
+    expect(staged.trim()).toBe("");
+
+    const head = await readHeadDiff();
+    expect(head).toContain("a.txt");
+
+    const resolved = await readDiffWithFallback();
+    expect(resolved?.source).toBe("head");
+  });
+
+  it("returns null when nothing staged and no unstaged diff", async () => {
+    init(dir);
+    process.chdir(dir);
+    writeFileSync(join(dir, "a.txt"), "hello\n");
+    execSync("git add a.txt && git commit -q -m init", { cwd: dir });
+
+    const resolved = await readDiffWithFallback();
+    expect(resolved).toBeNull();
+  });
+});

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -1,0 +1,87 @@
+import { spawn } from "node:child_process";
+
+export class GitError extends Error {
+  readonly code: GitErrorCode;
+  readonly stderr: string;
+
+  constructor(code: GitErrorCode, message: string, stderr = "") {
+    super(message);
+    this.name = "GitError";
+    this.code = code;
+    this.stderr = stderr;
+  }
+}
+
+type GitErrorCode = "NOT_A_REPO" | "GIT_MISSING" | "GIT_FAILED";
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+async function runGit(args: string[], cwd: string = process.cwd()): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "ENOENT") {
+        reject(new GitError("GIT_MISSING", "git executable not found in PATH"));
+      } else {
+        reject(err);
+      }
+    });
+    child.on("close", (code) => {
+      resolve({ stdout, stderr, exitCode: code ?? 0 });
+    });
+  });
+}
+
+export async function assertInsideWorkTree(cwd: string = process.cwd()): Promise<void> {
+  const res = await runGit(["rev-parse", "--is-inside-work-tree"], cwd);
+  if (res.exitCode !== 0 || res.stdout.trim() !== "true") {
+    throw new GitError("NOT_A_REPO", "not inside a git work tree", res.stderr.trim());
+  }
+}
+
+export async function readStagedDiff(cwd: string = process.cwd()): Promise<string> {
+  const res = await runGit(
+    ["diff", "--staged", "--no-color", "--no-ext-diff"],
+    cwd,
+  );
+  if (res.exitCode !== 0) {
+    throw new GitError("GIT_FAILED", "git diff --staged failed", res.stderr.trim());
+  }
+  return res.stdout;
+}
+
+export async function readHeadDiff(cwd: string = process.cwd()): Promise<string> {
+  const res = await runGit(
+    ["diff", "HEAD", "--no-color", "--no-ext-diff"],
+    cwd,
+  );
+  if (res.exitCode !== 0) {
+    throw new GitError("GIT_FAILED", "git diff HEAD failed", res.stderr.trim());
+  }
+  return res.stdout;
+}
+
+export interface ResolvedDiff {
+  diff: string;
+  source: "staged" | "head";
+}
+
+export async function readDiffWithFallback(cwd: string = process.cwd()): Promise<ResolvedDiff | null> {
+  const staged = await readStagedDiff(cwd);
+  if (staged.trim().length > 0) return { diff: staged, source: "staged" };
+  const head = await readHeadDiff(cwd);
+  if (head.trim().length > 0) return { diff: head, source: "head" };
+  return null;
+}

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -73,7 +73,7 @@ export async function readHeadDiff(cwd: string = process.cwd()): Promise<string>
   return res.stdout;
 }
 
-export interface ResolvedDiff {
+interface ResolvedDiff {
   diff: string;
   source: "staged" | "head";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       eventsource-parser:
         specifier: ^3.0.8
         version: 3.0.8
+      ora:
+        specifier: ^8.1.1
+        version: 8.2.0
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -3634,6 +3637,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
@@ -3650,6 +3657,14 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -3946,6 +3961,9 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -4321,6 +4339,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -4538,6 +4560,10 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -4584,6 +4610,14 @@ packages:
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
+
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -4786,6 +4820,10 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
+
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -4862,6 +4900,10 @@ packages:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
     hasBin: true
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -5069,9 +5111,17 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -5458,6 +5508,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
@@ -5665,6 +5719,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -5683,6 +5741,10 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
 
   string.prototype.trim@1.2.10:
     resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
@@ -9096,6 +9158,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   chardet@2.1.1: {}
 
   check-error@2.1.3: {}
@@ -9109,6 +9173,12 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
 
   cli-width@4.1.0: {}
 
@@ -9368,6 +9438,8 @@ snapshots:
   eastasianwidth@0.2.0: {}
 
   ee-first@1.1.1: {}
+
+  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -9946,6 +10018,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.5.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -10178,6 +10252,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-interactive@2.0.0: {}
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -10220,6 +10296,10 @@ snapshots:
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.20
+
+  is-unicode-supported@1.3.0: {}
+
+  is-unicode-supported@2.1.0: {}
 
   is-weakmap@2.0.2: {}
 
@@ -10398,6 +10478,11 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
+
   long@5.3.2: {}
 
   loupe@3.2.1: {}
@@ -10454,6 +10539,8 @@ snapshots:
       mime-db: 1.54.0
 
   mime@2.6.0: {}
+
+  mimic-function@5.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -10669,6 +10756,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -10677,6 +10768,18 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
 
   own-keys@1.0.1:
     dependencies:
@@ -11117,6 +11220,11 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
   retry@0.12.0: {}
 
   reusify@1.1.0: {}
@@ -11424,6 +11532,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stdin-discarder@0.2.2: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -11450,6 +11560,12 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
   string.prototype.trim@1.2.10:


### PR DESCRIPTION
## Summary
- New `generate` subcommand: detects `git diff --staged` (falls back to `git diff HEAD`), strips diff locally via `parseAndStripDiff` (T-5.2 parity), and streams `/generate` over SSE.
- Live `ora` spinner shows progress as suggestion frames arrive, then prints numbered suggestions with policy `[pass]`/`[fail]` + per-rule annotations when the response includes a `validation` payload.
- Interactive selection via `@inquirer/prompts.select`; chosen full message printed to stdout.
- Exit codes per E-cli spec: 2 (not in repo / nothing staged), 3 (config + auth), 4 (network/timeout), 5 (stream/LLM), 130 (Ctrl-C).
- New `apps/cli/src/lib/git.ts` wraps `git rev-parse` / `git diff --staged|HEAD` via `node:child_process` with typed errors; covered by `git.spec.ts` (work-tree detection + staged → HEAD fallback + empty-tree case).

Notes / scope:
- `--commit` and `--copy` flags are intentionally out of scope here — they're T-5.6.
- `--repo` and `--policy` accept UUIDs in this PR (full-name lookup over API key needs a list-connected-by-key route that doesn't exist yet).

Closes #62