### PR TITLE
feat(T-5.8): cli smoke-test runner script

### DIFF
--- a/apps/cli/scripts/smoke.sh
+++ b/apps/cli/scripts/smoke.sh
@@ -5,6 +5,13 @@
 # a deployed API, in a throwaway repo. Captures exit codes and the resulting
 # commit so the run can be pasted into the T-5.8 task doc for sign-off.
 #
+# Operator-driven: step 4 invokes the inquirer suggestion picker. Do not
+# wire this into unattended CI — the prompt has no non-interactive path.
+#
+# The operator's real ~/.projectrc is NEVER touched: PROJECTRC_PATH is
+# exported to a temp file before any CLI invocation, and `configure`'s
+# saveConfig honours that env var (see apps/cli/src/lib/config.ts).
+#
 # Usage:
 #   API_URL=https://api.example.com \
 #   API_KEY=git_xxx \
@@ -52,9 +59,8 @@ if [ ! -f "$CLI_BIN" ]; then
   exit 65
 fi
 
-WORKDIR=${WORKDIR:-$(mktemp -d -t cli-smoke.XXXXXX)}
-PROJECTRC=$(mktemp -t projectrc.XXXXXX)
-chmod 600 "$PROJECTRC"
+WORKDIR=${WORKDIR:-$(mktemp -d "${TMPDIR:-/tmp}/cli-smoke.XXXXXX")}
+PROJECTRC=$(mktemp "${TMPDIR:-/tmp}/projectrc.XXXXXX")
 
 cleanup() {
   local code=$?
@@ -75,34 +81,39 @@ echo "API_URL  = $API_URL"
 echo "PROVIDER = $PROVIDER"
 echo "MODEL    = $MODEL"
 echo "WORKDIR  = $WORKDIR"
-echo "CONFIG   = $PROJECTRC"
+echo "CONFIG   = $PROJECTRC (PROJECTRC_PATH; ~/.projectrc untouched)"
 echo
 
 step "1. configure"
 node "$CLI_BIN" configure --url "$API_URL" --key "$API_KEY"
 configure_rc=$?
-if [ $configure_rc -ne 0 ]; then red "configure failed (exit $configure_rc)"; exit $configure_rc; fi
+if [ "$configure_rc" -ne 0 ]; then red "configure failed (exit $configure_rc)"; exit "$configure_rc"; fi
 green "configure ok (exit $configure_rc)"
 
 step "2. whoami"
 node "$CLI_BIN" whoami
 whoami_rc=$?
-if [ $whoami_rc -ne 0 ]; then red "whoami failed (exit $whoami_rc)"; exit $whoami_rc; fi
+if [ "$whoami_rc" -ne 0 ]; then red "whoami failed (exit $whoami_rc)"; exit "$whoami_rc"; fi
 green "whoami ok (exit $whoami_rc)"
 
 step "3. throwaway repo"
-cd "$WORKDIR"
-git init -q -b main
-git config user.email "smoke@example.com"
-git config user.name  "Smoke Tester"
-printf 'hello\n' > README.md
-git add README.md
-git commit -q -m "init"
-printf 'hello\nworld\n' > README.md
-printf 'pkg = 1\n' > pkg.txt
-git add README.md pkg.txt
-git status --short
+(
+  set -e
+  cd "$WORKDIR"
+  git init -q -b main
+  git config user.email "smoke@example.com"
+  git config user.name  "Smoke Tester"
+  printf 'hello\n' > README.md
+  git add README.md
+  git commit -q -m "init"
+  printf 'hello\nworld\n' > README.md
+  printf 'pkg = 1\n' > pkg.txt
+  git add README.md pkg.txt
+  git status --short
+) || { red "throwaway repo setup failed"; exit 1; }
 echo
+
+cd "$WORKDIR" || { red "cd workdir failed"; exit 1; }
 
 step "4. generate --commit (interactive: pick a suggestion)"
 yellow "the CLI will prompt — choose a suggestion to commit, or 'q' to abort."
@@ -112,9 +123,9 @@ if [ -n "${POLICY_ID:-}" ]; then generate_args+=(--policy "$POLICY_ID"); fi
 node "$CLI_BIN" generate "${generate_args[@]}"
 generate_rc=$?
 echo
-if [ $generate_rc -ne 0 ]; then
+if [ "$generate_rc" -ne 0 ]; then
   red "generate failed (exit $generate_rc)"
-  exit $generate_rc
+  exit "$generate_rc"
 fi
 green "generate ok (exit $generate_rc)"
 

--- a/apps/cli/scripts/smoke.sh
+++ b/apps/cli/scripts/smoke.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# CLI end-to-end smoke test.
+#
+# Walks the operator through configure -> whoami -> generate --commit against
+# a deployed API, in a throwaway repo. Captures exit codes and the resulting
+# commit so the run can be pasted into the T-5.8 task doc for sign-off.
+#
+# Usage:
+#   API_URL=https://api.example.com \
+#   API_KEY=git_xxx \
+#   PROVIDER=openai \
+#   MODEL=gpt-4o-mini \
+#   bash apps/cli/scripts/smoke.sh
+#
+# Optional env:
+#   CLI_BIN          path to the built CLI (default: <repo>/apps/cli/dist/index.js)
+#   REPO_ID          uuid passed via --repo
+#   POLICY_ID        uuid passed via --policy
+#   WORKDIR          override throwaway repo location (default: mktemp)
+#   KEEP_WORKDIR=1   skip cleanup of the throwaway repo (for debugging)
+#
+# Exit code: 0 on success, non-zero on the first failed step.
+
+set -u
+set -o pipefail
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+bold()   { printf '\033[1m%s\033[0m\n' "$*"; }
+
+step() { bold ""; bold "── $* ──"; }
+
+require_env() {
+  local name=$1
+  if [ -z "${!name:-}" ]; then
+    red "missing required env: $name"
+    exit 64
+  fi
+}
+
+require_env API_URL
+require_env API_KEY
+PROVIDER=${PROVIDER:-openai}
+MODEL=${MODEL:-gpt-4o-mini}
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null && pwd)
+CLI_BIN=${CLI_BIN:-"$SCRIPT_DIR/../dist/index.js"}
+if [ ! -f "$CLI_BIN" ]; then
+  red "CLI binary not found at $CLI_BIN"
+  yellow "build first: pnpm -F @commit-analyzer/cli build"
+  exit 65
+fi
+
+WORKDIR=${WORKDIR:-$(mktemp -d -t cli-smoke.XXXXXX)}
+PROJECTRC=$(mktemp -t projectrc.XXXXXX)
+chmod 600 "$PROJECTRC"
+
+cleanup() {
+  local code=$?
+  if [ "${KEEP_WORKDIR:-0}" != "1" ]; then
+    rm -rf "$WORKDIR" "$PROJECTRC"
+  else
+    yellow "kept workdir: $WORKDIR"
+    yellow "kept config:  $PROJECTRC"
+  fi
+  exit $code
+}
+trap cleanup EXIT
+
+export PROJECTRC_PATH="$PROJECTRC"
+
+bold "T-5.8 — CLI smoke test"
+echo "API_URL  = $API_URL"
+echo "PROVIDER = $PROVIDER"
+echo "MODEL    = $MODEL"
+echo "WORKDIR  = $WORKDIR"
+echo "CONFIG   = $PROJECTRC"
+echo
+
+step "1. configure"
+node "$CLI_BIN" configure --url "$API_URL" --key "$API_KEY"
+configure_rc=$?
+if [ $configure_rc -ne 0 ]; then red "configure failed (exit $configure_rc)"; exit $configure_rc; fi
+green "configure ok (exit $configure_rc)"
+
+step "2. whoami"
+node "$CLI_BIN" whoami
+whoami_rc=$?
+if [ $whoami_rc -ne 0 ]; then red "whoami failed (exit $whoami_rc)"; exit $whoami_rc; fi
+green "whoami ok (exit $whoami_rc)"
+
+step "3. throwaway repo"
+cd "$WORKDIR"
+git init -q -b main
+git config user.email "smoke@example.com"
+git config user.name  "Smoke Tester"
+printf 'hello\n' > README.md
+git add README.md
+git commit -q -m "init"
+printf 'hello\nworld\n' > README.md
+printf 'pkg = 1\n' > pkg.txt
+git add README.md pkg.txt
+git status --short
+echo
+
+step "4. generate --commit (interactive: pick a suggestion)"
+yellow "the CLI will prompt — choose a suggestion to commit, or 'q' to abort."
+generate_args=(--provider "$PROVIDER" --model "$MODEL" --commit)
+if [ -n "${REPO_ID:-}" ];   then generate_args+=(--repo   "$REPO_ID");   fi
+if [ -n "${POLICY_ID:-}" ]; then generate_args+=(--policy "$POLICY_ID"); fi
+node "$CLI_BIN" generate "${generate_args[@]}"
+generate_rc=$?
+echo
+if [ $generate_rc -ne 0 ]; then
+  red "generate failed (exit $generate_rc)"
+  exit $generate_rc
+fi
+green "generate ok (exit $generate_rc)"
+
+step "5. verify commit"
+log_count=$(git rev-list --count HEAD)
+if [ "$log_count" -lt 2 ]; then
+  red "expected at least 2 commits, found $log_count"
+  exit 1
+fi
+git log -1 --format='%H%n%s%n%n%b' | sed 's/^/    /'
+
+bold ""
+green "── smoke test PASSED ──"
+echo "configure rc=$configure_rc  whoami rc=$whoami_rc  generate rc=$generate_rc"

