### PR TITLE
fix(T-7.4): inject cli version at build time

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -32,12 +32,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build CLI (with workspace deps)
-        run: pnpm exec turbo run build --filter=git-insight-cli
-
-      - name: Test
-        run: pnpm --filter git-insight-cli test
-
       - name: Set version from tag
         run: |
           VERSION="${GITHUB_REF_NAME#cli-v}"
@@ -47,6 +41,12 @@ jobs:
           fi
           pnpm --filter git-insight-cli exec npm version "$VERSION" --no-git-tag-version
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Build CLI (with workspace deps)
+        run: pnpm exec turbo run build --filter=git-insight-cli --force
+
+      - name: Test
+        run: pnpm --filter git-insight-cli test
 
       - name: Publish
         run: pnpm --filter git-insight-cli publish --no-git-checks

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -5,12 +5,14 @@ import { registerGenerateCommand } from "./commands/generate.js";
 import { registerKeysCommand } from "./commands/keys.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
 
+declare const __CLI_VERSION__: string;
+
 const program = new Command();
 
 program
   .name("git-insight")
   .description("Commit-message generator CLI (AI-assisted)")
-  .version("0.0.0");
+  .version(typeof __CLI_VERSION__ === "string" ? __CLI_VERSION__ : "0.0.0");
 
 registerConfigureCommand(program);
 registerGenerateCommand(program);

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -1,4 +1,10 @@
+import { readFileSync } from "node:fs";
+
 import { defineConfig } from "tsup";
+
+const pkg = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf8"),
+) as { version: string };
 
 export default defineConfig({
   entry: { index: "src/index.ts" },
@@ -7,6 +13,9 @@ export default defineConfig({
   target: "node20",
   bundle: true,
   noExternal: [/^@commit-analyzer\//],
+  define: {
+    __CLI_VERSION__: JSON.stringify(pkg.version),
+  },
   clean: true,
   sourcemap: true,
   minify: false,


### PR DESCRIPTION
## Summary
- CLI bundle had `0.0.0` baked in at build time because version bump in workflow ran AFTER build. Symptom: `git-insight-cli --version` printed `0.0.0` despite manifest being `0.1.0`.
- Inject version via tsup `define` from `package.json` at build time.
- Reorder workflow: bump version → build → test → publish (was: build → test → bump → publish). Build is forced (`--force`) so turbo doesn't serve a stale cached bundle compiled against the old version.

## Test
Local: bumped to 0.1.1 → rebuilt → `node dist/index.js --version` printed `0.1.1`. Restored to 0.0.0, all 80 tests still pass.

After merge: tag `cli-v0.1.1` → workflow republishes → `npm i -g git-insight-cli` shows `0.1.1`.