### PR TITLE
fix(T-6.7): relax csp on /api/docs for scalar cdn

### DIFF
--- a/apps/api/src/modules/openapi/openapi.controller.test.ts
+++ b/apps/api/src/modules/openapi/openapi.controller.test.ts
@@ -76,6 +76,21 @@ describe("OpenapiController (HTTP)", () => {
     expect(res.text.length).toBeGreaterThan(500);
   });
 
+  it("relaxes CSP for the UI so Scalar's CDN bundle can load", async () => {
+    app = await buildApp();
+    const res = await request(server()).get("/api/docs");
+    const csp = res.headers["content-security-policy"];
+    expect(csp).toMatch(/script-src[^;]*https:\/\/cdn\.jsdelivr\.net/u);
+    expect(csp).toMatch(/style-src[^;]*https:\/\/cdn\.jsdelivr\.net/u);
+  });
+
+  it("does not relax CSP on the JSON route", async () => {
+    app = await buildApp();
+    const res = await request(server()).get("/api/docs/openapi.json");
+    const csp = res.headers["content-security-policy"];
+    if (csp) expect(csp).not.toMatch(/cdn\.jsdelivr\.net/u);
+  });
+
   describe("with Basic auth credentials configured", () => {
     beforeEach(() => {
       getServerEnvMock.mockReturnValue({

--- a/apps/api/src/modules/openapi/openapi.controller.ts
+++ b/apps/api/src/modules/openapi/openapi.controller.ts
@@ -59,6 +59,24 @@ export class OpenapiController {
     throw new UnauthorizedException();
   }
 
+  // Scalar loads its bundle from cdn.jsdelivr.net, which the global helmet
+  // CSP (`default-src 'self'`) blocks. Override CSP for the docs HTML route
+  // only — the JSON route inherits the strict default.
+  private allowScalarCdn(res: Response): void {
+    res.setHeader(
+      "Content-Security-Policy",
+      [
+        "default-src 'self'",
+        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com",
+        "font-src 'self' https://fonts.gstatic.com data:",
+        "img-src 'self' data: https:",
+        "connect-src 'self' https:",
+        "worker-src 'self' blob:",
+      ].join("; "),
+    );
+  }
+
   @Get("openapi.json")
   openapiJson(@Req() req: Request, @Res() res: Response): void {
     if (!this.authorize(req, res)) return;
@@ -68,6 +86,7 @@ export class OpenapiController {
   @Get()
   ui(@Req() req: Request, @Res() res: Response): void {
     if (!this.authorize(req, res)) return;
+    this.allowScalarCdn(res);
     (this.scalarHandler as (req: Request, res: Response) => void)(req, res);
   }
 }


### PR DESCRIPTION
## Summary
- The Scalar UI HTML pulls `https://cdn.jsdelivr.net/npm/@scalar/api-reference`, which the global Helmet CSP (`default-src 'self'`) blocks — `/api/docs` rendered blank in production.
- Override CSP on the `/api/docs` (UI) route only to allow `cdn.jsdelivr.net` for `script-src` and `style-src`, plus the bundle's font/image needs. The JSON route keeps the strict default.

## Test plan
- [x] `pnpm -F @commit-analyzer/api typecheck`
- [x] `pnpm -F @commit-analyzer/api lint`
- [x] `pnpm -F @commit-analyzer/api test -- src/modules/openapi` (49 passed)
- [x] New: asserts `script-src` + `style-src` include `cdn.jsdelivr.net` on `/api/docs`, and that `/api/docs/openapi.json` does not.