--- a/apps/cli/src/lib/config.spec.ts
+++ b/apps/cli/src/lib/config.spec.ts
@@ -110,6 +110,13 @@ describe("loadConfig", () => {
     expect(await loadConfig()).toEqual(VALID);
   });
 
+  it("loads via PROJECTRC_PATH with an arbitrary extension", async () => {
+    const path = join(dir, "rc.A1bC2d");
+    await fs.writeFile(path, JSON.stringify(VALID), { mode: 0o600 });
+    process.env.PROJECTRC_PATH = path;
+    expect(await loadConfig()).toEqual(VALID);
+  });
+
   it("finds ~/.projectrc via upward walk", async () => {
     const path = join(dir, ".projectrc");
     await fs.writeFile(path, JSON.stringify(VALID), { mode: 0o600 });

--- a/apps/cli/src/lib/config.spec.ts
+++ b/apps/cli/src/lib/config.spec.ts
@@ -35,12 +35,17 @@ describe("config schema", () => {
 
 describe("saveConfig", () => {
   let dir: string;
+  let prevEnv: string | undefined;
 
   beforeEach(async () => {
     dir = await mkdtemp(join(tmpdir(), "git-insight-cfg-"));
+    prevEnv = process.env.PROJECTRC_PATH;
+    delete process.env.PROJECTRC_PATH;
   });
 
   afterEach(async () => {
+    if (prevEnv === undefined) delete process.env.PROJECTRC_PATH;
+    else process.env.PROJECTRC_PATH = prevEnv;
     await rm(dir, { recursive: true, force: true });
   });
 
@@ -65,6 +70,15 @@ describe("saveConfig", () => {
     const path = join(dir, "config.json");
     await expect(saveConfig({ apiUrl: "x", apiKey: "y" } as never, path)).rejects.toBeDefined();
     await expect(fs.access(path)).rejects.toBeDefined();
+  });
+
+  it("writes to PROJECTRC_PATH when no path is passed", async () => {
+    const path = join(dir, "rc.json");
+    process.env.PROJECTRC_PATH = path;
+    const written = await saveConfig(VALID);
+    expect(written).toBe(path);
+    const parsed = JSON.parse(await fs.readFile(path, "utf8")) as unknown;
+    expect(parsed).toEqual(VALID);
   });
 });
 

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -114,7 +114,7 @@ async function assertSecureMode(path: string): Promise<void> {
 
 export async function saveConfig(
   config: CliConfig,
-  path = join(homedir(), ".projectrc"),
+  path: string = process.env.PROJECTRC_PATH ?? join(homedir(), ".projectrc"),
 ): Promise<string> {
   const validated = configSchema.parse(config);
   const json = `${JSON.stringify(validated, null, 2)}\n`;

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -35,8 +35,7 @@ type ConfigErrorCode = "MISSING" | "INVALID" | "PERMISSIONS" | "READ";
 export async function loadConfig(): Promise<CliConfig> {
   const envPath = process.env.PROJECTRC_PATH;
   if (envPath) {
-    const loader = cosmiconfig(CONFIG_MODULE_NAME);
-    const found = await loadAt(loader, envPath);
+    const found = await loadJsonFile(envPath);
     return finalize(found, `no config at PROJECTRC_PATH=${envPath}. Run \`git-insight configure\`.`);
   }
 
@@ -78,13 +77,24 @@ async function finalize(
 type Explorer = ReturnType<typeof cosmiconfig>;
 type LoadResult = Awaited<ReturnType<Explorer["load"]>>;
 
-async function loadAt(explorer: Explorer, path: string): Promise<LoadResult | null> {
+async function loadJsonFile(path: string): Promise<LoadResult | null> {
+  let raw: string;
   try {
-    return await explorer.load(path);
+    raw = await fs.readFile(path, "utf8");
   } catch (err) {
     if (isEnoent(err)) return null;
-    throw err;
+    throw new ConfigError("READ", `cannot read config file ${path}`, { cause: err });
   }
+  if (raw.trim() === "") {
+    return { config: {}, filepath: path, isEmpty: true } as LoadResult;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new ConfigError("INVALID", `config at ${path} is not valid JSON`, { cause: err });
+  }
+  return { config: parsed, filepath: path, isEmpty: false } as LoadResult;
 }
 
 function isEnoent(err: unknown): boolean {


### PR DESCRIPTION
## Summary
- Adds `apps/cli/scripts/smoke.sh` — a parameterized end-to-end smoke runner that walks `configure` → `whoami` → `generate --commit` against any `$API_URL`, in a throwaway repo, asserting exit codes at every step and cleaning up temp config + workdir on exit.
- Routes both reads **and writes** through `PROJECTRC_PATH`: `saveConfig`'s default now falls back to `process.env.PROJECTRC_PATH` before `~/.projectrc`, so the script's exported temp path is honoured by `configure`. Without this fix, step 1 would have silently overwritten the operator's real `~/.projectrc` on a successful run.
- Hardens setup: `cd` is guarded; throwaway-repo init runs in a `set -e` subshell so any failure surfaces at the real call site.

## Scope note (staging vs. production)
`docs/11-deployment.md` §1 states this project is single-environment CD — there is **no staging stack**. The task title "Staging smoke test" is therefore reinterpreted as: ship a parameterized checklist runner now, and have the operator record a production run after the first deploy.

This script is operator-driven (step 4 invokes the inquirer suggestion picker). Do not wire it into unattended CI.

## Doc updates (gitignored — not in this diff)
`docs/` is gitignored in this repo, so the following edits live only in the working copy:
- `docs/tasks/phase-5-cli/T-5.8-staging-smoke.md` — deliverable description, the negative-path wiring proof, and a structured template for the operator's production run record.
- `docs/11-deployment.md` §11 — build-checklist entry now references `apps/cli/scripts/smoke.sh`.

## Test plan
- [x] `pnpm -F @commit-analyzer/cli typecheck`
- [x] `pnpm -F @commit-analyzer/cli lint`
- [x] `pnpm -F @commit-analyzer/cli test` (79 tests pass — adds one for `saveConfig` honouring `PROJECTRC_PATH`)
- [x] `bash -n apps/cli/scripts/smoke.sh` (syntax)
- [x] Negative wiring run: `API_URL=http://127.0.0.1:1 API_KEY=git_… bash apps/cli/scripts/smoke.sh` → script exits 4 (configure NetworkError), cleanup runs.
- [ ] Operator: positive run against production after first deploy, paste output into the task doc record.

Closes #65
