### PR TITLE
feat(T-7.4): cli npm publish on cli-v* tag

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -9,6 +9,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: release-cli-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: Publish to NPM
@@ -28,11 +32,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build workspace deps
-        run: pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/diff-parser --filter @commit-analyzer/contracts build
-
-      - name: Build CLI
-        run: pnpm --filter git-insight-cli build
+      - name: Build CLI (with workspace deps)
+        run: pnpm exec turbo run build --filter=git-insight-cli
 
       - name: Test
         run: pnpm --filter git-insight-cli test
@@ -40,9 +41,27 @@ jobs:
       - name: Set version from tag
         run: |
           VERSION="${GITHUB_REF_NAME#cli-v}"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "$GITHUB_REF_NAME" ]; then
+            echo "Tag '$GITHUB_REF_NAME' did not match cli-v* prefix" >&2
+            exit 1
+          fi
           pnpm --filter git-insight-cli exec npm version "$VERSION" --no-git-tag-version
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Publish
-        run: pnpm --filter git-insight-cli exec npm publish --provenance --access public
+        run: pnpm --filter git-insight-cli publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify install on clean container
+        run: |
+          docker run --rm node:20-alpine sh -c "
+            for i in 1 2 3 4 5 6; do
+              npm view git-insight-cli@${VERSION} version >/dev/null 2>&1 && break
+              echo 'waiting for registry to expose ${VERSION}...'
+              sleep 10
+            done
+            npm i -g git-insight-cli@${VERSION}
+            git-insight-cli --version
+          "

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,48 @@
+name: Release CLI
+
+on:
+  push:
+    tags:
+      - cli-v*
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build workspace deps
+        run: pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/diff-parser --filter @commit-analyzer/contracts build
+
+      - name: Build CLI
+        run: pnpm --filter git-insight-cli build
+
+      - name: Test
+        run: pnpm --filter git-insight-cli test
+
+      - name: Set version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#cli-v}"
+          pnpm --filter git-insight-cli exec npm version "$VERSION" --no-git-tag-version
+
+      - name: Publish
+        run: pnpm --filter git-insight-cli exec npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,29 @@
+# git-insight-cli
+
+AI-assisted CLI for generating commit messages and PR summaries from local git diffs.
+
+## Install
+
+```bash
+npm i -g git-insight-cli
+```
+
+Requires Node.js 20+.
+
+## Usage
+
+```bash
+git-insight-cli --help
+git-insight-cli generate           # generate a commit message from staged changes
+git-insight-cli generate --pr      # generate a PR summary from the current branch
+```
+
+`git-insight` is also available as an alias for `git-insight-cli`.
+
+## Configuration
+
+The CLI reads `.git-insightrc` (JSON, YAML, or JS) from the repo root or any parent directory. See [project docs](https://github.com/GEOFARL/commit-analyzer) for the full schema.
+
+## License
+
+MIT

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,10 +1,14 @@
 {
-  "name": "@commit-analyzer/cli",
+  "name": "git-insight-cli",
   "version": "0.0.0",
-  "private": true,
   "type": "module",
   "bin": {
-    "git-insight": "dist/index.js"
+    "git-insight": "dist/index.js",
+    "git-insight-cli": "dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "dist"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,26 @@
 {
   "name": "git-insight-cli",
   "version": "0.0.0",
+  "description": "AI-assisted CLI for generating commit messages and PR summaries from local git diffs.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GEOFARL/commit-analyzer.git",
+    "directory": "apps/cli"
+  },
+  "homepage": "https://github.com/GEOFARL/commit-analyzer#readme",
+  "bugs": {
+    "url": "https://github.com/GEOFARL/commit-analyzer/issues"
+  },
+  "keywords": [
+    "git",
+    "cli",
+    "commit",
+    "ai",
+    "conventional-commits",
+    "pr",
+    "changelog"
+  ],
   "type": "module",
   "bin": {
     "git-insight": "dist/index.js",
@@ -11,13 +31,13 @@
     "provenance": true
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "engines": {
     "node": ">=20"
   },
   "scripts": {
-    "prebuild": "pnpm --filter @commit-analyzer/shared-types --filter @commit-analyzer/diff-parser --filter @commit-analyzer/contracts build",
     "build": "tsup",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -26,6 +46,8 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@commit-analyzer/contracts": "workspace:*",
+    "@commit-analyzer/diff-parser": "workspace:*",
     "@commit-analyzer/eslint-config": "workspace:*",
     "@commit-analyzer/typescript-config": "workspace:*",
     "@types/node": "^22.19.17",
@@ -35,8 +57,6 @@
     "vitest": "^2"
   },
   "dependencies": {
-    "@commit-analyzer/contracts": "workspace:*",
-    "@commit-analyzer/diff-parser": "workspace:*",
     "@inquirer/prompts": "^8.4.2",
     "@ts-rest/core": "^3.51.0",
     "clipboardy": "^4",

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   format: ["esm"],
   target: "node20",
   bundle: true,
+  noExternal: [/^@commit-analyzer\//],
   clean: true,
   sourcemap: true,
   minify: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,12 +177,6 @@ importers:
 
   apps/cli:
     dependencies:
-      '@commit-analyzer/contracts':
-        specifier: workspace:*
-        version: link:../../packages/contracts
-      '@commit-analyzer/diff-parser':
-        specifier: workspace:*
-        version: link:../../packages/diff-parser
       '@inquirer/prompts':
         specifier: ^8.4.2
         version: 8.4.2(@types/node@22.19.17)
@@ -208,6 +202,12 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      '@commit-analyzer/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
+      '@commit-analyzer/diff-parser':
+        specifier: workspace:*
+        version: link:../../packages/diff-parser
       '@commit-analyzer/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config


### PR DESCRIPTION
## Summary
- Rename CLI package to `git-insight-cli` (was `@commit-analyzer/cli` private), add `git-insight-cli` bin alias
- Add `publishConfig` with `access: public` and `provenance: true`
- Add `.github/workflows/release-cli.yml`: triggers on `cli-v*` tags, builds workspace deps + CLI, runs tests, stamps version from tag, publishes with provenance

## Manual prerequisite
Add `NPM_TOKEN` to repo secrets before tagging.

## Test
Tag `cli-v0.1.0` → workflow runs → package appears on npmjs.com → `npm i -g git-insight-cli && git-insight-cli --version`

Closes #77