### PR TITLE
fix(T-5.5): handle empty repo with no HEAD

### DIFF
--- a/apps/cli/src/lib/git.spec.ts
+++ b/apps/cli/src/lib/git.spec.ts
@@ -79,4 +79,15 @@ describe("git helpers", () => {
     const resolved = await readDiffWithFallback();
     expect(resolved).toBeNull();
   });
+
+  it("returns null in a fresh repo with no commits and nothing staged", async () => {
+    init(dir);
+    process.chdir(dir);
+
+    const head = await readHeadDiff();
+    expect(head).toBe("");
+
+    const resolved = await readDiffWithFallback();
+    expect(resolved).toBeNull();
+  });
 });

--- a/apps/cli/src/lib/git.ts
+++ b/apps/cli/src/lib/git.ts
@@ -63,6 +63,8 @@ export async function readStagedDiff(cwd: string = process.cwd()): Promise<strin
 }
 
 export async function readHeadDiff(cwd: string = process.cwd()): Promise<string> {
+  const head = await runGit(["rev-parse", "--verify", "--quiet", "HEAD"], cwd);
+  if (head.exitCode !== 0) return "";
   const res = await runGit(
     ["diff", "HEAD", "--no-color", "--no-ext-diff"],
     cwd,


### PR DESCRIPTION
## Summary
- In a fresh git repo with zero commits, `git diff HEAD` errors with "ambiguous argument 'HEAD'", which propagated as exit 1 ("error: git diff HEAD failed (...)") instead of the expected exit 2 + "nothing to commit".
- `readHeadDiff` now probes `git rev-parse --verify --quiet HEAD` first and returns `""` when no HEAD exists, so the fallback behaves like an empty diff and `runGenerate` reports the clean "nothing to commit" message.
- New regression test in `git.spec.ts` covers the no-HEAD case.

Found via end-to-end smoke test of the merged T-5.5 binary in `/tmp/cli-smoke` (a freshly `git init`-ed repo).